### PR TITLE
alternative strategy to avoid BRMIX error

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -129,19 +129,31 @@ class VaspErrorHandler(ErrorHandler):
                             "action": {"_set": {"SYMPREC": 1e-8}}})
 
         if "brmix" in self.errors:
-            actions.append({"dict": "INCAR",
-                            "action": {"_set": {"ISYM": 0}}})
+            #actions.append({"dict": "INCAR",
+            #                "action": {"_set": {"ISYM": 0}}})
 
             if vi["KPOINTS"].style == Kpoints.supported_modes.Monkhorst:
                 actions.append({"dict": "KPOINTS",
                                 "action": {"_set": {"generation_style": "Gamma"}}})
 
+            if vi["KPOINTS"].num_kpts < 1:
+                all_kpts_even = all([
+                    bool(n % 2 == 0) for n in vi["KPOINTS"].kpts[0]
+                ])
+                print("all_kpts_even = {}".format(all_kpts_even))
+                if all_kpts_even:
+                    new_kpts = (tuple(n+1 for n in vi["KPOINTS"].kpts[0]),)
+                    print("new_kpts = {}".format(new_kpts))
+                    actions.append({"dict": "KPOINTS", "action": {"_set": {
+                        "kpoints": new_kpts
+                    }}})
+
             # Based on VASP forum's recommendation, you should delete the
             # CHGCAR and WAVECAR when dealing with this error.
-            actions.append({"file": "CHGCAR",
-                            "action": {"_file_delete": {'mode': "actual"}}})
-            actions.append({"file": "WAVECAR",
-                            "action": {"_file_delete": {'mode': "actual"}}})
+            #actions.append({"file": "CHGCAR",
+            #                "action": {"_file_delete": {'mode': "actual"}}})
+            #actions.append({"file": "WAVECAR",
+            #                "action": {"_file_delete": {'mode': "actual"}}})
 
         if "zpotrf" in self.errors:
             # Usually caused by short bond distances. If on the first step,


### PR DESCRIPTION
Our current VASP installation (v5.2) used for MP production was compiled using the Intel compiler. Apparently, this causes some of our static GGA calculations to throw a serious BRMIX error, which results in custodian to reach its maximum allowed errors. After quite some trial and error, the following strategy using a combination of generation style, kpoints and ISYM settings seems to allow many of our failed static GGA runs to complete successfully.

For instance, starting with the default settings of

```
Monkhorst   —   [12, 12, 12]   —   ISYM default
```

the static GGA run throws a BRMIX error and custodian aborts it after a certain step - as expected. Normally, custodian would now react by setting ISYM to 0, changing to the Gamma generation style, and removing the CHGCAR/WAVECAR files. This will cause the job to restart another 4 times until it hits the maximum number of errors allowed and then fizzle. However, I can get the run to complete successfully on the second try, by instead keeping the CHGCAR/WAVECAR files and the ISYM default, switching to Gamma generation style, and increasing the kpoints by one to make it odd:

```
keep CHGCAR and WAVECAR
Gamma       —   [13, 13, 13]   —   ISYM default
```

The only caveat is the warning

```
random wavefunctions but no delay for mixing, default for NELMDL
```

where `initial charge from wave function` should show up in the VASP output.

This pull request is a preliminary implementation of this strategy. It’s obviously conflicting with what custodian would normally do in this situation. @shyuep, what would be a good way to implement multiple different recipes to be tried for the same error - in this case, the above strategy before switching to ISYM = 0 (which apparently runs significantly slower)?

Note that this implementation is currently being used in MP's production but does not necessarily need to be part of the official custodian. I'm fine with simply keeping this pull request and the respective branch for record and discussion purposes only.