### PR TITLE
Also call terminate function in natural terminations

### DIFF
--- a/custodian/custodian.py
+++ b/custodian/custodian.py
@@ -363,6 +363,7 @@ class Custodian(object):
             # While the job is running, we use the handlers that are
             # monitors to monitor the job.
             if isinstance(p, subprocess.Popen):
+                terminate = None
                 if self.monitors:
                     n = 0
                     while True:
@@ -376,6 +377,10 @@ class Custodian(object):
                                                        terminate)
                 else:
                     p.wait()
+
+                if terminate is not None and terminate != p.terminate:
+                    terminate()
+                    time.sleep(self.polling_time_step)
 
             logger.info("{}.run has completed. "
                         "Checking remaining handlers".format(job.name))

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -47,7 +47,7 @@ from custodian.ansible.actions import FileActions
 from custodian.vasp.interpreter import VaspModder
 
 VASP_BACKUP_FILES = {"INCAR", "KPOINTS", "POSCAR", "OUTCAR", "OSZICAR",
-                     "vasprun.xml", "vasp.out"}
+                     "vasprun.xml", "vasp.out", "std_err.txt"}
 
 
 class VaspErrorHandler(ErrorHandler):

--- a/custodian/vasp/jobs.py
+++ b/custodian/vasp/jobs.py
@@ -41,8 +41,8 @@ class VaspJob(Job):
     can be a complex processing of inputs etc. with initialization.
     """
 
-    def __init__(self, vasp_cmd, output_file="vasp.out", suffix="",
-                 final=True, backup=True, auto_npar=True,
+    def __init__(self, vasp_cmd, output_file="vasp.out", stderr_file="std_err.txt",
+                 suffix="", final=True, backup=True, auto_npar=True,
                  auto_gamma=True, settings_override=None,
                  gamma_vasp_cmd=None, copy_magmom=False):
         """
@@ -56,6 +56,8 @@ class VaspJob(Job):
                 ["mpirun", "pvasp.5.2.11"]
             output_file (str): Name of file to direct standard out to.
                 Defaults to "vasp.out".
+            output_file (str): Name of file to direct standard error to.
+                Defaults to "std_err.txt".
             suffix (str): A suffix to be appended to the final output. E.g.,
                 to rename all VASP output from say vasp.out to
                 vasp.out.relax1, provide ".relax1" as the suffix.
@@ -101,6 +103,7 @@ class VaspJob(Job):
         """
         self.vasp_cmd = vasp_cmd
         self.output_file = output_file
+        self.stderr_file = stderr_file
         self.final = final
         self.backup = backup
         self.suffix = suffix
@@ -168,8 +171,10 @@ class VaspJob(Job):
                 elif which(cmd[-1] + ".gamma"):
                     cmd[-1] += ".gamma"
         logging.info("Running {}".format(" ".join(cmd)))
-        with open(self.output_file, 'w') as f:
-            p = subprocess.Popen(cmd, stdout=f)
+        with open(self.output_file, 'w') as f_std, \
+                open(self.stderr_file, "w", buffering=1) as f_err:
+            # use line bufferring for stderr
+            p = subprocess.Popen(cmd, stdout=f_std, stderr=f_err)
         return p
 
     def postprocess(self):


### PR DESCRIPTION
I added terminate() to natural termination path. This is helpful when VASP is naturally terminated. If there is an error, e.g. segmentation fault, the resources also tends to not be released. Please be noted that it will add an additional 10 seconds sleep to wait for the resources to be release. This commit only affects custodian run with custom terminate function.