### PR TITLE
minor fix to vis for deserialization

### DIFF
--- a/custodian/vasp/jobs.py
+++ b/custodian/vasp/jobs.py
@@ -344,7 +344,7 @@ class VaspJob(Job):
         d = dict(vasp_cmd=self.vasp_cmd,
                  output_file=self.output_file, suffix=self.suffix,
                  final=self.final, backup=self.backup,
-                 default_vasp_input_set=self.default_vis.as_dict(),
+                 default_vasp_input_set=self.default_vis,
                  auto_npar=self.auto_npar, auto_gamma=self.auto_gamma,
                  settings_override=self.settings_override,
                  gamma_vasp_cmd=self.gamma_vasp_cmd


### PR DESCRIPTION
Minor fix for jobs.py to ensure deserialization.  Note that it causes a warning to be issued from using deprecated MPVaspInputSet.


