### PR TITLE
add evenize k-point mesh for internal error in GENERATE_KPOINTS_TRANS

### DIFF
--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -501,7 +501,7 @@ class PotimHandlerTest(unittest.TestCase):
         os.chdir(cwd)
 
 
-class StdErrHandlerTest(unittest.TestCase):
+class LrfCommHandlerTest(unittest.TestCase):
 
     def setUp(self):
         os.chdir(test_dir)
@@ -527,6 +527,33 @@ class StdErrHandlerTest(unittest.TestCase):
         os.chdir('lrf_comm')
         for f in ["INCAR", "OUTCAR", "std_err.txt"]:
             shutil.move(f+".orig", f)
+        clean_dir()
+        os.chdir(cwd)
+
+
+class KpointsTransHandlerTest(unittest.TestCase):
+
+    def setUp(self):
+        os.chdir(test_dir)
+        shutil.copy("KPOINTS", "KPOINTS.orig")
+
+    def test_kpoints_trans(self):
+        h = StdErrHandler("std_err.txt.kpoints_trans")
+        self.assertEqual(h.check(), True)
+        d = h.correct()
+        self.assertEqual(d["errors"], ['kpoints_trans'])
+        self.assertEqual(d["actions"],
+                         [{u'action': {u'_set':
+                                {u'kpoints': [[4, 4, 4]]}},
+                                u'dict': u'KPOINTS'}])
+
+        self.assertEqual(h.check(), True)
+        d = h.correct()
+        self.assertEqual(d["errors"], ['kpoints_trans'])
+        self.assertEqual(d["actions"], [])  # don't correct twice
+
+    def tearDown(self):
+        shutil.move("KPOINTS.orig", "KPOINTS")
         clean_dir()
         os.chdir(cwd)
 

--- a/test_files/std_err.txt.kpoints_trans
+++ b/test_files/std_err.txt.kpoints_trans
@@ -1,0 +1,34 @@
+[tscc-2-52.sdsc.edu:28010] 15 more processes have sent help message help-mpi-btl-openib-cpc-base.txt / no cpcs for port
+[tscc-2-52.sdsc.edu:28010] Set MCA parameter "orte_base_help_aggregate" to 0 to see all help / error messages
+ internal error in GENERATE_KPOINTS_TRANS: number of G-vector changed in star 
+ internal error in GENERATE_KPOINTS_TRANS: number of G-vector changed in star 
+        2392        2393
+        2392        2393
+ internal error in GENERATE_KPOINTS_TRANS: number of G-vector changed in star 
+        2392        2393
+ internal error in GENERATE_KPOINTS_TRANS: number of G-vector changed in star 
+        2392        2393
+ internal error in GENERATE_KPOINTS_TRANS: number of G-vector changed in star 
+        2392        2393
+ internal error in GENERATE_KPOINTS_TRANS: number of G-vector changed in star 
+ internal error in GENERATE_KPOINTS_TRANS: number of G-vector changed in star 
+        2392        2393
+ internal error in GENERATE_KPOINTS_TRANS: number of G-vector changed in star 
+        2392        2393
+        2392        2393
+ internal error in GENERATE_KPOINTS_TRANS: number of G-vector changed in star 
+        2392        2393
+ internal error in GENERATE_KPOINTS_TRANS: number of G-vector changed in star 
+        2392        2393
+ internal error in GENERATE_KPOINTS_TRANS: number of G-vector changed in star 
+        2392        2393
+ internal error in GENERATE_KPOINTS_TRANS: number of G-vector changed in star 
+        2392        2393
+ internal error in GENERATE_KPOINTS_TRANS: number of G-vector changed in star 
+        2392        2393
+ internal error in GENERATE_KPOINTS_TRANS: number of G-vector changed in star 
+        2392        2393
+ internal error in GENERATE_KPOINTS_TRANS: number of G-vector changed in star 
+        2392        2393
+ internal error in GENERATE_KPOINTS_TRANS: number of G-vector changed in star 
+        2392        2393


### PR DESCRIPTION
## Summary

* Make the k-mesh more even (same strategy as MeshErrorHandler) when getting "internal error in GENERATE_KPOINTS_TRANS" (typically seen in dielectric runs). e.g. Gamma 11x11x6 -> Gamma 9x9x9

(This branch can be deleted after merging)