### PR TITLE
format correct dictionary in *.error with pformat

### DIFF
--- a/custodian/custodian.py
+++ b/custodian/custodian.py
@@ -13,6 +13,7 @@ import os
 from abc import ABCMeta, abstractmethod
 from itertools import islice
 import warnings
+import json
 
 import six
 
@@ -571,7 +572,7 @@ class Custodian(object):
                         terminate_func = None
                     d = h.correct()
                     d["handler"] = h
-                    logger.error(str(d))
+                    logger.error(("\n"+json.dumps(d, indent=4)).replace("\n", "\n"+" "*4))
                     corrections.append(d)
             except Exception:
                 if not self.skip_over_errors:

--- a/custodian/custodian.py
+++ b/custodian/custodian.py
@@ -13,7 +13,7 @@ import os
 from abc import ABCMeta, abstractmethod
 from itertools import islice
 import warnings
-import json
+from pprint import pformat
 
 import six
 
@@ -572,7 +572,7 @@ class Custodian(object):
                         terminate_func = None
                     d = h.correct()
                     d["handler"] = h
-                    logger.error(("\n"+json.dumps(d, indent=4)).replace("\n", "\n"+" "*4))
+                    logger.error("\n" + pformat(d, indent=2, width=-1))
                     corrections.append(d)
             except Exception:
                 if not self.skip_over_errors:


### PR DESCRIPTION
## Summary

format correct dictionary in *.error with pformat. The text would be more readable.
finally like this:
```
{ u'actions': [ { u'action': { u'_set': { u'ISMEAR': 0}},
                  u'dict': u'INCAR'},
                { u'action': { u'_set': { u'ISTART': 1}},
                  u'dict': u'INCAR'},
                { u'action': { u'_set': { u'ALGO': u'Normal'}},
                  u'dict': u'INCAR'}],
  u'errors': [ u'brmix',
               u'pssyevx',
               u'dentet'],
  u'handler': <custodian.vasp.handlers.VaspErrorHandler object at 0x2b3d7950fd90>}
```