### PR TITLE
Fixed bug and improved NonConvergingErrorHandler

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -411,7 +411,7 @@ class NonConvergingErrorHandler(ErrorHandler, MSONable):
         nelm = vi["INCAR"].get("NELM", 60)
         try:
             oszicar = Oszicar(self.output_filename)
-            esteps = oszicar.ionic_steps
+            esteps = oszicar.electronic_steps
             if len(esteps) > self.nionic_steps:
                 return all([len(e) == nelm for e in esteps[-(self.nionic_steps+1):-1]])
         except:


### PR DESCRIPTION
Fixed bug in NonConvergingErrorHandler : check of the number of electronic steps for each ionic step was performed on the dictionary of results (Oszicar.ionic_steps) and not on the list of electronic steps.
Added a possible fallback from ALGO = Fast to ALGO = Normal in NonConvergingErrorHandler.
