### PR TITLE
Added EDDDAV error handling in VaspErrorHandler : after "tet" correction...

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -78,7 +78,8 @@ class VaspErrorHandler(ErrorHandler):
         "amin": ["One of the lattice vectors is very long (>50 A), but AMIN"],
         "zbrent": ["ZBRENT: fatal internal in"],
         "pssyevx": ["ERROR in subspace rotation PSSYEVX"],
-        "eddrmm": ["WARNING in EDDRMM: call to ZHEGV failed"]
+        "eddrmm": ["WARNING in EDDRMM: call to ZHEGV failed"],
+        "edddav": ["Error EDDDAV: Call to ZHEGV failed"]
     }
 
     def __init__(self, output_filename="vasp.out"):
@@ -246,6 +247,9 @@ class VaspErrorHandler(ErrorHandler):
             actions.append({"file": "CHGCAR",
                             "action": {"_file_delete": {'mode': "actual"}}})
             actions.append({"file": "WAVECAR",
+                            "action": {"_file_delete": {'mode': "actual"}}})
+        if "edddav" in self.errors:
+            actions.append({"file": "CHGCAR",
                             "action": {"_file_delete": {'mode': "actual"}}})
 
         VaspModder(vi=vi).apply_actions(actions)

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -162,6 +162,12 @@ class VaspErrorHandlerTest(unittest.TestCase):
         i = Incar.from_file("INCAR")
         self.assertEqual(i["POTIM"], 0.25)
 
+    def test_edddav(self):
+        h = VaspErrorHandler("vasp.edddav")
+        self.assertEqual(h.check(), True)
+        self.assertEqual(h.correct()["errors"], ["edddav"])
+        self.assertFalse(os.path.exists("CHGCAR"))
+
     def tearDown(self):
         os.chdir(test_dir)
         shutil.move("INCAR.orig", "INCAR")

--- a/test_files/vasp.edddav
+++ b/test_files/vasp.edddav
@@ -1,0 +1,1 @@
+Error EDDDAV: Call to ZHEGV failed. Returncode =   7 1   8


### PR DESCRIPTION
..., the CHGCAR is not removed and this can sometimes lead to a problem in DAVIDSON algorithm, need to restart calculation without CHGCAR in the folder

Added test_edddav in test_handlers