### PR TITLE
Updates to DriftErrorHandler

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -618,9 +618,11 @@ class DriftErrorHandler(ErrorHandler):
         outcar = Outcar("OUTCAR")
 
         if len(outcar.data.get('drift', [])) < self.to_average:
+            # Ensure enough steps to get average drift
             return False
         else:
-            curr_drift = np.sum(np.abs(outcar.data.get("drift", [])[::-1][:self.to_average])) / (3 * self.to_average)
+            curr_drift = outcar.data.get("drift", [])[::-1][:self.to_average]
+            curr_drift = np.average([np.norm(d) for d in curr_drift])
             return curr_drift > self.max_drift
 
     def correct(self):

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -606,9 +606,14 @@ class DriftErrorHandler(ErrorHandler):
 
     def check(self):
 
+        incar = Incar.from_file("INCAR")
+        if incar.get("EDIFFG", 0.1) >= 0 or incar.get("NSW",0) == 0:
+            # Only activate when force relaxing and ionic steps
+            # NSW check prevents accidental effects when running DFPT
+            return False
+
         if not self.max_drift:
-            incar = Incar.from_file("INCAR")
-            self.max_drift = incar.get("EDIFFG", -0.05) * -1
+            self.max_drift = incar["EDIFFG"] * -1
 
         outcar = Outcar("OUTCAR")
 

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -622,7 +622,7 @@ class DriftErrorHandler(ErrorHandler):
             return False
         else:
             curr_drift = outcar.data.get("drift", [])[::-1][:self.to_average]
-            curr_drift = np.average([np.norm(d) for d in curr_drift])
+            curr_drift = np.average([np.linalg.norm(d) for d in curr_drift])
             return curr_drift > self.max_drift
 
     def correct(self):
@@ -653,7 +653,8 @@ class DriftErrorHandler(ErrorHandler):
                             "action": {"_set": {"ENAUG": int(incar.get("ENAUG", 1040) * self.enaug_multiply)}}})
 
 
-        curr_drift = np.sum(np.abs(outcar.data.get("drift",[])[::-1][:self.to_average])) / (3 * self.to_average)
+        curr_drift = outcar.data.get("drift", [])[::-1][:self.to_average]
+        curr_drift = np.average([np.linalg.norm(d) for d in curr_drift])
         VaspModder(vi=vi).apply_actions(actions)
         return {"errors": "Excessive drift {} > {}".format(curr_drift, self.max_drift), "actions": actions}
 

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -696,11 +696,14 @@ class DriftErrorHandlerTest(unittest.TestCase):
         self.assertFalse(h.check())
 
         h = DriftErrorHandler(max_drift=0.0001)
-        self.assertTrue(h.check())
+        self.assertFalse(h.check())
 
         incar = Incar.from_file("INCAR")
         incar["EDIFFG"] = -0.01
         incar.write_file("INCAR")
+
+        h = DriftErrorHandler(max_drift=0.0001)
+        self.assertTrue(h.check())
 
         h = DriftErrorHandler()
         h.check()


### PR DESCRIPTION
Updates to Drift Correct
- Updated the drift calculation to use norm rather than just average
- Better logic to enable Drift correction only when EDIFFG < 0 and NSW = 0
 Prevents correction during DFPT calculations.