### PR TITLE
Checking for existence of some vasp files to double check that VASP started running

### DIFF
--- a/custodian/vasp/tests/test_validators.py
+++ b/custodian/vasp/tests/test_validators.py
@@ -1,4 +1,4 @@
-from custodian.vasp.validators import VasprunXMLValidator
+from custodian.vasp.validators import VasprunXMLValidator, VaspFilesValidator
 
 import os
 import unittest
@@ -28,6 +28,26 @@ class VasprunXMLValidatorTest(unittest.TestCase):
     def tearDownClass(cls):
         os.chdir(cwd)
 
+class VaspFilesValidatorTest(unittest.TestCase):
+
+    def test_check_and_correct(self):
+        # just an example where CONTCAR is not present
+        os.chdir(os.path.join(test_dir, "positive_energy"))
+        h = VaspFilesValidator()
+        self.assertTrue(h.check())
+
+        os.chdir(os.path.join(test_dir, "postprocess"))
+        self.assertFalse(h.check())
+
+    def test_as_dict(self):
+        h = VaspFilesValidator()
+        d = h.as_dict()
+        h2 = VaspFilesValidator.from_dict(d)
+        self.assertIsInstance(h2, VaspFilesValidator)
+
+    @classmethod
+    def tearDownClass(cls):
+        os.chdir(cwd)
 
 if __name__ == "__main__":
     unittest.main()

--- a/custodian/vasp/validators.py
+++ b/custodian/vasp/validators.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals, division
 
 from custodian.custodian import Validator
 from pymatgen.io.vasp import Vasprun
-
+import os
 
 class VasprunXMLValidator(Validator):
     """
@@ -19,4 +19,20 @@ class VasprunXMLValidator(Validator):
             Vasprun("vasprun.xml")
         except:
             return True
+        return False
+
+
+class VaspFilesValidator(Validator):
+    """
+    Check for existence of some of the files that VASP
+        normally create upon running.
+    """
+
+    def __init__(self):
+        pass
+
+    def check(self):
+        for vfile in ["CONTCAR", "OSZICAR", "OUTCAR"]:
+            if not os.path.exists(vfile):
+                return True
         return False


### PR DESCRIPTION
## Summary

This is to double check that VASP started running in which case, CONTCAR, OSZICAR and OUTCAR and definitely created though they may be empty. This is to make sure we avoid previous problems where a complete OUTCAR and vasprun.xml are present from a different VASP calculations.