### PR TITLE
Update the unconverged error handler for SCAN

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -753,12 +753,17 @@ class UnconvergedErrorHandler(ErrorHandler):
         actions = [{"file": "CONTCAR",
                     "action": {"_file_copy": {"dest": "POSCAR"}}}]
         if not v.converged_electronic:
-            new_settings = {"ISTART": 1,
-                            "ALGO": "Normal",
-                            "NELMDL": -6,
-                            "BMIX": 0.001,
-                            "AMIX_MAG": 0.8,
-                            "BMIX_MAG": 0.001} 
+            # For SCAN try switching to CG for the electronic minimization
+            print(v.incar.get("METAGGA"))
+            if "SCAN" in v.incar.get("METAGGA","").upper():
+                new_settings = {"ALGO": "All"}
+            else:
+                new_settings = {"ISTART": 1,
+                                "ALGO": "Normal",
+                                "NELMDL": -6,
+                                "BMIX": 0.001,
+                                "AMIX_MAG": 0.8,
+                                "BMIX_MAG": 0.001} 
 
             if all([v.incar.get(k,"") == val for k,val in new_settings.items()]):
                 return {"errors": ["Unconverged"], "actions": None}

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -357,7 +357,17 @@ class UnconvergedErrorHandlerTest(unittest.TestCase):
         self.assertEqual(d["errors"], ['Unconverged'])
         os.remove("vasprun.xml")
 
-    def test_to_from_dict(self):
+    def test_check_correct_scan(self):
+        shutil.copy("vasprun.xml.scan", "vasprun.xml")
+        h = UnconvergedErrorHandler()
+        self.assertTrue(h.check())
+        d = h.correct()
+        self.assertEqual(d["errors"], ['Unconverged'])
+        self.assertIn({"dict": "INCAR",
+                           "action": {"_set": {"ALGO": "All"}}},d["actions"])
+        os.remove("vasprun.xml")
+
+    def test_to_from_dict(self):2
         h = UnconvergedErrorHandler("random_name.xml")
         h2 = UnconvergedErrorHandler.from_dict(h.as_dict())
         self.assertEqual(type(h2), UnconvergedErrorHandler)

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -367,7 +367,7 @@ class UnconvergedErrorHandlerTest(unittest.TestCase):
                            "action": {"_set": {"ALGO": "All"}}},d["actions"])
         os.remove("vasprun.xml")
 
-    def test_to_from_dict(self):2
+    def test_to_from_dict(self):
         h = UnconvergedErrorHandler("random_name.xml")
         h2 = UnconvergedErrorHandler.from_dict(h.as_dict())
         self.assertEqual(type(h2), UnconvergedErrorHandler)

--- a/test_files/unconverged/vasprun.xml.scan
+++ b/test_files/unconverged/vasprun.xml.scan
@@ -1,0 +1,15936 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<modeling>
+ <generator>
+  <i name="program" type="string">vasp </i>
+  <i name="version" type="string">5.4.4  </i>
+  <i name="subversion" type="string">18Apr17 (build Jun 29 2017 14:33:36) complex                          parallel </i>
+  <i name="platform" type="string">IFC17_CrayMPICH </i>
+  <i name="date" type="string">2017 12 08 </i>
+  <i name="time" type="string">10:16:40 </i>
+ </generator>
+ <incar>
+  <i type="int" name="ISTART">     1</i>
+  <i type="string" name="PREC">accurate</i>
+  <i type="string" name="ALGO"> Normal</i>
+  <i type="logical" name="ADDGRID"> T  </i>
+  <i type="int" name="ISPIN">     2</i>
+  <i name="BMIX">      0.00100000</i>
+  <i name="AMIX_MAG">      0.80000000</i>
+  <i name="BMIX_MAG">      0.00100000</i>
+  <i type="int" name="ICHARG">     0</i>
+  <i type="int" name="NELM">   100</i>
+  <i type="int" name="NELMDL">    -6</i>
+  <i type="int" name="IBRION">    -1</i>
+  <i name="EDIFF">      0.00001000</i>
+  <i name="EDIFFG">     -0.05000000</i>
+  <i type="int" name="NSW">     0</i>
+  <i type="int" name="ISIF">     3</i>
+  <i name="ENCUT">    520.00000000</i>
+  <v name="MAGMOM">      0.00000000      0.00000000</v>
+  <i type="string" name="LREAL"> Auto</i>
+  <i type="int" name="ISMEAR">    -5</i>
+  <i name="SIGMA">      0.05000000</i>
+  <i type="logical" name="LWAVE"> F  </i>
+  <i type="logical" name="LCHARG"> T  </i>
+  <i type="logical" name="LVHAR"> T  </i>
+  <i type="int" name="LORBIT">    11</i>
+  <i type="logical" name="LASPH"> T  </i>
+  <i type="logical" name="LAECHG"> T  </i>
+  <v type="int" name="KPOINT_BSE">    -1     0     0     0</v>
+  <i type="int" name="NELM">   100</i>
+  <i type="string" name="METAGGA"> Scan</i>
+  <i type="logical" name="LASPH"> T  </i>
+ </incar>
+ <structure name="primitive_cell" >
+  <crystal>
+   <varray name="basis" >
+    <v>       3.97062800      -0.01718700       2.52612800 </v>
+    <v>       1.37824500       3.72379200       2.52612800 </v>
+    <v>      -0.02480100      -0.01718700       4.70601700 </v>
+   </varray>
+   <i name="volume">     70.04059440 </i>
+   <varray name="rec_basis" >
+    <v>       0.25082090      -0.09349856       0.00098037 </v>
+    <v>       0.00053491       0.26768039       0.00098042 </v>
+    <v>      -0.13492449      -0.09349851       0.21144139 </v>
+   </varray>
+  </crystal>
+  <varray name="positions" >
+   <v>       0.23465600       0.23465600       0.23465600 </v>
+   <v>      -0.23465600      -0.23465600      -0.23465600 </v>
+  </varray>
+ </structure>
+ <varray name="primitive_index" >
+  <v type="int" >        1 </v>
+  <v type="int" >        2 </v>
+ </varray>
+ <kpoints>
+  <generation param="Monkhorst-Pack">
+   <v type="int" name="divisions">       8        8        8 </v>
+   <v name="usershift">      0.00000000       0.00000000       0.00000000 </v>
+   <v name="genvec1">      0.12500000       0.00000000       0.00000000 </v>
+   <v name="genvec2">     -0.00000000       0.12500000      -0.00000000 </v>
+   <v name="genvec3">     -0.00000000      -0.00000000       0.12500000 </v>
+   <v name="shift">      0.50000000       0.50000000       0.50000000 </v>
+  </generation>
+  <varray name="kpointlist" >
+   <v>       0.06250000       0.06250000       0.06250000 </v>
+   <v>       0.18750000       0.06250000       0.06250000 </v>
+   <v>       0.31250000       0.06250000       0.06250000 </v>
+   <v>       0.43750000       0.06250000       0.06250000 </v>
+   <v>      -0.43750000       0.06250000       0.06250000 </v>
+   <v>      -0.31250000       0.06250000       0.06250000 </v>
+   <v>      -0.18750000       0.06250000       0.06250000 </v>
+   <v>      -0.06250000       0.06250000       0.06250000 </v>
+   <v>       0.18750000       0.18750000       0.06250000 </v>
+   <v>       0.31250000       0.18750000       0.06250000 </v>
+   <v>       0.43750000       0.18750000       0.06250000 </v>
+   <v>      -0.43750000       0.18750000       0.06250000 </v>
+   <v>      -0.31250000       0.18750000       0.06250000 </v>
+   <v>      -0.18750000       0.18750000       0.06250000 </v>
+   <v>      -0.06250000       0.18750000       0.06250000 </v>
+   <v>       0.31250000       0.31250000       0.06250000 </v>
+   <v>       0.43750000       0.31250000       0.06250000 </v>
+   <v>      -0.43750000       0.31250000       0.06250000 </v>
+   <v>      -0.31250000       0.31250000       0.06250000 </v>
+   <v>      -0.18750000       0.31250000       0.06250000 </v>
+   <v>      -0.06250000       0.31250000       0.06250000 </v>
+   <v>       0.43750000       0.43750000       0.06250000 </v>
+   <v>      -0.43750000       0.43750000       0.06250000 </v>
+   <v>      -0.31250000       0.43750000       0.06250000 </v>
+   <v>      -0.18750000       0.43750000       0.06250000 </v>
+   <v>      -0.06250000       0.43750000       0.06250000 </v>
+   <v>      -0.43750000      -0.43750000       0.06250000 </v>
+   <v>      -0.31250000      -0.43750000       0.06250000 </v>
+   <v>      -0.18750000      -0.43750000       0.06250000 </v>
+   <v>      -0.31250000      -0.31250000       0.06250000 </v>
+   <v>      -0.18750000      -0.31250000       0.06250000 </v>
+   <v>      -0.18750000      -0.18750000       0.06250000 </v>
+   <v>       0.18750000       0.18750000       0.18750000 </v>
+   <v>       0.31250000       0.18750000       0.18750000 </v>
+   <v>       0.43750000       0.18750000       0.18750000 </v>
+   <v>      -0.43750000       0.18750000       0.18750000 </v>
+   <v>      -0.31250000       0.18750000       0.18750000 </v>
+   <v>      -0.18750000       0.18750000       0.18750000 </v>
+   <v>       0.31250000       0.31250000       0.18750000 </v>
+   <v>       0.43750000       0.31250000       0.18750000 </v>
+   <v>      -0.43750000       0.31250000       0.18750000 </v>
+   <v>      -0.31250000       0.31250000       0.18750000 </v>
+   <v>      -0.18750000       0.31250000       0.18750000 </v>
+   <v>       0.43750000       0.43750000       0.18750000 </v>
+   <v>      -0.43750000       0.43750000       0.18750000 </v>
+   <v>      -0.31250000       0.43750000       0.18750000 </v>
+   <v>      -0.18750000       0.43750000       0.18750000 </v>
+   <v>      -0.43750000      -0.43750000       0.18750000 </v>
+   <v>      -0.31250000      -0.43750000       0.18750000 </v>
+   <v>      -0.31250000      -0.31250000       0.18750000 </v>
+   <v>       0.31250000       0.31250000       0.31250000 </v>
+   <v>       0.43750000       0.31250000       0.31250000 </v>
+   <v>      -0.43750000       0.31250000       0.31250000 </v>
+   <v>      -0.31250000       0.31250000       0.31250000 </v>
+   <v>       0.43750000       0.43750000       0.31250000 </v>
+   <v>      -0.43750000       0.43750000       0.31250000 </v>
+   <v>      -0.31250000       0.43750000       0.31250000 </v>
+   <v>      -0.43750000      -0.43750000       0.31250000 </v>
+   <v>       0.43750000       0.43750000       0.43750000 </v>
+   <v>      -0.43750000       0.43750000       0.43750000 </v>
+  </varray>
+  <varray name="weights" >
+   <v>       0.00390625 </v>
+   <v>       0.01171875 </v>
+   <v>       0.01171875 </v>
+   <v>       0.01171875 </v>
+   <v>       0.01171875 </v>
+   <v>       0.01171875 </v>
+   <v>       0.01171875 </v>
+   <v>       0.01171875 </v>
+   <v>       0.01171875 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.01171875 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.01171875 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.01171875 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.01171875 </v>
+   <v>       0.02343750 </v>
+   <v>       0.01171875 </v>
+   <v>       0.00390625 </v>
+   <v>       0.01171875 </v>
+   <v>       0.01171875 </v>
+   <v>       0.01171875 </v>
+   <v>       0.01171875 </v>
+   <v>       0.01171875 </v>
+   <v>       0.01171875 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.01171875 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.01171875 </v>
+   <v>       0.02343750 </v>
+   <v>       0.01171875 </v>
+   <v>       0.00390625 </v>
+   <v>       0.01171875 </v>
+   <v>       0.01171875 </v>
+   <v>       0.01171875 </v>
+   <v>       0.01171875 </v>
+   <v>       0.02343750 </v>
+   <v>       0.02343750 </v>
+   <v>       0.01171875 </v>
+   <v>       0.00390625 </v>
+   <v>       0.01171875 </v>
+  </varray>
+  <varray name="tetrahedronlist"  type="int" >
+   <v type="int" >       12        1        2        9       33 </v>
+   <v type="int" >       12        2        9       10       34 </v>
+   <v type="int" >       12        2        3       10       34 </v>
+   <v type="int" >       12        2        9       33       34 </v>
+   <v type="int" >       12        3       10       11       35 </v>
+   <v type="int" >       12        3        4       11       35 </v>
+   <v type="int" >       12        3       10       34       35 </v>
+   <v type="int" >       12        4       11       12       36 </v>
+   <v type="int" >       12        4        5       12       36 </v>
+   <v type="int" >       12        4       11       35       36 </v>
+   <v type="int" >       12        5       12       13       37 </v>
+   <v type="int" >       12        5        6       13       37 </v>
+   <v type="int" >       12        5       12       36       37 </v>
+   <v type="int" >       12        6       13       14       38 </v>
+   <v type="int" >       12        6        7       14       38 </v>
+   <v type="int" >       12        6       13       37       38 </v>
+   <v type="int" >       12        7       14       15       32 </v>
+   <v type="int" >       12        7        8       15       32 </v>
+   <v type="int" >       12        7       14       32       38 </v>
+   <v type="int" >       12        2        8        9       15 </v>
+   <v type="int" >       12        1        2        8        9 </v>
+   <v type="int" >       12        8        9       15       32 </v>
+   <v type="int" >       12        9       10       16       39 </v>
+   <v type="int" >       12        9       10       34       39 </v>
+   <v type="int" >       12        9       33       34       39 </v>
+   <v type="int" >       12       10       16       17       40 </v>
+   <v type="int" >       12       10       11       17       40 </v>
+   <v type="int" >       12       10       11       35       40 </v>
+   <v type="int" >       12       10       16       39       40 </v>
+   <v type="int" >       12       10       34       39       40 </v>
+   <v type="int" >       12       10       34       35       40 </v>
+   <v type="int" >       12       11       17       18       41 </v>
+   <v type="int" >       12       11       12       18       41 </v>
+   <v type="int" >       12       11       12       36       41 </v>
+   <v type="int" >       12       11       17       40       41 </v>
+   <v type="int" >       12       11       35       40       41 </v>
+   <v type="int" >       12       11       35       36       41 </v>
+   <v type="int" >       12       12       18       19       42 </v>
+   <v type="int" >       12       12       13       19       42 </v>
+   <v type="int" >       12       12       13       37       42 </v>
+   <v type="int" >       12       12       18       41       42 </v>
+   <v type="int" >       12       12       36       41       42 </v>
+   <v type="int" >       12       12       36       37       42 </v>
+   <v type="int" >       12       13       19       20       43 </v>
+   <v type="int" >       12       13       14       20       43 </v>
+   <v type="int" >       12       13       14       38       43 </v>
+   <v type="int" >       12       13       19       42       43 </v>
+   <v type="int" >       12       13       37       42       43 </v>
+   <v type="int" >       12       13       37       38       43 </v>
+   <v type="int" >       12       14       20       21       31 </v>
+   <v type="int" >       12       14       15       21       31 </v>
+   <v type="int" >       12       14       15       31       32 </v>
+   <v type="int" >       12       14       20       31       43 </v>
+   <v type="int" >       12       14       31       38       43 </v>
+   <v type="int" >       12       14       31       32       38 </v>
+   <v type="int" >       12        3       10       15       21 </v>
+   <v type="int" >       12        2        3       10       15 </v>
+   <v type="int" >       12        2        9       10       15 </v>
+   <v type="int" >       12       10       15       21       31 </v>
+   <v type="int" >       12       10       15       31       32 </v>
+   <v type="int" >       12        9       10       15       32 </v>
+   <v type="int" >       12       16       17       22       44 </v>
+   <v type="int" >       12       16       17       40       44 </v>
+   <v type="int" >       12       16       39       40       44 </v>
+   <v type="int" >       12       17       22       23       45 </v>
+   <v type="int" >       12       17       18       23       45 </v>
+   <v type="int" >       12       17       18       41       45 </v>
+   <v type="int" >       12       17       22       44       45 </v>
+   <v type="int" >       12       17       40       44       45 </v>
+   <v type="int" >       12       17       40       41       45 </v>
+   <v type="int" >       12       18       23       24       46 </v>
+   <v type="int" >       12       18       19       24       46 </v>
+   <v type="int" >       12       18       19       42       46 </v>
+   <v type="int" >       12       18       23       45       46 </v>
+   <v type="int" >       12       18       41       45       46 </v>
+   <v type="int" >       12       18       41       42       46 </v>
+   <v type="int" >       12       19       24       25       47 </v>
+   <v type="int" >       12       19       20       25       47 </v>
+   <v type="int" >       12       19       20       43       47 </v>
+   <v type="int" >       12       19       24       46       47 </v>
+   <v type="int" >       12       19       42       46       47 </v>
+   <v type="int" >       12       19       42       43       47 </v>
+   <v type="int" >       12       20       25       26       29 </v>
+   <v type="int" >       12       20       21       26       29 </v>
+   <v type="int" >       12       20       21       29       31 </v>
+   <v type="int" >       12       20       25       29       47 </v>
+   <v type="int" >       12       20       29       43       47 </v>
+   <v type="int" >       12       20       29       31       43 </v>
+   <v type="int" >       12        4       11       21       26 </v>
+   <v type="int" >       12        3        4       11       21 </v>
+   <v type="int" >       12        3       10       11       21 </v>
+   <v type="int" >       12       11       21       26       29 </v>
+   <v type="int" >       12       11       21       29       31 </v>
+   <v type="int" >       12       10       11       21       31 </v>
+   <v type="int" >       12       22       23       27       48 </v>
+   <v type="int" >       12       22       23       45       48 </v>
+   <v type="int" >       12       22       44       45       48 </v>
+   <v type="int" >       12       23       27       28       49 </v>
+   <v type="int" >       12       23       24       28       49 </v>
+   <v type="int" >       12       23       24       46       49 </v>
+   <v type="int" >       12       23       27       48       49 </v>
+   <v type="int" >       12       23       45       48       49 </v>
+   <v type="int" >       12       23       45       46       49 </v>
+   <v type="int" >       12       24       28       29       47 </v>
+   <v type="int" >       12       24       25       29       47 </v>
+   <v type="int" >       12       24       25       47       47 </v>
+   <v type="int" >       12       24       28       47       49 </v>
+   <v type="int" >       12       24       46       47       49 </v>
+   <v type="int" >       12       24       46       47       47 </v>
+   <v type="int" >       12       25       25       26       29 </v>
+   <v type="int" >        6       25       25       26       26 </v>
+   <v type="int" >       12       25       25       29       47 </v>
+   <v type="int" >        6       25       25       47       47 </v>
+   <v type="int" >       12        5       12       26       26 </v>
+   <v type="int" >       12        4        5       12       26 </v>
+   <v type="int" >       12        4       11       12       26 </v>
+   <v type="int" >       12       12       25       26       26 </v>
+   <v type="int" >       12       12       25       26       29 </v>
+   <v type="int" >       12       11       12       26       29 </v>
+   <v type="int" >       12       27       28       30       50 </v>
+   <v type="int" >       12       27       28       49       50 </v>
+   <v type="int" >       12       27       48       49       50 </v>
+   <v type="int" >       12       28       30       31       43 </v>
+   <v type="int" >       12       28       29       31       43 </v>
+   <v type="int" >       12       28       29       43       47 </v>
+   <v type="int" >       12       28       30       43       50 </v>
+   <v type="int" >       12       28       43       49       50 </v>
+   <v type="int" >       12       28       43       47       49 </v>
+   <v type="int" >       12        6       13       21       26 </v>
+   <v type="int" >       12        5        6       13       26 </v>
+   <v type="int" >       12        5       12       13       26 </v>
+   <v type="int" >       12       13       20       21       26 </v>
+   <v type="int" >       12       13       20       25       26 </v>
+   <v type="int" >       12       12       13       25       26 </v>
+   <v type="int" >       12       30       31       32       38 </v>
+   <v type="int" >       12       30       31       38       43 </v>
+   <v type="int" >       12       30       38       43       50 </v>
+   <v type="int" >       12        7       14       15       21 </v>
+   <v type="int" >       12        6        7       14       21 </v>
+   <v type="int" >       12        6       13       14       21 </v>
+   <v type="int" >       12       14       14       15       21 </v>
+   <v type="int" >       12       14       14       20       21 </v>
+   <v type="int" >       12       13       14       20       21 </v>
+   <v type="int" >        6        8        8       15       15 </v>
+   <v type="int" >       12        7        8       15       15 </v>
+   <v type="int" >       12        7       14       15       15 </v>
+   <v type="int" >        6       14       14       15       15 </v>
+   <v type="int" >       12        1        2        8        8 </v>
+   <v type="int" >       12        2        8        8       15 </v>
+   <v type="int" >       12        2        7        8       15 </v>
+   <v type="int" >       12       33       34       39       51 </v>
+   <v type="int" >       12       34       39       40       52 </v>
+   <v type="int" >       12       34       35       40       52 </v>
+   <v type="int" >       12       34       39       51       52 </v>
+   <v type="int" >       12       35       40       41       53 </v>
+   <v type="int" >       12       35       36       41       53 </v>
+   <v type="int" >       12       35       40       52       53 </v>
+   <v type="int" >       12       36       41       42       54 </v>
+   <v type="int" >       12       36       37       42       54 </v>
+   <v type="int" >       12       36       41       53       54 </v>
+   <v type="int" >       12       37       42       43       50 </v>
+   <v type="int" >       12       37       38       43       50 </v>
+   <v type="int" >       12       37       42       50       54 </v>
+   <v type="int" >       12       10       16       31       32 </v>
+   <v type="int" >       12        9       10       16       32 </v>
+   <v type="int" >       12       16       30       31       32 </v>
+   <v type="int" >       12       39       40       44       55 </v>
+   <v type="int" >       12       39       40       52       55 </v>
+   <v type="int" >       12       39       51       52       55 </v>
+   <v type="int" >       12       40       44       45       56 </v>
+   <v type="int" >       12       40       41       45       56 </v>
+   <v type="int" >       12       40       41       53       56 </v>
+   <v type="int" >       12       40       44       55       56 </v>
+   <v type="int" >       12       40       52       55       56 </v>
+   <v type="int" >       12       40       52       53       56 </v>
+   <v type="int" >       12       41       45       46       57 </v>
+   <v type="int" >       12       41       42       46       57 </v>
+   <v type="int" >       12       41       42       54       57 </v>
+   <v type="int" >       12       41       45       56       57 </v>
+   <v type="int" >       12       41       53       56       57 </v>
+   <v type="int" >       12       41       53       54       57 </v>
+   <v type="int" >       12       42       46       47       49 </v>
+   <v type="int" >       12       42       43       47       49 </v>
+   <v type="int" >       12       42       43       49       50 </v>
+   <v type="int" >       12       42       46       49       57 </v>
+   <v type="int" >       12       42       49       54       57 </v>
+   <v type="int" >       12       42       49       50       54 </v>
+   <v type="int" >       12       11       17       29       31 </v>
+   <v type="int" >       12       10       11       17       31 </v>
+   <v type="int" >       12       10       16       17       31 </v>
+   <v type="int" >       12       17       28       29       31 </v>
+   <v type="int" >       12       17       28       30       31 </v>
+   <v type="int" >       12       16       17       30       31 </v>
+   <v type="int" >       12       44       45       48       58 </v>
+   <v type="int" >       12       44       45       56       58 </v>
+   <v type="int" >       12       44       55       56       58 </v>
+   <v type="int" >       12       45       48       49       57 </v>
+   <v type="int" >       12       45       46       49       57 </v>
+   <v type="int" >       12       45       46       57       57 </v>
+   <v type="int" >       12       45       48       57       58 </v>
+   <v type="int" >       12       45       56       57       58 </v>
+   <v type="int" >       12       45       56       57       57 </v>
+   <v type="int" >       12       46       46       47       49 </v>
+   <v type="int" >        6       46       46       47       47 </v>
+   <v type="int" >       12       46       46       49       57 </v>
+   <v type="int" >        6       46       46       57       57 </v>
+   <v type="int" >       12       12       18       25       29 </v>
+   <v type="int" >       12       11       12       18       29 </v>
+   <v type="int" >       12       11       17       18       29 </v>
+   <v type="int" >       12       18       24       25       29 </v>
+   <v type="int" >       12       18       24       28       29 </v>
+   <v type="int" >       12       17       18       28       29 </v>
+   <v type="int" >       12       48       49       50       54 </v>
+   <v type="int" >       12       48       49       54       57 </v>
+   <v type="int" >       12       48       54       57       58 </v>
+   <v type="int" >       12       13       19       20       25 </v>
+   <v type="int" >       12       12       13       19       25 </v>
+   <v type="int" >       12       12       18       19       25 </v>
+   <v type="int" >       12       19       19       20       25 </v>
+   <v type="int" >       12       19       19       24       25 </v>
+   <v type="int" >       12       18       19       24       25 </v>
+   <v type="int" >        6       14       14       20       20 </v>
+   <v type="int" >       12       13       14       20       20 </v>
+   <v type="int" >       12       13       19       20       20 </v>
+   <v type="int" >        6       19       19       20       20 </v>
+   <v type="int" >       12        2        3        7       15 </v>
+   <v type="int" >       12        3        7       15       21 </v>
+   <v type="int" >       12        3        6        7       21 </v>
+   <v type="int" >       12       51       52       55       59 </v>
+   <v type="int" >       12       52       55       56       60 </v>
+   <v type="int" >       12       52       53       56       60 </v>
+   <v type="int" >       12       52       55       59       60 </v>
+   <v type="int" >       12       53       56       57       58 </v>
+   <v type="int" >       12       53       54       57       58 </v>
+   <v type="int" >       12       53       56       58       60 </v>
+   <v type="int" >       12       17       22       28       30 </v>
+   <v type="int" >       12       16       17       22       30 </v>
+   <v type="int" >       12       22       27       28       30 </v>
+   <v type="int" >       12       55       56       58       60 </v>
+   <v type="int" >       12       55       56       60       60 </v>
+   <v type="int" >       12       55       59       60       60 </v>
+   <v type="int" >       12       56       56       57       58 </v>
+   <v type="int" >        6       56       56       57       57 </v>
+   <v type="int" >       12       56       56       58       60 </v>
+   <v type="int" >        6       56       56       60       60 </v>
+   <v type="int" >       12       18       23       24       28 </v>
+   <v type="int" >       12       17       18       23       28 </v>
+   <v type="int" >       12       17       22       23       28 </v>
+   <v type="int" >       12       23       23       24       28 </v>
+   <v type="int" >       12       23       23       27       28 </v>
+   <v type="int" >       12       22       23       27       28 </v>
+   <v type="int" >        6       19       19       24       24 </v>
+   <v type="int" >       12       18       19       24       24 </v>
+   <v type="int" >       12       18       23       24       24 </v>
+   <v type="int" >        6       23       23       24       24 </v>
+   <v type="int" >       12        3        4        6       21 </v>
+   <v type="int" >       12        4        6       21       26 </v>
+   <v type="int" >       12        4        5        6       26 </v>
+   <v type="int" >        6       59       59       60       60 </v>
+   <v type="int" >        6       23       23       27       27 </v>
+   <v type="int" >       12       22       23       27       27 </v>
+   <v type="int" >       12        4        5        5       26 </v>
+   <v type="int" >        6        5        5       26       26 </v>
+   <v type="int" >        6        1        1        8        8 </v>
+  </varray>
+  <i name="volumeweight">      0.00032552 </i>
+ </kpoints>
+ <parameters>
+  <separator name="general" >
+   <i type="string" name="SYSTEM">unknown system</i>
+   <i type="logical" name="LCOMPAT"> F  </i>
+  </separator>
+  <separator name="electronic" >
+   <i type="string" name="PREC">accura</i>
+   <i name="ENMAX">    520.00000000</i>
+   <i name="ENAUG">    265.42700000</i>
+   <i name="EDIFF">      0.00001000</i>
+   <i type="int" name="IALGO">    38</i>
+   <i type="int" name="IWAVPR">    10</i>
+   <i type="int" name="NBANDS">    16</i>
+   <i name="NELECT">     10.00000000</i>
+   <i type="int" name="TURBO">     0</i>
+   <i type="int" name="IRESTART">     0</i>
+   <i type="int" name="NREBOOT">     0</i>
+   <i type="int" name="NMIN">     0</i>
+   <i name="EREF">      0.00000000</i>
+   <separator name="electronic smearing" >
+    <i type="int" name="ISMEAR">    -5</i>
+    <i name="SIGMA">      0.05000000</i>
+    <i name="KSPACING">      0.50000000</i>
+    <i type="logical" name="KGAMMA"> T  </i>
+   </separator>
+   <separator name="electronic projectors" >
+    <i type="logical" name="LREAL"> T  </i>
+    <v name="ROPT">     -0.00025000</v>
+    <i type="int" name="LMAXPAW">  -100</i>
+    <i type="int" name="LMAXMIX">     2</i>
+    <i type="logical" name="NLSPLINE"> F  </i>
+   </separator>
+   <separator name="electronic startup" >
+    <i type="int" name="ISTART">     0</i>
+    <i type="int" name="ICHARG">     2</i>
+    <i type="int" name="INIWAV">     1</i>
+   </separator>
+   <separator name="electronic spin" >
+    <i type="int" name="ISPIN">     2</i>
+    <i type="logical" name="LNONCOLLINEAR"> F  </i>
+    <v name="MAGMOM">      0.00000000      0.00000000</v>
+    <i name="NUPDOWN">     -1.00000000</i>
+    <i type="logical" name="LSORBIT"> F  </i>
+    <v name="SAXIS">      0.00000000      0.00000000      1.00000000</v>
+    <i type="logical" name="LSPIRAL"> F  </i>
+    <v name="QSPIRAL">      0.00000000      0.00000000      0.00000000</v>
+    <i type="logical" name="LZEROZ"> F  </i>
+   </separator>
+   <separator name="electronic exchange-correlation" >
+    <i type="logical" name="LASPH"> T  </i>
+    <i type="logical" name="LMETAGGA"> F  </i>
+   </separator>
+   <separator name="electronic convergence" >
+    <i type="int" name="NELM">   100</i>
+    <i type="int" name="NELMDL">    -6</i>
+    <i type="int" name="NELMIN">     2</i>
+    <i name="ENINI">    520.00000000</i>
+    <separator name="electronic convergence detail" >
+     <i type="logical" name="LDIAG"> T  </i>
+     <i type="logical" name="LSUBROT"> F  </i>
+     <i name="WEIMIN">      0.00000000</i>
+     <i name="EBREAK">      0.00000016</i>
+     <i name="DEPER">      0.30000000</i>
+     <i type="int" name="NRMM">     4</i>
+     <i name="TIME">      0.40000000</i>
+    </separator>
+   </separator>
+   <separator name="electronic mixer" >
+    <i name="AMIX">      0.40000000</i>
+    <i name="BMIX">      0.00100000</i>
+    <i name="AMIN">      0.10000000</i>
+    <i name="AMIX_MAG">      0.80000000</i>
+    <i name="BMIX_MAG">      0.00100000</i>
+    <separator name="electronic mixer details" >
+     <i type="int" name="IMIX">     4</i>
+     <i type="logical" name="MIXFIRST"> F  </i>
+     <i type="int" name="MAXMIX">   -45</i>
+     <i name="WC">    100.00000000</i>
+     <i type="int" name="INIMIX">     1</i>
+     <i type="int" name="MIXPRE">     1</i>
+     <i type="int" name="MREMOVE">     5</i>
+    </separator>
+   </separator>
+   <separator name="electronic dipolcorrection" >
+    <i type="logical" name="LDIPOL"> F  </i>
+    <i type="logical" name="LMONO"> F  </i>
+    <i type="int" name="IDIPOL">     0</i>
+    <i name="EPSILON">      1.00000000</i>
+    <v name="DIPOL">   -100.00000000   -100.00000000   -100.00000000</v>
+    <i name="EFIELD">      0.00000000</i>
+   </separator>
+  </separator>
+  <separator name="grids" >
+   <i type="int" name="NGX">    36</i>
+   <i type="int" name="NGY">    36</i>
+   <i type="int" name="NGZ">    36</i>
+   <i type="int" name="NGXF">    72</i>
+   <i type="int" name="NGYF">    72</i>
+   <i type="int" name="NGZF">    72</i>
+   <i type="logical" name="ADDGRID"> T  </i>
+  </separator>
+  <separator name="ionic" >
+   <i type="int" name="NSW">     0</i>
+   <i type="int" name="IBRION">    -1</i>
+   <i type="int" name="MDALGO">     0</i>
+   <i type="int" name="ISIF">     3</i>
+   <i name="PSTRESS">      0.00000000</i>
+   <i name="EDIFFG">     -0.05000000</i>
+   <i type="int" name="NFREE">     0</i>
+   <i name="POTIM">      0.50000000</i>
+   <i name="SMASS">     -3.00000000</i>
+   <i name="SCALEE">      1.00000000</i>
+  </separator>
+  <separator name="ionic md" >
+   <i name="TEBEG">      0.00010000</i>
+   <i name="TEEND">      0.00010000</i>
+   <i type="int" name="NBLOCK">     1</i>
+   <i type="int" name="KBLOCK">     1</i>
+   <i type="int" name="NPACO">   256</i>
+   <i name="APACO">     16.00000000</i>
+  </separator>
+  <separator name="symmetry" >
+   <i type="int" name="ISYM">     2</i>
+   <i name="SYMPREC">      0.00001000</i>
+  </separator>
+  <separator name="dos" >
+   <i type="int" name="LORBIT">    11</i>
+   <v name="RWIGS">     -1.00000000</v>
+   <i type="int" name="NEDOS">   301</i>
+   <i name="EMIN">     10.00000000</i>
+   <i name="EMAX">    -10.00000000</i>
+   <i name="EFERMI">      0.00000000</i>
+  </separator>
+  <separator name="writing" >
+   <i type="int" name="NWRITE">     2</i>
+   <i type="logical" name="LWAVE"> F  </i>
+   <i type="logical" name="LDOWNSAMPLE"> F  </i>
+   <i type="logical" name="LCHARG"> T  </i>
+   <i type="logical" name="LPARD"> F  </i>
+   <i type="logical" name="LVTOT"> F  </i>
+   <i type="logical" name="LVHAR"> T  </i>
+   <i type="logical" name="LELF"> F  </i>
+   <i type="logical" name="LOPTICS"> F  </i>
+   <v name="STM">      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="performance" >
+   <i type="int" name="NPAR">     8</i>
+   <i type="int" name="NSIM">     4</i>
+   <i type="int" name="NBLK">    -1</i>
+   <i type="logical" name="LPLANE"> T  </i>
+   <i type="logical" name="LSCALAPACK"> T  </i>
+   <i type="logical" name="LSCAAWARE"> F  </i>
+   <i type="logical" name="LSCALU"> F  </i>
+   <i type="logical" name="LASYNC"> F  </i>
+   <i type="logical" name="LORBITALREAL"> F  </i>
+  </separator>
+  <separator name="miscellaneous" >
+   <i type="int" name="IDIOT">     3</i>
+   <i type="int" name="ISPECIAL">     0</i>
+   <i type="logical" name="LMUSIC"> F  </i>
+   <v name="POMASS">    208.98000000</v>
+   <v name="DARWINR">      0.00000000</v>
+   <v name="DARWINV">      1.00000000</v>
+   <i type="logical" name="LCORR"> T  </i>
+  </separator>
+  <i type="logical" name="GGA_COMPAT"> T  </i>
+  <i type="logical" name="LBERRY"> F  </i>
+  <i type="int" name="ICORELEVEL">     0</i>
+  <i type="logical" name="LDAU"> F  </i>
+  <i type="int" name="I_CONSTRAINED_M">     0</i>
+  <separator name="electronic exchange-correlation" >
+   <i type="string" name="GGA">--</i>
+   <i type="int" name="VOSKOWN">     0</i>
+   <i type="logical" name="LHFCALC"> F  </i>
+   <i type="string" name="PRECFOCK"></i>
+   <i type="logical" name="LSYMGRAD"> F  </i>
+   <i type="logical" name="LHFONE"> F  </i>
+   <i type="logical" name="LRHFCALC"> F  </i>
+   <i type="logical" name="LTHOMAS"> F  </i>
+   <i type="logical" name="LMODELHF"> F  </i>
+   <i type="logical" name="LFOCKACE"> F  </i>
+   <i name="ENCUT4O">     -1.00000000</i>
+   <i type="int" name="EXXOEP">     0</i>
+   <i type="int" name="FOURORBIT">     0</i>
+   <i name="AEXX">      0.00000000</i>
+   <i name="HFALPHA">      0.00000000</i>
+   <i name="MCALPHA">      0.00000000</i>
+   <i name="ALDAX">      1.00000000</i>
+   <i name="AGGAX">      1.00000000</i>
+   <i name="ALDAC">      1.00000000</i>
+   <i name="AGGAC">      1.00000000</i>
+   <i type="int" name="NKREDX">     1</i>
+   <i type="int" name="NKREDY">     1</i>
+   <i type="int" name="NKREDZ">     1</i>
+   <i type="logical" name="SHIFTRED"> F  </i>
+   <i type="logical" name="ODDONLY"> F  </i>
+   <i type="logical" name="EVENONLY"> F  </i>
+   <i type="int" name="LMAXFOCK">     0</i>
+   <i type="int" name="NMAXFOCKAE">     0</i>
+   <i type="logical" name="LFOCKAEDFT"> F  </i>
+   <i name="HFSCREEN">      0.00000000</i>
+   <i name="HFSCREENC">      0.00000000</i>
+   <i type="int" name="NBANDSGWLOW">     0</i>
+  </separator>
+  <separator name="vdW DFT" >
+   <i type="logical" name="LUSE_VDW"> F  </i>
+   <i name="Zab_VDW">     -0.84910000</i>
+   <i name="PARAM1">      0.12340000</i>
+   <i name="PARAM2">      1.00000000</i>
+   <i name="PARAM3">      0.00000000</i>
+  </separator>
+  <separator name="model GW" >
+   <i type="int" name="MODEL_GW">     0</i>
+   <i name="MODEL_EPS0">     21.01217832</i>
+   <i name="MODEL_ALPHA">      1.00000000</i>
+  </separator>
+  <separator name="linear response parameters" >
+   <i type="logical" name="LEPSILON"> F  </i>
+   <i type="logical" name="LRPA"> F  </i>
+   <i type="logical" name="LNABLA"> F  </i>
+   <i type="logical" name="LVEL"> F  </i>
+   <i type="int" name="KINTER">     0</i>
+   <i name="CSHIFT">      0.10000000</i>
+   <i name="OMEGAMAX">     -1.00000000</i>
+   <i name="DEG_THRESHOLD">      0.00200000</i>
+   <i name="RTIME">     -0.10000000</i>
+   <i name="WPLASMAI">      0.00000000</i>
+   <v name="DFIELD">      0.00000000      0.00000000      0.00000000</v>
+   <v name="WPLASMA">      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="orbital magnetization" >
+   <i type="logical" name="NUCIND"> F  </i>
+   <v name="MAGPOS">      0.00000000      0.00000000      0.00000000</v>
+   <i type="logical" name="LNICSALL"> T  </i>
+   <i type="logical" name="ORBITALMAG"> F  </i>
+   <i type="logical" name="LMAGBLOCH"> F  </i>
+   <i type="logical" name="LCHIMAG"> F  </i>
+   <i type="logical" name="LGAUGE"> T  </i>
+   <i type="int" name="MAGATOM">     0</i>
+   <v name="MAGDIPOL">      0.00000000      0.00000000      0.00000000</v>
+   <v name="AVECCONST">      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="response functions" >
+   <i type="logical" name="LADDER"> F  </i>
+   <i type="logical" name="LRPAFORCE"> F  </i>
+   <i type="logical" name="LFXC"> F  </i>
+   <i type="logical" name="LHARTREE"> T  </i>
+   <i type="int" name="IBSE">     0</i>
+   <v type="int" name="KPOINT">    -1     0     0     0</v>
+   <i type="logical" name="LTCTE"> F  </i>
+   <i type="logical" name="LTETE"> F  </i>
+   <i type="logical" name="LTRIPLET"> F  </i>
+   <i type="logical" name="LFXCEPS"> F  </i>
+   <i type="logical" name="LFXHEG"> F  </i>
+   <i type="int" name="NATURALO">     2</i>
+   <i type="logical" name="L2ORDER"> F  </i>
+   <i type="logical" name="LMP2LT"> F  </i>
+   <i type="logical" name="LUSEW"> F  </i>
+   <i name="ENCUTGW">     -2.00000000</i>
+   <i name="ENCUTGWSOFT">     -2.00000000</i>
+   <i name="ENCUTLF">     -1.00000000</i>
+   <i type="int" name="LMAXMP2">    -1</i>
+   <i name="SCISSOR">      0.00000000</i>
+   <i type="int" name="NOMEGA">     0</i>
+   <i type="int" name="NOMEGAR">     0</i>
+   <i type="int" name="NBANDSGW">    -1</i>
+   <i type="int" name="NBANDSO">    -1</i>
+   <i type="int" name="NBANDSV">    -1</i>
+   <i type="int" name="NELM">   100</i>
+   <i type="int" name="NELMHF">     1</i>
+   <i type="int" name="DIM">     3</i>
+   <i type="int" name="ANTIRES">     0</i>
+   <i name="OMEGAMAX">    -30.00000000</i>
+   <i name="OMEGAMIN">    -30.00000000</i>
+   <i name="OMEGATL">   -200.00000000</i>
+   <i type="int" name="OMEGAGRID">   140</i>
+   <i name="CSHIFT">     -0.10000000</i>
+   <i type="logical" name="SELFENERGY"> F  </i>
+   <i type="logical" name="LSPECTRAL"> F  </i>
+   <i type="logical" name="LSPECTRALGW"> F  </i>
+   <i type="logical" name="LSINGLES"> F  </i>
+   <i type="logical" name="LFERMIGW"> F  </i>
+   <i type="logical" name="ODDONLYGW"> F  </i>
+   <i type="logical" name="EVENONLYGW"> F  </i>
+   <i type="int" name="NKREDLFX">     1</i>
+   <i type="int" name="NKREDLFY">     1</i>
+   <i type="int" name="NKREDLFZ">     1</i>
+   <i type="int" name="MAXMEM">  2800</i>
+   <i type="int" name="TELESCOPE">     0</i>
+   <i type="int" name="TAUPAR">     1</i>
+   <i type="int" name="OMEGAPAR">    -1</i>
+   <i name="LAMBDA">      1.00000000</i>
+  </separator>
+  <separator name="External order field" >
+   <i name="OFIELD_KAPPA">      0.00000000</i>
+   <v name="OFIELD_K">      0.00000000      0.00000000      0.00000000</v>
+   <i name="OFIELD_Q6_NEAR">      0.00000000</i>
+   <i name="OFIELD_Q6_FAR">      0.00000000</i>
+   <i name="OFIELD_A">      0.00000000</i>
+  </separator>
+ </parameters>
+ <atominfo>
+  <atoms>       2 </atoms>
+  <types>       1 </types>
+  <array name="atoms" >
+   <dimension dim="1">ion</dimension>
+   <field type="string">element</field>
+   <field type="int">atomtype</field>
+   <set>
+    <rc><c>Bi</c><c>   1</c></rc>
+    <rc><c>Bi</c><c>   1</c></rc>
+   </set>
+  </array>
+  <array name="atomtypes" >
+   <dimension dim="1">type</dimension>
+   <field type="int">atomspertype</field>
+   <field type="string">element</field>
+   <field>mass</field>
+   <field>valence</field>
+   <field type="string">pseudopotential</field>
+   <set>
+    <rc><c>   2</c><c>Bi</c><c>    208.98000000</c><c>      5.00000000</c><c> PAW_PBE Bi 08Apr2002                   </c></rc>
+   </set>
+  </array>
+ </atominfo>
+ <structure name="initialpos" >
+  <crystal>
+   <varray name="basis" >
+    <v>       3.97062800      -0.01718700       2.52612800 </v>
+    <v>       1.37824500       3.72379200       2.52612800 </v>
+    <v>      -0.02480100      -0.01718700       4.70601700 </v>
+   </varray>
+   <i name="volume">     70.04059440 </i>
+   <varray name="rec_basis" >
+    <v>       0.25082090      -0.09349856       0.00098037 </v>
+    <v>       0.00053491       0.26768039       0.00098042 </v>
+    <v>      -0.13492449      -0.09349851       0.21144139 </v>
+   </varray>
+  </crystal>
+  <varray name="positions" >
+   <v>       0.23465600       0.23465600       0.23465600 </v>
+   <v>       0.76534400       0.76534400       0.76534400 </v>
+  </varray>
+ </structure>
+ <calculation>
+  <scstep>
+   <time name="dav">   15.21    1.94</time>
+   <time name="total">   22.93    7.44</time>
+   <energy>
+    <i name="alphaZ">      3.42601119 </i>
+    <i name="ewald">   -310.71786193 </i>
+    <i name="hartreedc">    -12.71669924 </i>
+    <i name="XCdc">   -237.53852469 </i>
+    <i name="pawpsdc">    377.06337611 </i>
+    <i name="pawaedc">   -268.17759008 </i>
+    <i name="eentropy">      0.00000000 </i>
+    <i name="bandstr">     16.44199140 </i>
+    <i name="atom">    301.62628180 </i>
+    <i name="e_fr_energy">   -130.59301544 </i>
+    <i name="e_wo_entrp">   -130.59301544 </i>
+    <i name="e_0_energy">   -130.59301544 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   18.54    2.33</time>
+   <time name="total">   18.64    2.39</time>
+   <energy>
+    <i name="e_fr_energy">   -160.71020407 </i>
+    <i name="e_wo_entrp">   -160.71020407 </i>
+    <i name="e_0_energy">   -160.71020407 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   21.82    2.79</time>
+   <time name="total">   21.84    2.81</time>
+   <energy>
+    <i name="e_fr_energy">   -162.70049849 </i>
+    <i name="e_wo_entrp">   -162.70049849 </i>
+    <i name="e_0_energy">   -162.70049849 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   18.61    2.34</time>
+   <time name="total">   18.76    2.36</time>
+   <energy>
+    <i name="e_fr_energy">   -162.79807631 </i>
+    <i name="e_wo_entrp">   -162.79807631 </i>
+    <i name="e_0_energy">   -162.79807631 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   17.70    2.22</time>
+   <time name="total">   17.88    2.24</time>
+   <energy>
+    <i name="e_fr_energy">   -162.79987628 </i>
+    <i name="e_wo_entrp">   -162.79987628 </i>
+    <i name="e_0_energy">   -162.79987628 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   18.66    2.34</time>
+   <time name="total">   23.16    3.13</time>
+   <energy>
+    <i name="e_fr_energy">   -162.79992772 </i>
+    <i name="e_wo_entrp">   -162.79992772 </i>
+    <i name="e_0_energy">   -162.79992772 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   17.70    2.22</time>
+   <time name="total">   29.46    8.53</time>
+   <energy>
+    <i name="e_fr_energy">   -156.39123586 </i>
+    <i name="e_wo_entrp">   -156.39123586 </i>
+    <i name="e_0_energy">   -156.39123586 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   17.60    2.20</time>
+   <time name="total">   29.30    8.48</time>
+   <energy>
+    <i name="e_fr_energy">   -157.38809185 </i>
+    <i name="e_wo_entrp">   -157.38809185 </i>
+    <i name="e_0_energy">   -157.38809185 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   17.14    2.15</time>
+   <time name="total">   28.71    8.40</time>
+   <energy>
+    <i name="e_fr_energy">   -157.29045370 </i>
+    <i name="e_wo_entrp">   -157.29045370 </i>
+    <i name="e_0_energy">   -157.29045370 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   15.34    1.92</time>
+   <time name="total">   26.95    8.17</time>
+   <energy>
+    <i name="e_fr_energy">   -157.92245318 </i>
+    <i name="e_wo_entrp">   -157.92245318 </i>
+    <i name="e_0_energy">   -157.92245318 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   17.80    2.23</time>
+   <time name="total">   29.26    8.47</time>
+   <energy>
+    <i name="e_fr_energy">   -157.85145786 </i>
+    <i name="e_wo_entrp">   -157.85145786 </i>
+    <i name="e_0_energy">   -157.85145786 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   15.40    1.93</time>
+   <time name="total">   27.03    8.17</time>
+   <energy>
+    <i name="e_fr_energy">   -157.51846334 </i>
+    <i name="e_wo_entrp">   -157.51846334 </i>
+    <i name="e_0_energy">   -157.51846334 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   15.10    1.89</time>
+   <time name="total">   26.82    8.18</time>
+   <energy>
+    <i name="e_fr_energy">   -157.78184559 </i>
+    <i name="e_wo_entrp">   -157.78184559 </i>
+    <i name="e_0_energy">   -157.78184559 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.40    1.80</time>
+   <time name="total">   26.05    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.41827646 </i>
+    <i name="e_wo_entrp">   -157.41827646 </i>
+    <i name="e_0_energy">   -157.41827646 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.41    1.80</time>
+   <time name="total">   26.12    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.55219334 </i>
+    <i name="e_wo_entrp">   -157.55219334 </i>
+    <i name="e_0_energy">   -157.55219334 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.46    1.81</time>
+   <time name="total">   26.10    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.61337474 </i>
+    <i name="e_wo_entrp">   -157.61337474 </i>
+    <i name="e_0_energy">   -157.61337474 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.38    1.80</time>
+   <time name="total">   26.12    8.07</time>
+   <energy>
+    <i name="e_fr_energy">   -157.66513867 </i>
+    <i name="e_wo_entrp">   -157.66513867 </i>
+    <i name="e_0_energy">   -157.66513867 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.44    1.81</time>
+   <time name="total">   26.06    8.05</time>
+   <energy>
+    <i name="e_fr_energy">   -157.65992822 </i>
+    <i name="e_wo_entrp">   -157.65992822 </i>
+    <i name="e_0_energy">   -157.65992822 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.39    1.80</time>
+   <time name="total">   26.07    8.05</time>
+   <energy>
+    <i name="e_fr_energy">   -157.53019155 </i>
+    <i name="e_wo_entrp">   -157.53019155 </i>
+    <i name="e_0_energy">   -157.53019155 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.47    1.81</time>
+   <time name="total">   26.09    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.51390638 </i>
+    <i name="e_wo_entrp">   -157.51390638 </i>
+    <i name="e_0_energy">   -157.51390638 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.44    1.81</time>
+   <time name="total">   26.42    8.14</time>
+   <energy>
+    <i name="e_fr_energy">   -157.47803282 </i>
+    <i name="e_wo_entrp">   -157.47803282 </i>
+    <i name="e_0_energy">   -157.47803282 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.42    1.80</time>
+   <time name="total">   26.21    8.09</time>
+   <energy>
+    <i name="e_fr_energy">   -157.51864947 </i>
+    <i name="e_wo_entrp">   -157.51864947 </i>
+    <i name="e_0_energy">   -157.51864947 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.48    1.81</time>
+   <time name="total">   26.39    8.10</time>
+   <energy>
+    <i name="e_fr_energy">   -157.60753221 </i>
+    <i name="e_wo_entrp">   -157.60753221 </i>
+    <i name="e_0_energy">   -157.60753221 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.33    1.79</time>
+   <time name="total">   26.09    8.05</time>
+   <energy>
+    <i name="e_fr_energy">   -157.60662177 </i>
+    <i name="e_wo_entrp">   -157.60662177 </i>
+    <i name="e_0_energy">   -157.60662177 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.33    1.79</time>
+   <time name="total">   26.26    8.11</time>
+   <energy>
+    <i name="e_fr_energy">   -157.68058783 </i>
+    <i name="e_wo_entrp">   -157.68058783 </i>
+    <i name="e_0_energy">   -157.68058783 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.47    1.81</time>
+   <time name="total">   26.17    8.07</time>
+   <energy>
+    <i name="e_fr_energy">   -157.66596736 </i>
+    <i name="e_wo_entrp">   -157.66596736 </i>
+    <i name="e_0_energy">   -157.66596736 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.18    8.07</time>
+   <energy>
+    <i name="e_fr_energy">   -157.65651957 </i>
+    <i name="e_wo_entrp">   -157.65651957 </i>
+    <i name="e_0_energy">   -157.65651957 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.43    1.80</time>
+   <time name="total">   26.13    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.65540395 </i>
+    <i name="e_wo_entrp">   -157.65540395 </i>
+    <i name="e_0_energy">   -157.65540395 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.39    1.80</time>
+   <time name="total">   26.12    8.07</time>
+   <energy>
+    <i name="e_fr_energy">   -157.63349621 </i>
+    <i name="e_wo_entrp">   -157.63349621 </i>
+    <i name="e_0_energy">   -157.63349621 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.01    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.61690505 </i>
+    <i name="e_wo_entrp">   -157.61690505 </i>
+    <i name="e_0_energy">   -157.61690505 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.37    1.80</time>
+   <time name="total">   26.19    8.07</time>
+   <energy>
+    <i name="e_fr_energy">   -157.60136208 </i>
+    <i name="e_wo_entrp">   -157.60136208 </i>
+    <i name="e_0_energy">   -157.60136208 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.29    1.79</time>
+   <time name="total">   25.98    8.04</time>
+   <energy>
+    <i name="e_fr_energy">   -157.61142522 </i>
+    <i name="e_wo_entrp">   -157.61142522 </i>
+    <i name="e_0_energy">   -157.61142522 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.47    1.81</time>
+   <time name="total">   26.38    8.10</time>
+   <energy>
+    <i name="e_fr_energy">   -157.59750131 </i>
+    <i name="e_wo_entrp">   -157.59750131 </i>
+    <i name="e_0_energy">   -157.59750131 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.51    1.81</time>
+   <time name="total">   26.19    8.10</time>
+   <energy>
+    <i name="e_fr_energy">   -157.62271254 </i>
+    <i name="e_wo_entrp">   -157.62271254 </i>
+    <i name="e_0_energy">   -157.62271254 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.30    1.79</time>
+   <time name="total">   26.49    8.63</time>
+   <energy>
+    <i name="e_fr_energy">   -157.60704529 </i>
+    <i name="e_wo_entrp">   -157.60704529 </i>
+    <i name="e_0_energy">   -157.60704529 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.31    1.79</time>
+   <time name="total">   26.12    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.62063493 </i>
+    <i name="e_wo_entrp">   -157.62063493 </i>
+    <i name="e_0_energy">   -157.62063493 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   75.63   94.31</time>
+   <energy>
+    <i name="e_fr_energy">   -157.59823141 </i>
+    <i name="e_wo_entrp">   -157.59823141 </i>
+    <i name="e_0_energy">   -157.59823141 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.00    8.25</time>
+   <energy>
+    <i name="e_fr_energy">   -157.62516770 </i>
+    <i name="e_wo_entrp">   -157.62516770 </i>
+    <i name="e_0_energy">   -157.62516770 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.25    8.09</time>
+   <energy>
+    <i name="e_fr_energy">   -157.60482205 </i>
+    <i name="e_wo_entrp">   -157.60482205 </i>
+    <i name="e_0_energy">   -157.60482205 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.33    1.79</time>
+   <time name="total">   26.04    8.05</time>
+   <energy>
+    <i name="e_fr_energy">   -157.62190488 </i>
+    <i name="e_wo_entrp">   -157.62190488 </i>
+    <i name="e_0_energy">   -157.62190488 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.48    1.81</time>
+   <time name="total">   26.32    8.12</time>
+   <energy>
+    <i name="e_fr_energy">   -157.60790752 </i>
+    <i name="e_wo_entrp">   -157.60790752 </i>
+    <i name="e_0_energy">   -157.60790752 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.03    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.62620993 </i>
+    <i name="e_wo_entrp">   -157.62620993 </i>
+    <i name="e_0_energy">   -157.62620993 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.31    1.79</time>
+   <time name="total">   26.30    8.09</time>
+   <energy>
+    <i name="e_fr_energy">   -157.59342200 </i>
+    <i name="e_wo_entrp">   -157.59342200 </i>
+    <i name="e_0_energy">   -157.59342200 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.42    1.80</time>
+   <time name="total">   26.17    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.61778270 </i>
+    <i name="e_wo_entrp">   -157.61778270 </i>
+    <i name="e_0_energy">   -157.61778270 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.28    1.79</time>
+   <time name="total">   26.24    8.10</time>
+   <energy>
+    <i name="e_fr_energy">   -157.61402616 </i>
+    <i name="e_wo_entrp">   -157.61402616 </i>
+    <i name="e_0_energy">   -157.61402616 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.35    1.79</time>
+   <time name="total">   26.09    8.10</time>
+   <energy>
+    <i name="e_fr_energy">   -157.60419346 </i>
+    <i name="e_wo_entrp">   -157.60419346 </i>
+    <i name="e_0_energy">   -157.60419346 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.29    1.79</time>
+   <time name="total">   26.26    8.09</time>
+   <energy>
+    <i name="e_fr_energy">   -157.61950777 </i>
+    <i name="e_wo_entrp">   -157.61950777 </i>
+    <i name="e_0_energy">   -157.61950777 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.33    1.79</time>
+   <time name="total">   26.04    8.05</time>
+   <energy>
+    <i name="e_fr_energy">   -157.59589186 </i>
+    <i name="e_wo_entrp">   -157.59589186 </i>
+    <i name="e_0_energy">   -157.59589186 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.48    1.81</time>
+   <time name="total">   26.32    8.11</time>
+   <energy>
+    <i name="e_fr_energy">   -157.64057512 </i>
+    <i name="e_wo_entrp">   -157.64057512 </i>
+    <i name="e_0_energy">   -157.64057512 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.50    1.81</time>
+   <time name="total">   26.40    8.11</time>
+   <energy>
+    <i name="e_fr_energy">   -157.59945479 </i>
+    <i name="e_wo_entrp">   -157.59945479 </i>
+    <i name="e_0_energy">   -157.59945479 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.47    1.81</time>
+   <time name="total">   26.47    8.14</time>
+   <energy>
+    <i name="e_fr_energy">   -157.65318335 </i>
+    <i name="e_wo_entrp">   -157.65318335 </i>
+    <i name="e_0_energy">   -157.65318335 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.00    8.04</time>
+   <energy>
+    <i name="e_fr_energy">   -157.59081297 </i>
+    <i name="e_wo_entrp">   -157.59081297 </i>
+    <i name="e_0_energy">   -157.59081297 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.46    1.81</time>
+   <time name="total">   26.30    8.10</time>
+   <energy>
+    <i name="e_fr_energy">   -157.63186876 </i>
+    <i name="e_wo_entrp">   -157.63186876 </i>
+    <i name="e_0_energy">   -157.63186876 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.41    1.80</time>
+   <time name="total">   26.18    8.08</time>
+   <energy>
+    <i name="e_fr_energy">   -157.57610004 </i>
+    <i name="e_wo_entrp">   -157.57610004 </i>
+    <i name="e_0_energy">   -157.57610004 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.24    8.08</time>
+   <energy>
+    <i name="e_fr_energy">   -157.63794085 </i>
+    <i name="e_wo_entrp">   -157.63794085 </i>
+    <i name="e_0_energy">   -157.63794085 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.40    1.80</time>
+   <time name="total">   26.12    8.05</time>
+   <energy>
+    <i name="e_fr_energy">   -157.57584537 </i>
+    <i name="e_wo_entrp">   -157.57584537 </i>
+    <i name="e_0_energy">   -157.57584537 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.31    1.79</time>
+   <time name="total">   26.06    8.05</time>
+   <energy>
+    <i name="e_fr_energy">   -157.64220915 </i>
+    <i name="e_wo_entrp">   -157.64220915 </i>
+    <i name="e_0_energy">   -157.64220915 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.09    8.07</time>
+   <energy>
+    <i name="e_fr_energy">   -157.57787547 </i>
+    <i name="e_wo_entrp">   -157.57787547 </i>
+    <i name="e_0_energy">   -157.57787547 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.08    8.08</time>
+   <energy>
+    <i name="e_fr_energy">   -157.64775534 </i>
+    <i name="e_wo_entrp">   -157.64775534 </i>
+    <i name="e_0_energy">   -157.64775534 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.33    1.79</time>
+   <time name="total">   26.10    8.05</time>
+   <energy>
+    <i name="e_fr_energy">   -157.57201070 </i>
+    <i name="e_wo_entrp">   -157.57201070 </i>
+    <i name="e_0_energy">   -157.57201070 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.29    1.79</time>
+   <time name="total">   26.04    8.05</time>
+   <energy>
+    <i name="e_fr_energy">   -157.64274340 </i>
+    <i name="e_wo_entrp">   -157.64274340 </i>
+    <i name="e_0_energy">   -157.64274340 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.31    1.79</time>
+   <time name="total">   26.03    8.04</time>
+   <energy>
+    <i name="e_fr_energy">   -157.59277658 </i>
+    <i name="e_wo_entrp">   -157.59277658 </i>
+    <i name="e_0_energy">   -157.59277658 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.07    8.08</time>
+   <energy>
+    <i name="e_fr_energy">   -157.66238015 </i>
+    <i name="e_wo_entrp">   -157.66238015 </i>
+    <i name="e_0_energy">   -157.66238015 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.30    1.79</time>
+   <time name="total">   26.02    8.05</time>
+   <energy>
+    <i name="e_fr_energy">   -157.59132197 </i>
+    <i name="e_wo_entrp">   -157.59132197 </i>
+    <i name="e_0_energy">   -157.59132197 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.33    1.79</time>
+   <time name="total">   26.09    8.05</time>
+   <energy>
+    <i name="e_fr_energy">   -157.66464632 </i>
+    <i name="e_wo_entrp">   -157.66464632 </i>
+    <i name="e_0_energy">   -157.66464632 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.08    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.61014570 </i>
+    <i name="e_wo_entrp">   -157.61014570 </i>
+    <i name="e_0_energy">   -157.61014570 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.30    1.79</time>
+   <time name="total">   26.06    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.65712428 </i>
+    <i name="e_wo_entrp">   -157.65712428 </i>
+    <i name="e_0_energy">   -157.65712428 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.29    1.79</time>
+   <time name="total">   25.99    8.04</time>
+   <energy>
+    <i name="e_fr_energy">   -157.60179229 </i>
+    <i name="e_wo_entrp">   -157.60179229 </i>
+    <i name="e_0_energy">   -157.60179229 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.31    1.79</time>
+   <time name="total">   26.06    8.05</time>
+   <energy>
+    <i name="e_fr_energy">   -157.66343385 </i>
+    <i name="e_wo_entrp">   -157.66343385 </i>
+    <i name="e_0_energy">   -157.66343385 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.42    1.80</time>
+   <time name="total">   26.19    8.08</time>
+   <energy>
+    <i name="e_fr_energy">   -157.60450821 </i>
+    <i name="e_wo_entrp">   -157.60450821 </i>
+    <i name="e_0_energy">   -157.60450821 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.89   41.97</time>
+   <time name="total">   68.60   90.14</time>
+   <energy>
+    <i name="e_fr_energy">   -157.65664809 </i>
+    <i name="e_wo_entrp">   -157.65664809 </i>
+    <i name="e_0_energy">   -157.65664809 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.31    1.79</time>
+   <time name="total">   26.00    8.04</time>
+   <energy>
+    <i name="e_fr_energy">   -157.61840646 </i>
+    <i name="e_wo_entrp">   -157.61840646 </i>
+    <i name="e_0_energy">   -157.61840646 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.38    1.80</time>
+   <time name="total">   26.18    8.07</time>
+   <energy>
+    <i name="e_fr_energy">   -157.67289563 </i>
+    <i name="e_wo_entrp">   -157.67289563 </i>
+    <i name="e_0_energy">   -157.67289563 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.04    8.04</time>
+   <energy>
+    <i name="e_fr_energy">   -157.62539732 </i>
+    <i name="e_wo_entrp">   -157.62539732 </i>
+    <i name="e_0_energy">   -157.62539732 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.34    1.79</time>
+   <time name="total">   26.30    8.09</time>
+   <energy>
+    <i name="e_fr_energy">   -157.65813506 </i>
+    <i name="e_wo_entrp">   -157.65813506 </i>
+    <i name="e_0_energy">   -157.65813506 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.10    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.62337787 </i>
+    <i name="e_wo_entrp">   -157.62337787 </i>
+    <i name="e_0_energy">   -157.62337787 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.49    1.81</time>
+   <time name="total">   26.24    8.08</time>
+   <energy>
+    <i name="e_fr_energy">   -157.65837027 </i>
+    <i name="e_wo_entrp">   -157.65837027 </i>
+    <i name="e_0_energy">   -157.65837027 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.08    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.62584358 </i>
+    <i name="e_wo_entrp">   -157.62584358 </i>
+    <i name="e_0_energy">   -157.62584358 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.31    1.79</time>
+   <time name="total">   26.10    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.66058632 </i>
+    <i name="e_wo_entrp">   -157.66058632 </i>
+    <i name="e_0_energy">   -157.66058632 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.34    1.79</time>
+   <time name="total">   26.16    8.08</time>
+   <energy>
+    <i name="e_fr_energy">   -157.62213287 </i>
+    <i name="e_wo_entrp">   -157.62213287 </i>
+    <i name="e_0_energy">   -157.62213287 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.33    1.79</time>
+   <time name="total">   26.03    8.04</time>
+   <energy>
+    <i name="e_fr_energy">   -157.65991752 </i>
+    <i name="e_wo_entrp">   -157.65991752 </i>
+    <i name="e_0_energy">   -157.65991752 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.34    1.79</time>
+   <time name="total">   26.12    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.62428486 </i>
+    <i name="e_wo_entrp">   -157.62428486 </i>
+    <i name="e_0_energy">   -157.62428486 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.47    1.81</time>
+   <time name="total">   26.29    8.09</time>
+   <energy>
+    <i name="e_fr_energy">   -157.66306732 </i>
+    <i name="e_wo_entrp">   -157.66306732 </i>
+    <i name="e_0_energy">   -157.66306732 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.14    8.09</time>
+   <energy>
+    <i name="e_fr_energy">   -157.62064406 </i>
+    <i name="e_wo_entrp">   -157.62064406 </i>
+    <i name="e_0_energy">   -157.62064406 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.04    8.05</time>
+   <energy>
+    <i name="e_fr_energy">   -157.65934259 </i>
+    <i name="e_wo_entrp">   -157.65934259 </i>
+    <i name="e_0_energy">   -157.65934259 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.38    1.80</time>
+   <time name="total">   26.08    8.04</time>
+   <energy>
+    <i name="e_fr_energy">   -157.61913422 </i>
+    <i name="e_wo_entrp">   -157.61913422 </i>
+    <i name="e_0_energy">   -157.61913422 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.37    1.80</time>
+   <time name="total">   26.19    8.08</time>
+   <energy>
+    <i name="e_fr_energy">   -157.66008384 </i>
+    <i name="e_wo_entrp">   -157.66008384 </i>
+    <i name="e_0_energy">   -157.66008384 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.08    8.07</time>
+   <energy>
+    <i name="e_fr_energy">   -157.61776636 </i>
+    <i name="e_wo_entrp">   -157.61776636 </i>
+    <i name="e_0_energy">   -157.61776636 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.30    1.79</time>
+   <time name="total">   26.09    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.65917057 </i>
+    <i name="e_wo_entrp">   -157.65917057 </i>
+    <i name="e_0_energy">   -157.65917057 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.34    1.79</time>
+   <time name="total">   26.08    8.05</time>
+   <energy>
+    <i name="e_fr_energy">   -157.61183144 </i>
+    <i name="e_wo_entrp">   -157.61183144 </i>
+    <i name="e_0_energy">   -157.61183144 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.34    1.79</time>
+   <time name="total">   26.20    8.09</time>
+   <energy>
+    <i name="e_fr_energy">   -157.65303482 </i>
+    <i name="e_wo_entrp">   -157.65303482 </i>
+    <i name="e_0_energy">   -157.65303482 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.09    8.07</time>
+   <energy>
+    <i name="e_fr_energy">   -157.60567733 </i>
+    <i name="e_wo_entrp">   -157.60567733 </i>
+    <i name="e_0_energy">   -157.60567733 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.33    1.79</time>
+   <time name="total">   26.23    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.64415859 </i>
+    <i name="e_wo_entrp">   -157.64415859 </i>
+    <i name="e_0_energy">   -157.64415859 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.12    8.05</time>
+   <energy>
+    <i name="e_fr_energy">   -157.59917256 </i>
+    <i name="e_wo_entrp">   -157.59917256 </i>
+    <i name="e_0_energy">   -157.59917256 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.32    1.79</time>
+   <time name="total">   26.12    8.08</time>
+   <energy>
+    <i name="e_fr_energy">   -157.63949640 </i>
+    <i name="e_wo_entrp">   -157.63949640 </i>
+    <i name="e_0_energy">   -157.63949640 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.30    1.79</time>
+   <time name="total">   26.14    8.09</time>
+   <energy>
+    <i name="e_fr_energy">   -157.59466623 </i>
+    <i name="e_wo_entrp">   -157.59466623 </i>
+    <i name="e_0_energy">   -157.59466623 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.33    1.79</time>
+   <time name="total">   26.07    8.06</time>
+   <energy>
+    <i name="e_fr_energy">   -157.64275989 </i>
+    <i name="e_wo_entrp">   -157.64275989 </i>
+    <i name="e_0_energy">   -157.64275989 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.34    1.79</time>
+   <time name="total">   26.82    8.47</time>
+   <energy>
+    <i name="e_fr_energy">   -157.58602617 </i>
+    <i name="e_wo_entrp">   -157.58602617 </i>
+    <i name="e_0_energy">   -157.58602617 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.33    1.79</time>
+   <time name="total">   26.07    8.05</time>
+   <energy>
+    <i name="e_fr_energy">   -157.64366415 </i>
+    <i name="e_wo_entrp">   -157.64366415 </i>
+    <i name="e_0_energy">   -157.64366415 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">   14.39    1.80</time>
+   <time name="total">   22.07    7.37</time>
+   <energy>
+    <i name="alphaZ">      3.42601119 </i>
+    <i name="ewald">   -310.71786193 </i>
+    <i name="hartreedc">    -13.42142446 </i>
+    <i name="XCdc">   -238.10044545 </i>
+    <i name="pawpsdc">    400.14656089 </i>
+    <i name="pawaedc">   -292.76135216 </i>
+    <i name="eentropy">      0.00000000 </i>
+    <i name="bandstr">     -7.78205860 </i>
+    <i name="atom">    301.62628180 </i>
+    <i name="e_fr_energy">   -157.58428872 </i>
+    <i name="e_wo_entrp">   -157.58428872 </i>
+    <i name="e_0_energy">   -157.58428872 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       3.97062800      -0.01718700       2.52612800 </v>
+     <v>       1.37824500       3.72379200       2.52612800 </v>
+     <v>      -0.02480100      -0.01718700       4.70601700 </v>
+    </varray>
+    <i name="volume">     70.04059440 </i>
+    <varray name="rec_basis" >
+     <v>       0.25082090      -0.09349856       0.00098037 </v>
+     <v>       0.00053491       0.26768039       0.00098042 </v>
+     <v>      -0.13492449      -0.09349851       0.21144139 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.23465600       0.23465600       0.23465600 </v>
+    <v>       0.76534400       0.76534400       0.76534400 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>       0.10322128       0.07152917       0.18919006 </v>
+   <v>      -0.10322128      -0.07152917      -0.18919006 </v>
+  </varray>
+  <varray name="stress" >
+   <v>      13.90083967       2.23622649       5.91467344 </v>
+   <v>       2.23622649      12.22345955       4.09868511 </v>
+   <v>       5.91467344       4.09868511      21.51458242 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">   -157.58428872 </i>
+   <i name="e_wo_entrp">   -157.58428872 </i>
+   <i name="e_0_energy">      0.00000000 </i>
+  </energy>
+  <time name="totalsc"> 2787.71  976.78</time>
+  <eigenvalues>
+   <array>
+    <dimension dim="1">band</dimension>
+    <dimension dim="2">kpoint</dimension>
+    <dimension dim="3">spin</dimension>
+    <field>eigene</field>
+    <field>occ</field>
+    <set>
+     <set comment="spin 1">
+      <set comment="kpoint 1">
+       <r>   -8.5725    1.0000 </r>
+       <r>   -2.6756    1.0000 </r>
+       <r>    3.5500    1.0000 </r>
+       <r>    3.6723    1.0000 </r>
+       <r>    3.6745    1.0000 </r>
+       <r>    7.3160    0.0000 </r>
+       <r>    8.0570    0.0000 </r>
+       <r>    8.0573    0.0000 </r>
+       <r>   10.9331    0.0000 </r>
+       <r>   11.2489    0.0000 </r>
+       <r>   11.2496    0.0000 </r>
+       <r>   12.1082    0.0000 </r>
+       <r>   12.4249    0.0000 </r>
+       <r>   13.5924    0.0000 </r>
+       <r>   13.5930    0.0000 </r>
+       <r>   22.0069    0.0000 </r>
+      </set>
+      <set comment="kpoint 2">
+       <r>   -8.3777    1.0000 </r>
+       <r>   -3.1364    1.0000 </r>
+       <r>    3.1714    1.0000 </r>
+       <r>    3.8824    1.0000 </r>
+       <r>    4.0432    1.0000 </r>
+       <r>    6.7573    0.0000 </r>
+       <r>    7.2741    0.0000 </r>
+       <r>    8.0228    0.0000 </r>
+       <r>   10.5804    0.0000 </r>
+       <r>   11.3727    0.0000 </r>
+       <r>   11.4919    0.0000 </r>
+       <r>   13.0657    0.0000 </r>
+       <r>   13.6978    0.0000 </r>
+       <r>   14.5844    0.0000 </r>
+       <r>   14.7754    0.0000 </r>
+       <r>   19.7200    0.0000 </r>
+      </set>
+      <set comment="kpoint 3">
+       <r>   -7.8882    1.0000 </r>
+       <r>   -4.0814    1.0000 </r>
+       <r>    2.9260    1.0000 </r>
+       <r>    4.0294    1.0000 </r>
+       <r>    4.5147    1.0000 </r>
+       <r>    5.7667    0.0000 </r>
+       <r>    6.4337    0.0000 </r>
+       <r>    7.5100    0.0000 </r>
+       <r>   10.8262    0.0000 </r>
+       <r>   12.0875    0.0000 </r>
+       <r>   12.2424    0.0000 </r>
+       <r>   14.8387    0.0000 </r>
+       <r>   15.9418    0.0000 </r>
+       <r>   16.4852    0.0000 </r>
+       <r>   16.5840    0.0000 </r>
+       <r>   17.5588    0.0000 </r>
+      </set>
+      <set comment="kpoint 4">
+       <r>   -7.1441    1.0000 </r>
+       <r>   -5.1951    1.0000 </r>
+       <r>    2.9874    1.0000 </r>
+       <r>    3.9909    1.0000 </r>
+       <r>    4.8710    1.0000 </r>
+       <r>    4.9742    0.0000 </r>
+       <r>    6.0062    0.0000 </r>
+       <r>    6.7381    0.0000 </r>
+       <r>   12.1101    0.0000 </r>
+       <r>   13.3447    0.0000 </r>
+       <r>   13.3983    0.0000 </r>
+       <r>   14.6982    0.0000 </r>
+       <r>   16.2749    0.0000 </r>
+       <r>   17.3061    0.0000 </r>
+       <r>   18.0877    0.0000 </r>
+       <r>   18.8005    0.0000 </r>
+      </set>
+      <set comment="kpoint 5">
+       <r>   -6.6051    1.0000 </r>
+       <r>   -5.8412    1.0000 </r>
+       <r>    3.3519    1.0000 </r>
+       <r>    3.7311    1.0000 </r>
+       <r>    4.2292    1.0000 </r>
+       <r>    5.4561    0.0000 </r>
+       <r>    6.1184    0.0000 </r>
+       <r>    6.1864    0.0000 </r>
+       <r>   12.5439    0.0000 </r>
+       <r>   14.0396    0.0000 </r>
+       <r>   14.5718    0.0000 </r>
+       <r>   14.9387    0.0000 </r>
+       <r>   15.3724    0.0000 </r>
+       <r>   15.4532    0.0000 </r>
+       <r>   19.3908    0.0000 </r>
+       <r>   20.0505    0.0000 </r>
+      </set>
+      <set comment="kpoint 6">
+       <r>   -7.3718    1.0000 </r>
+       <r>   -4.8705    1.0000 </r>
+       <r>    3.4872    1.0000 </r>
+       <r>    3.7834    1.0000 </r>
+       <r>    3.8997    1.0000 </r>
+       <r>    5.6398    0.0000 </r>
+       <r>    6.2872    0.0000 </r>
+       <r>    6.7889    0.0000 </r>
+       <r>   11.1373    0.0000 </r>
+       <r>   12.8292    0.0000 </r>
+       <r>   13.6551    0.0000 </r>
+       <r>   15.7297    0.0000 </r>
+       <r>   16.6175    0.0000 </r>
+       <r>   17.2627    0.0000 </r>
+       <r>   17.7359    0.0000 </r>
+       <r>   17.8929    0.0000 </r>
+      </set>
+      <set comment="kpoint 7">
+       <r>   -8.0523    1.0000 </r>
+       <r>   -3.7586    1.0000 </r>
+       <r>    3.4043    1.0000 </r>
+       <r>    3.4974    1.0000 </r>
+       <r>    4.2259    1.0000 </r>
+       <r>    5.9780    0.0000 </r>
+       <r>    7.0174    0.0000 </r>
+       <r>    7.5765    0.0000 </r>
+       <r>   10.3806    0.0000 </r>
+       <r>   11.6263    0.0000 </r>
+       <r>   12.3560    0.0000 </r>
+       <r>   14.4510    0.0000 </r>
+       <r>   15.1167    0.0000 </r>
+       <r>   15.3468    0.0000 </r>
+       <r>   16.6675    0.0000 </r>
+       <r>   19.5443    0.0000 </r>
+      </set>
+      <set comment="kpoint 8">
+       <r>   -8.4620    1.0000 </r>
+       <r>   -2.9174    1.0000 </r>
+       <r>    3.3953    1.0000 </r>
+       <r>    3.4862    1.0000 </r>
+       <r>    4.0654    1.0000 </r>
+       <r>    6.8639    0.0000 </r>
+       <r>    7.6278    0.0000 </r>
+       <r>    8.1851    0.0000 </r>
+       <r>   10.4782    0.0000 </r>
+       <r>   11.2669    0.0000 </r>
+       <r>   11.5582    0.0000 </r>
+       <r>   12.5837    0.0000 </r>
+       <r>   13.2415    0.0000 </r>
+       <r>   13.7367    0.0000 </r>
+       <r>   14.7160    0.0000 </r>
+       <r>   21.8135    0.0000 </r>
+      </set>
+      <set comment="kpoint 9">
+       <r>   -8.2975    1.0000 </r>
+       <r>   -3.2680    1.0000 </r>
+       <r>    2.9902    1.0000 </r>
+       <r>    3.2325    1.0000 </r>
+       <r>    4.9084    1.0000 </r>
+       <r>    5.7711    0.0000 </r>
+       <r>    7.8847    0.0000 </r>
+       <r>    8.4055    0.0000 </r>
+       <r>   10.2340    0.0000 </r>
+       <r>   11.7921    0.0000 </r>
+       <r>   12.2004    0.0000 </r>
+       <r>   12.8343    0.0000 </r>
+       <r>   13.8016    0.0000 </r>
+       <r>   13.8844    0.0000 </r>
+       <r>   16.2092    0.0000 </r>
+       <r>   20.0209    0.0000 </r>
+      </set>
+      <set comment="kpoint 10">
+       <r>   -7.9258    1.0000 </r>
+       <r>   -3.8857    1.0000 </r>
+       <r>    2.4506    1.0000 </r>
+       <r>    3.1784    1.0000 </r>
+       <r>    4.3334    1.0000 </r>
+       <r>    6.1697    0.0000 </r>
+       <r>    7.6102    0.0000 </r>
+       <r>    8.4697    0.0000 </r>
+       <r>   10.0720    0.0000 </r>
+       <r>   12.5848    0.0000 </r>
+       <r>   12.8675    0.0000 </r>
+       <r>   13.7236    0.0000 </r>
+       <r>   14.8127    0.0000 </r>
+       <r>   15.7239    0.0000 </r>
+       <r>   17.2652    0.0000 </r>
+       <r>   18.2701    0.0000 </r>
+      </set>
+      <set comment="kpoint 11">
+       <r>   -7.2919    1.0000 </r>
+       <r>   -4.8134    1.0000 </r>
+       <r>    2.2282    1.0000 </r>
+       <r>    2.8339    1.0000 </r>
+       <r>    3.9978    1.0000 </r>
+       <r>    6.3656    0.0000 </r>
+       <r>    7.4003    0.0000 </r>
+       <r>    8.1013    0.0000 </r>
+       <r>   10.5682    0.0000 </r>
+       <r>   13.6739    0.0000 </r>
+       <r>   13.8955    0.0000 </r>
+       <r>   14.7043    0.0000 </r>
+       <r>   15.5192    0.0000 </r>
+       <r>   17.1838    0.0000 </r>
+       <r>   17.6155    0.0000 </r>
+       <r>   18.3978    0.0000 </r>
+      </set>
+      <set comment="kpoint 12">
+       <r>   -6.5352    1.0000 </r>
+       <r>   -5.7372    1.0000 </r>
+       <r>    2.2550    1.0000 </r>
+       <r>    2.5097    1.0000 </r>
+       <r>    4.2417    1.0000 </r>
+       <r>    5.7957    0.0000 </r>
+       <r>    7.3485    0.0000 </r>
+       <r>    7.9488    0.0000 </r>
+       <r>   12.0290    0.0000 </r>
+       <r>   12.5883    0.0000 </r>
+       <r>   14.7248    0.0000 </r>
+       <r>   15.1826    0.0000 </r>
+       <r>   15.7963    0.0000 </r>
+       <r>   17.5779    0.0000 </r>
+       <r>   18.7909    0.0000 </r>
+       <r>   18.9194    0.0000 </r>
+      </set>
+      <set comment="kpoint 13">
+       <r>   -6.9286    1.0000 </r>
+       <r>   -5.2903    1.0000 </r>
+       <r>    2.0905    1.0000 </r>
+       <r>    3.0762    1.0000 </r>
+       <r>    4.4105    1.0000 </r>
+       <r>    5.5646    0.0000 </r>
+       <r>    6.6662    0.0000 </r>
+       <r>    8.4662    0.0000 </r>
+       <r>   11.1557    0.0000 </r>
+       <r>   13.0892    0.0000 </r>
+       <r>   14.0096    0.0000 </r>
+       <r>   15.6320    0.0000 </r>
+       <r>   15.8411    0.0000 </r>
+       <r>   17.6956    0.0000 </r>
+       <r>   18.0820    0.0000 </r>
+       <r>   19.3695    0.0000 </r>
+      </set>
+      <set comment="kpoint 14">
+       <r>   -7.6611    1.0000 </r>
+       <r>   -4.3160    1.0000 </r>
+       <r>    2.3132    1.0000 </r>
+       <r>    3.9439    1.0000 </r>
+       <r>    4.0469    1.0000 </r>
+       <r>    5.9757    0.0000 </r>
+       <r>    6.2552    0.0000 </r>
+       <r>    8.6975    0.0000 </r>
+       <r>   10.3556    0.0000 </r>
+       <r>   12.0779    0.0000 </r>
+       <r>   13.8950    0.0000 </r>
+       <r>   14.0078    0.0000 </r>
+       <r>   15.9819    0.0000 </r>
+       <r>   16.8413    0.0000 </r>
+       <r>   17.6635    0.0000 </r>
+       <r>   18.8193    0.0000 </r>
+      </set>
+      <set comment="kpoint 15">
+       <r>   -8.1610    1.0000 </r>
+       <r>   -3.5246    1.0000 </r>
+       <r>    2.9620    1.0000 </r>
+       <r>    3.5194    1.0000 </r>
+       <r>    4.5866    1.0000 </r>
+       <r>    5.8758    0.0000 </r>
+       <r>    7.1687    0.0000 </r>
+       <r>    8.2463    0.0000 </r>
+       <r>   10.1961    0.0000 </r>
+       <r>   11.6096    0.0000 </r>
+       <r>   12.3953    0.0000 </r>
+       <r>   13.3011    0.0000 </r>
+       <r>   14.5882    0.0000 </r>
+       <r>   15.1216    0.0000 </r>
+       <r>   16.4253    0.0000 </r>
+       <r>   19.5616    0.0000 </r>
+      </set>
+      <set comment="kpoint 16">
+       <r>   -7.6932    1.0000 </r>
+       <r>   -4.0347    1.0000 </r>
+       <r>    1.9654    1.0000 </r>
+       <r>    2.5819    1.0000 </r>
+       <r>    3.1436    1.0000 </r>
+       <r>    7.6593    0.0000 </r>
+       <r>    8.1692    0.0000 </r>
+       <r>    9.0890    0.0000 </r>
+       <r>   10.0318    0.0000 </r>
+       <r>   13.4180    0.0000 </r>
+       <r>   13.6900    0.0000 </r>
+       <r>   13.8216    0.0000 </r>
+       <r>   14.5603    0.0000 </r>
+       <r>   16.1008    0.0000 </r>
+       <r>   17.7109    0.0000 </r>
+       <r>   17.7929    0.0000 </r>
+      </set>
+      <set comment="kpoint 17">
+       <r>   -7.2203    1.0000 </r>
+       <r>   -4.5620    1.0000 </r>
+       <r>    1.3753    1.0000 </r>
+       <r>    2.0880    1.0000 </r>
+       <r>    2.9191    1.0000 </r>
+       <r>    7.9298    0.0000 </r>
+       <r>    8.8162    0.0000 </r>
+       <r>    9.2139    0.0000 </r>
+       <r>   10.1047    0.0000 </r>
+       <r>   14.1573    0.0000 </r>
+       <r>   14.5845    0.0000 </r>
+       <r>   15.1348    0.0000 </r>
+       <r>   15.2987    0.0000 </r>
+       <r>   16.1256    0.0000 </r>
+       <r>   17.6867    0.0000 </r>
+       <r>   17.9872    0.0000 </r>
+      </set>
+      <set comment="kpoint 18">
+       <r>   -6.5783    1.0000 </r>
+       <r>   -5.3417    1.0000 </r>
+       <r>    0.9922    1.0000 </r>
+       <r>    1.9131    1.0000 </r>
+       <r>    3.2643    1.0000 </r>
+       <r>    7.3210    0.0000 </r>
+       <r>    8.7241    0.0000 </r>
+       <r>    9.8961    0.0000 </r>
+       <r>   10.3564    0.0000 </r>
+       <r>   13.1155    0.0000 </r>
+       <r>   14.8700    0.0000 </r>
+       <r>   15.8773    0.0000 </r>
+       <r>   16.5039    0.0000 </r>
+       <r>   17.3467    0.0000 </r>
+       <r>   18.0098    0.0000 </r>
+       <r>   18.2871    0.0000 </r>
+      </set>
+      <set comment="kpoint 19">
+       <r>   -6.3027    1.0000 </r>
+       <r>   -5.7423    1.0000 </r>
+       <r>    1.0075    1.0000 </r>
+       <r>    2.3180    1.0000 </r>
+       <r>    3.7861    1.0000 </r>
+       <r>    6.3763    0.0000 </r>
+       <r>    7.9596    0.0000 </r>
+       <r>   10.1392    0.0000 </r>
+       <r>   11.6929    0.0000 </r>
+       <r>   11.8858    0.0000 </r>
+       <r>   13.5882    0.0000 </r>
+       <r>   15.3216    0.0000 </r>
+       <r>   18.0003    0.0000 </r>
+       <r>   18.2416    0.0000 </r>
+       <r>   18.7983    0.0000 </r>
+       <r>   18.9762    0.0000 </r>
+      </set>
+      <set comment="kpoint 20">
+       <r>   -7.0173    1.0000 </r>
+       <r>   -5.0912    1.0000 </r>
+       <r>    1.5880    1.0000 </r>
+       <r>    3.1637    1.0000 </r>
+       <r>    4.1749    1.0000 </r>
+       <r>    5.7335    0.0000 </r>
+       <r>    6.9251    0.0000 </r>
+       <r>    9.4197    0.0000 </r>
+       <r>   10.9126    0.0000 </r>
+       <r>   12.7379    0.0000 </r>
+       <r>   13.8172    0.0000 </r>
+       <r>   14.6639    0.0000 </r>
+       <r>   16.0893    0.0000 </r>
+       <r>   17.9496    0.0000 </r>
+       <r>   18.9140    0.0000 </r>
+       <r>   19.6174    0.0000 </r>
+      </set>
+      <set comment="kpoint 21">
+       <r>   -7.5772    1.0000 </r>
+       <r>   -4.5098    1.0000 </r>
+       <r>    2.7201    1.0000 </r>
+       <r>    3.6482    1.0000 </r>
+       <r>    4.3054    1.0000 </r>
+       <r>    5.7963    0.0000 </r>
+       <r>    6.3301    0.0000 </r>
+       <r>    7.8899    0.0000 </r>
+       <r>   10.7289    0.0000 </r>
+       <r>   12.1778    0.0000 </r>
+       <r>   13.7605    0.0000 </r>
+       <r>   14.9563    0.0000 </r>
+       <r>   16.1059    0.0000 </r>
+       <r>   17.1928    0.0000 </r>
+       <r>   17.4326    0.0000 </r>
+       <r>   17.8979    0.0000 </r>
+      </set>
+      <set comment="kpoint 22">
+       <r>   -6.9707    1.0000 </r>
+       <r>   -4.6000    1.0000 </r>
+       <r>    0.5924    1.0000 </r>
+       <r>    2.1144    1.0000 </r>
+       <r>    2.1166    1.0000 </r>
+       <r>    7.8449    0.0000 </r>
+       <r>    9.7693    0.0000 </r>
+       <r>   10.2838    0.0000 </r>
+       <r>   10.9131    0.0000 </r>
+       <r>   14.4007    0.0000 </r>
+       <r>   14.9337    0.0000 </r>
+       <r>   15.8762    0.0000 </r>
+       <r>   16.1823    0.0000 </r>
+       <r>   16.2978    0.0000 </r>
+       <r>   16.6206    0.0000 </r>
+       <r>   18.3823    0.0000 </r>
+      </set>
+      <set comment="kpoint 23">
+       <r>   -6.6240    1.0000 </r>
+       <r>   -4.9712    1.0000 </r>
+       <r>    0.2970    1.0000 </r>
+       <r>    1.7357    1.0000 </r>
+       <r>    2.4692    1.0000 </r>
+       <r>    8.0566    0.0000 </r>
+       <r>    9.2099    0.0000 </r>
+       <r>   10.4130    0.0000 </r>
+       <r>   11.5614    0.0000 </r>
+       <r>   14.0731    0.0000 </r>
+       <r>   15.2303    0.0000 </r>
+       <r>   16.0310    0.0000 </r>
+       <r>   16.5942    0.0000 </r>
+       <r>   17.0680    0.0000 </r>
+       <r>   17.2337    0.0000 </r>
+       <r>   17.8302    0.0000 </r>
+      </set>
+      <set comment="kpoint 24">
+       <r>   -6.2786    1.0000 </r>
+       <r>   -5.5525    1.0000 </r>
+       <r>    0.5487    1.0000 </r>
+       <r>    1.9094    1.0000 </r>
+       <r>    3.0179    1.0000 </r>
+       <r>    7.4757    0.0000 </r>
+       <r>    8.9491    0.0000 </r>
+       <r>   10.2356    0.0000 </r>
+       <r>   10.9729    0.0000 </r>
+       <r>   12.8661    0.0000 </r>
+       <r>   14.5464    0.0000 </r>
+       <r>   16.1276    0.0000 </r>
+       <r>   16.9941    0.0000 </r>
+       <r>   17.0388    0.0000 </r>
+       <r>   18.6229    0.0000 </r>
+       <r>   18.9618    0.0000 </r>
+      </set>
+      <set comment="kpoint 25">
+       <r>   -6.2588    1.0000 </r>
+       <r>   -5.8837    1.0000 </r>
+       <r>    1.3768    1.0000 </r>
+       <r>    2.6178    1.0000 </r>
+       <r>    3.6768    1.0000 </r>
+       <r>    6.1648    0.0000 </r>
+       <r>    7.7951    0.0000 </r>
+       <r>    9.2943    0.0000 </r>
+       <r>   11.8478    0.0000 </r>
+       <r>   12.2588    0.0000 </r>
+       <r>   13.7047    0.0000 </r>
+       <r>   15.5780    0.0000 </r>
+       <r>   16.7393    0.0000 </r>
+       <r>   17.7556    0.0000 </r>
+       <r>   18.6215    0.0000 </r>
+       <r>   19.1164    0.0000 </r>
+      </set>
+      <set comment="kpoint 26">
+       <r>   -6.7782    1.0000 </r>
+       <r>   -5.5739    1.0000 </r>
+       <r>    2.6895    1.0000 </r>
+       <r>    3.7514    1.0000 </r>
+       <r>    3.8279    1.0000 </r>
+       <r>    5.7136    0.0000 </r>
+       <r>    6.2123    0.0000 </r>
+       <r>    7.3686    0.0000 </r>
+       <r>   12.1429    0.0000 </r>
+       <r>   13.3021    0.0000 </r>
+       <r>   14.1232    0.0000 </r>
+       <r>   15.1390    0.0000 </r>
+       <r>   15.4518    0.0000 </r>
+       <r>   17.0566    0.0000 </r>
+       <r>   18.3299    0.0000 </r>
+       <r>   19.5614    0.0000 </r>
+      </set>
+      <set comment="kpoint 27">
+       <r>   -6.7011    1.0000 </r>
+       <r>   -4.7991    1.0000 </r>
+       <r>    0.2369    1.0000 </r>
+       <r>    1.9213    1.0000 </r>
+       <r>    2.0089    1.0000 </r>
+       <r>    7.7624    0.0000 </r>
+       <r>    9.9191    0.0000 </r>
+       <r>   10.5277    0.0000 </r>
+       <r>   11.7458    0.0000 </r>
+       <r>   14.7751    0.0000 </r>
+       <r>   15.4246    0.0000 </r>
+       <r>   15.6935    0.0000 </r>
+       <r>   16.1144    0.0000 </r>
+       <r>   16.8697    0.0000 </r>
+       <r>   17.2546    0.0000 </r>
+       <r>   17.7651    0.0000 </r>
+      </set>
+      <set comment="kpoint 28">
+       <r>   -6.8042    1.0000 </r>
+       <r>   -4.8825    1.0000 </r>
+       <r>    0.7322    1.0000 </r>
+       <r>    1.9048    1.0000 </r>
+       <r>    2.4882    1.0000 </r>
+       <r>    7.9960    0.0000 </r>
+       <r>    9.0041    0.0000 </r>
+       <r>   10.2413    0.0000 </r>
+       <r>   10.5623    0.0000 </r>
+       <r>   14.2977    0.0000 </r>
+       <r>   15.0473    0.0000 </r>
+       <r>   15.7820    0.0000 </r>
+       <r>   16.1443    0.0000 </r>
+       <r>   16.3496    0.0000 </r>
+       <r>   17.3554    0.0000 </r>
+       <r>   18.5335    0.0000 </r>
+      </set>
+      <set comment="kpoint 29">
+       <r>   -6.8531    1.0000 </r>
+       <r>   -5.1877    1.0000 </r>
+       <r>    1.6153    1.0000 </r>
+       <r>    2.4893    1.0000 </r>
+       <r>    3.1864    1.0000 </r>
+       <r>    6.9226    0.0000 </r>
+       <r>    8.2774    0.0000 </r>
+       <r>    8.8057    0.0000 </r>
+       <r>   10.3804    0.0000 </r>
+       <r>   14.0450    0.0000 </r>
+       <r>   14.3211    0.0000 </r>
+       <r>   15.1526    0.0000 </r>
+       <r>   15.9887    0.0000 </r>
+       <r>   16.3759    0.0000 </r>
+       <r>   18.2494    0.0000 </r>
+       <r>   19.3601    0.0000 </r>
+      </set>
+      <set comment="kpoint 30">
+       <r>   -7.2547    1.0000 </r>
+       <r>   -4.4311    1.0000 </r>
+       <r>    1.4142    1.0000 </r>
+       <r>    2.2857    1.0000 </r>
+       <r>    2.2863    1.0000 </r>
+       <r>    7.8551    0.0000 </r>
+       <r>    9.2474    0.0000 </r>
+       <r>    9.4024    0.0000 </r>
+       <r>   10.0828    0.0000 </r>
+       <r>   13.8637    0.0000 </r>
+       <r>   14.4441    0.0000 </r>
+       <r>   14.8901    0.0000 </r>
+       <r>   15.6151    0.0000 </r>
+       <r>   17.6621    0.0000 </r>
+       <r>   17.6864    0.0000 </r>
+       <r>   17.7868    0.0000 </r>
+      </set>
+      <set comment="kpoint 31">
+       <r>   -7.5316    1.0000 </r>
+       <r>   -4.3171    1.0000 </r>
+       <r>    2.1047    1.0000 </r>
+       <r>    2.8016    1.0000 </r>
+       <r>    3.0242    1.0000 </r>
+       <r>    7.5766    0.0000 </r>
+       <r>    7.6689    0.0000 </r>
+       <r>    8.6838    0.0000 </r>
+       <r>    9.9409    0.0000 </r>
+       <r>   13.3534    0.0000 </r>
+       <r>   13.8821    0.0000 </r>
+       <r>   14.2476    0.0000 </r>
+       <r>   15.3775    0.0000 </r>
+       <r>   17.0574    0.0000 </r>
+       <r>   17.5106    0.0000 </r>
+       <r>   17.6993    0.0000 </r>
+      </set>
+      <set comment="kpoint 32">
+       <r>   -7.9824    1.0000 </r>
+       <r>   -3.7115    1.0000 </r>
+       <r>    2.6522    1.0000 </r>
+       <r>    2.8670    1.0000 </r>
+       <r>    3.9502    1.0000 </r>
+       <r>    6.4552    0.0000 </r>
+       <r>    7.8702    0.0000 </r>
+       <r>    8.6983    0.0000 </r>
+       <r>    9.8834    0.0000 </r>
+       <r>   12.4760    0.0000 </r>
+       <r>   12.9378    0.0000 </r>
+       <r>   13.3509    0.0000 </r>
+       <r>   14.2754    0.0000 </r>
+       <r>   15.3042    0.0000 </r>
+       <r>   18.1662    0.0000 </r>
+       <r>   19.6141    0.0000 </r>
+      </set>
+      <set comment="kpoint 33">
+       <r>   -8.3232    1.0000 </r>
+       <r>   -3.3354    1.0000 </r>
+       <r>    3.7235    1.0000 </r>
+       <r>    3.7859    1.0000 </r>
+       <r>    3.7882    1.0000 </r>
+       <r>    6.8933    0.0000 </r>
+       <r>    7.3493    0.0000 </r>
+       <r>    7.3496    0.0000 </r>
+       <r>   10.5113    0.0000 </r>
+       <r>   11.7171    0.0000 </r>
+       <r>   11.7178    0.0000 </r>
+       <r>   13.4652    0.0000 </r>
+       <r>   14.2610    0.0000 </r>
+       <r>   14.7378    0.0000 </r>
+       <r>   14.7383    0.0000 </r>
+       <r>   19.8473    0.0000 </r>
+      </set>
+      <set comment="kpoint 34">
+       <r>   -8.0562    1.0000 </r>
+       <r>   -3.8077    1.0000 </r>
+       <r>    2.5614    1.0000 </r>
+       <r>    4.2913    1.0000 </r>
+       <r>    4.6688    1.0000 </r>
+       <r>    5.8572    0.0000 </r>
+       <r>    6.3058    0.0000 </r>
+       <r>    8.5322    0.0000 </r>
+       <r>   10.6529    0.0000 </r>
+       <r>   11.6769    0.0000 </r>
+       <r>   12.7236    0.0000 </r>
+       <r>   13.5897    0.0000 </r>
+       <r>   15.0041    0.0000 </r>
+       <r>   16.0265    0.0000 </r>
+       <r>   16.3871    0.0000 </r>
+       <r>   17.5880    0.0000 </r>
+      </set>
+      <set comment="kpoint 35">
+       <r>   -7.5163    1.0000 </r>
+       <r>   -4.5649    1.0000 </r>
+       <r>    1.7938    1.0000 </r>
+       <r>    4.1339    1.0000 </r>
+       <r>    4.6460    1.0000 </r>
+       <r>    5.6274    0.0000 </r>
+       <r>    6.1106    0.0000 </r>
+       <r>    9.0804    0.0000 </r>
+       <r>   11.0378    0.0000 </r>
+       <r>   12.2211    0.0000 </r>
+       <r>   13.7801    0.0000 </r>
+       <r>   14.3805    0.0000 </r>
+       <r>   14.8419    0.0000 </r>
+       <r>   17.3722    0.0000 </r>
+       <r>   18.3431    0.0000 </r>
+       <r>   18.7919    0.0000 </r>
+      </set>
+      <set comment="kpoint 36">
+       <r>   -6.7849    1.0000 </r>
+       <r>   -5.4373    1.0000 </r>
+       <r>    1.5997    1.0000 </r>
+       <r>    3.4889    1.0000 </r>
+       <r>    3.7986    1.0000 </r>
+       <r>    6.2764    0.0000 </r>
+       <r>    6.6650    0.0000 </r>
+       <r>    8.7289    0.0000 </r>
+       <r>   12.1859    0.0000 </r>
+       <r>   12.3091    0.0000 </r>
+       <r>   13.3574    0.0000 </r>
+       <r>   15.8718    0.0000 </r>
+       <r>   16.0392    0.0000 </r>
+       <r>   17.7894    0.0000 </r>
+       <r>   18.3245    0.0000 </r>
+       <r>   19.8463    0.0000 </r>
+      </set>
+      <set comment="kpoint 37">
+       <r>   -6.6838    1.0000 </r>
+       <r>   -5.5078    1.0000 </r>
+       <r>    1.9447    1.0000 </r>
+       <r>    2.9858    1.0000 </r>
+       <r>    3.1759    1.0000 </r>
+       <r>    6.8856    0.0000 </r>
+       <r>    7.3968    0.0000 </r>
+       <r>    8.0640    0.0000 </r>
+       <r>   10.7305    0.0000 </r>
+       <r>   14.0508    0.0000 </r>
+       <r>   14.9020    0.0000 </r>
+       <r>   15.0726    0.0000 </r>
+       <r>   15.9297    0.0000 </r>
+       <r>   17.7291    0.0000 </r>
+       <r>   18.1232    0.0000 </r>
+       <r>   18.9482    0.0000 </r>
+      </set>
+      <set comment="kpoint 38">
+       <r>   -7.4064    1.0000 </r>
+       <r>   -4.5665    1.0000 </r>
+       <r>    2.6294    1.0000 </r>
+       <r>    2.7735    1.0000 </r>
+       <r>    2.9073    1.0000 </r>
+       <r>    7.2813    0.0000 </r>
+       <r>    7.5224    0.0000 </r>
+       <r>    8.1633    0.0000 </r>
+       <r>    9.8897    0.0000 </r>
+       <r>   13.4772    0.0000 </r>
+       <r>   14.1697    0.0000 </r>
+       <r>   14.9556    0.0000 </r>
+       <r>   15.6722    0.0000 </r>
+       <r>   17.5226    0.0000 </r>
+       <r>   17.5315    0.0000 </r>
+       <r>   17.7760    0.0000 </r>
+      </set>
+      <set comment="kpoint 39">
+       <r>   -7.9092    1.0000 </r>
+       <r>   -4.0356    1.0000 </r>
+       <r>    2.7843    1.0000 </r>
+       <r>    3.1988    1.0000 </r>
+       <r>    4.6020    1.0000 </r>
+       <r>    5.8856    0.0000 </r>
+       <r>    7.7292    0.0000 </r>
+       <r>    7.8644    0.0000 </r>
+       <r>   10.2182    0.0000 </r>
+       <r>   12.5976    0.0000 </r>
+       <r>   13.2067    0.0000 </r>
+       <r>   14.4164    0.0000 </r>
+       <r>   14.9889    0.0000 </r>
+       <r>   15.6298    0.0000 </r>
+       <r>   17.3270    0.0000 </r>
+       <r>   17.6329    0.0000 </r>
+      </set>
+      <set comment="kpoint 40">
+       <r>   -7.4992    1.0000 </r>
+       <r>   -4.4991    1.0000 </r>
+       <r>    1.7779    1.0000 </r>
+       <r>    2.9154    1.0000 </r>
+       <r>    4.2452    1.0000 </r>
+       <r>    6.3050    0.0000 </r>
+       <r>    7.6046    0.0000 </r>
+       <r>    9.0648    0.0000 </r>
+       <r>   10.4599    0.0000 </r>
+       <r>   13.1775    0.0000 </r>
+       <r>   13.8201    0.0000 </r>
+       <r>   14.6087    0.0000 </r>
+       <r>   15.0164    0.0000 </r>
+       <r>   16.9100    0.0000 </r>
+       <r>   17.3215    0.0000 </r>
+       <r>   18.1592    0.0000 </r>
+      </set>
+      <set comment="kpoint 41">
+       <r>   -6.8827    1.0000 </r>
+       <r>   -5.1442    1.0000 </r>
+       <r>    1.1893    1.0000 </r>
+       <r>    2.1273    1.0000 </r>
+       <r>    4.7570    1.0000 </r>
+       <r>    5.6081    0.0000 </r>
+       <r>    8.4775    0.0000 </r>
+       <r>    9.7044    0.0000 </r>
+       <r>   10.9938    0.0000 </r>
+       <r>   12.4789    0.0000 </r>
+       <r>   13.9902    0.0000 </r>
+       <r>   15.0212    0.0000 </r>
+       <r>   16.4988    0.0000 </r>
+       <r>   17.9562    0.0000 </r>
+       <r>   18.8570    0.0000 </r>
+       <r>   19.1369    0.0000 </r>
+      </set>
+      <set comment="kpoint 42">
+       <r>   -6.4048    1.0000 </r>
+       <r>   -5.6138    1.0000 </r>
+       <r>    1.2195    1.0000 </r>
+       <r>    1.6672    1.0000 </r>
+       <r>    4.2982    1.0000 </r>
+       <r>    5.9619    0.0000 </r>
+       <r>    9.0587    0.0000 </r>
+       <r>    9.4566    0.0000 </r>
+       <r>   11.0009    0.0000 </r>
+       <r>   12.2182    0.0000 </r>
+       <r>   15.1984    0.0000 </r>
+       <r>   15.3758    0.0000 </r>
+       <r>   17.2468    0.0000 </r>
+       <r>   17.4349    0.0000 </r>
+       <r>   18.6970    0.0000 </r>
+       <r>   18.9476    0.0000 </r>
+      </set>
+      <set comment="kpoint 43">
+       <r>   -6.9291    1.0000 </r>
+       <r>   -5.0170    1.0000 </r>
+       <r>    1.5904    1.0000 </r>
+       <r>    1.8923    1.0000 </r>
+       <r>    3.5286    1.0000 </r>
+       <r>    6.7836    0.0000 </r>
+       <r>    8.6592    0.0000 </r>
+       <r>    9.0191    0.0000 </r>
+       <r>   10.4095    0.0000 </r>
+       <r>   13.9162    0.0000 </r>
+       <r>   14.0991    0.0000 </r>
+       <r>   15.0117    0.0000 </r>
+       <r>   16.1824    0.0000 </r>
+       <r>   17.7980    0.0000 </r>
+       <r>   18.3970    0.0000 </r>
+       <r>   18.5253    0.0000 </r>
+      </set>
+      <set comment="kpoint 44">
+       <r>   -7.2528    1.0000 </r>
+       <r>   -4.6394    1.0000 </r>
+       <r>    1.3651    1.0000 </r>
+       <r>    2.5975    1.0000 </r>
+       <r>    2.9429    1.0000 </r>
+       <r>    7.7970    0.0000 </r>
+       <r>    8.6094    0.0000 </r>
+       <r>    9.1213    0.0000 </r>
+       <r>   10.0068    0.0000 </r>
+       <r>   14.3085    0.0000 </r>
+       <r>   14.9712    0.0000 </r>
+       <r>   15.0932    0.0000 </r>
+       <r>   15.5471    0.0000 </r>
+       <r>   16.0877    0.0000 </r>
+       <r>   16.3119    0.0000 </r>
+       <r>   17.9227    0.0000 </r>
+      </set>
+      <set comment="kpoint 45">
+       <r>   -6.8260    1.0000 </r>
+       <r>   -4.9838    1.0000 </r>
+       <r>    0.7745    1.0000 </r>
+       <r>    1.6488    1.0000 </r>
+       <r>    3.5529    1.0000 </r>
+       <r>    7.1800    0.0000 </r>
+       <r>    9.1602    0.0000 </r>
+       <r>   10.1587    0.0000 </r>
+       <r>   10.7711    0.0000 </r>
+       <r>   13.1546    0.0000 </r>
+       <r>   14.8583    0.0000 </r>
+       <r>   15.7666    0.0000 </r>
+       <r>   16.4883    0.0000 </r>
+       <r>   16.8413    0.0000 </r>
+       <r>   17.7940    0.0000 </r>
+       <r>   18.1584    0.0000 </r>
+      </set>
+      <set comment="kpoint 46">
+       <r>   -6.3246    1.0000 </r>
+       <r>   -5.4911    1.0000 </r>
+       <r>    0.7251    1.0000 </r>
+       <r>    1.0569    1.0000 </r>
+       <r>    4.3772    1.0000 </r>
+       <r>    6.1180    0.0000 </r>
+       <r>    9.9212    0.0000 </r>
+       <r>   10.4995    0.0000 </r>
+       <r>   11.0946    0.0000 </r>
+       <r>   11.9405    0.0000 </r>
+       <r>   15.5578    0.0000 </r>
+       <r>   15.9114    0.0000 </r>
+       <r>   16.6654    0.0000 </r>
+       <r>   16.8195    0.0000 </r>
+       <r>   18.1698    0.0000 </r>
+       <r>   18.4514    0.0000 </r>
+      </set>
+      <set comment="kpoint 47">
+       <r>   -6.3025    1.0000 </r>
+       <r>   -5.6138    1.0000 </r>
+       <r>    0.9841    1.0000 </r>
+       <r>    1.3852    1.0000 </r>
+       <r>    4.2359    1.0000 </r>
+       <r>    5.9732    0.0000 </r>
+       <r>    9.7396    0.0000 </r>
+       <r>    9.8472    0.0000 </r>
+       <r>   11.0321    0.0000 </r>
+       <r>   12.1222    0.0000 </r>
+       <r>   14.9336    0.0000 </r>
+       <r>   15.4688    0.0000 </r>
+       <r>   16.4642    0.0000 </r>
+       <r>   17.2523    0.0000 </r>
+       <r>   18.8284    0.0000 </r>
+       <r>   19.3227    0.0000 </r>
+      </set>
+      <set comment="kpoint 48">
+       <r>   -6.6632    1.0000 </r>
+       <r>   -5.0293    1.0000 </r>
+       <r>    0.3146    1.0000 </r>
+       <r>    2.2798    1.0000 </r>
+       <r>    2.3658    1.0000 </r>
+       <r>    8.0626    0.0000 </r>
+       <r>    9.0923    0.0000 </r>
+       <r>   10.0078    0.0000 </r>
+       <r>   11.4148    0.0000 </r>
+       <r>   13.9666    0.0000 </r>
+       <r>   14.6669    0.0000 </r>
+       <r>   16.2326    0.0000 </r>
+       <r>   16.5818    0.0000 </r>
+       <r>   16.7181    0.0000 </r>
+       <r>   17.7905    0.0000 </r>
+       <r>   18.0261    0.0000 </r>
+      </set>
+      <set comment="kpoint 49">
+       <r>   -6.4693    1.0000 </r>
+       <r>   -5.2645    1.0000 </r>
+       <r>    0.4597    1.0000 </r>
+       <r>    1.4500    1.0000 </r>
+       <r>    3.3352    1.0000 </r>
+       <r>    7.3083    0.0000 </r>
+       <r>    9.1028    0.0000 </r>
+       <r>   10.7435    0.0000 </r>
+       <r>   11.1393    0.0000 </r>
+       <r>   12.9188    0.0000 </r>
+       <r>   15.4427    0.0000 </r>
+       <r>   15.9553    0.0000 </r>
+       <r>   16.4709    0.0000 </r>
+       <r>   17.1390    0.0000 </r>
+       <r>   18.0240    0.0000 </r>
+       <r>   18.5546    0.0000 </r>
+      </set>
+      <set comment="kpoint 50">
+       <r>   -6.7119    1.0000 </r>
+       <r>   -5.0896    1.0000 </r>
+       <r>    0.8315    1.0000 </r>
+       <r>    2.3469    1.0000 </r>
+       <r>    2.3752    1.0000 </r>
+       <r>    7.8876    0.0000 </r>
+       <r>    8.8362    0.0000 </r>
+       <r>    9.8807    0.0000 </r>
+       <r>   10.2016    0.0000 </r>
+       <r>   14.2569    0.0000 </r>
+       <r>   15.0795    0.0000 </r>
+       <r>   15.6685    0.0000 </r>
+       <r>   16.4039    0.0000 </r>
+       <r>   17.2579    0.0000 </r>
+       <r>   17.3610    0.0000 </r>
+       <r>   18.9920    0.0000 </r>
+      </set>
+      <set comment="kpoint 51">
+       <r>   -7.8658    1.0000 </r>
+       <r>   -4.2905    1.0000 </r>
+       <r>    3.8565    1.0000 </r>
+       <r>    4.0148    1.0000 </r>
+       <r>    4.0163    1.0000 </r>
+       <r>    6.3874    0.0000 </r>
+       <r>    6.4754    0.0000 </r>
+       <r>    6.4758    0.0000 </r>
+       <r>   11.0312    0.0000 </r>
+       <r>   12.6414    0.0000 </r>
+       <r>   12.6420    0.0000 </r>
+       <r>   15.4998    0.0000 </r>
+       <r>   16.3269    0.0000 </r>
+       <r>   16.3838    0.0000 </r>
+       <r>   16.3848    0.0000 </r>
+       <r>   17.7758    0.0000 </r>
+      </set>
+      <set comment="kpoint 52">
+       <r>   -7.5646    1.0000 </r>
+       <r>   -4.6467    1.0000 </r>
+       <r>    2.3074    1.0000 </r>
+       <r>    4.3167    1.0000 </r>
+       <r>    4.7226    1.0000 </r>
+       <r>    5.5720    0.0000 </r>
+       <r>    5.9289    0.0000 </r>
+       <r>    8.3607    0.0000 </r>
+       <r>   11.1859    0.0000 </r>
+       <r>   12.4783    0.0000 </r>
+       <r>   14.1435    0.0000 </r>
+       <r>   14.9356    0.0000 </r>
+       <r>   15.1152    0.0000 </r>
+       <r>   17.1561    0.0000 </r>
+       <r>   17.9243    0.0000 </r>
+       <r>   18.1128    0.0000 </r>
+      </set>
+      <set comment="kpoint 53">
+       <r>   -7.0511    1.0000 </r>
+       <r>   -5.0641    1.0000 </r>
+       <r>    1.1490    1.0000 </r>
+       <r>    3.5058    1.0000 </r>
+       <r>    3.7977    1.0000 </r>
+       <r>    6.6089    0.0000 </r>
+       <r>    6.8288    0.0000 </r>
+       <r>    9.9257    0.0000 </r>
+       <r>   11.6760    0.0000 </r>
+       <r>   12.5100    0.0000 </r>
+       <r>   12.8313    0.0000 </r>
+       <r>   14.5883    0.0000 </r>
+       <r>   16.6452    0.0000 </r>
+       <r>   18.6259    0.0000 </r>
+       <r>   18.7377    0.0000 </r>
+       <r>   19.3222    0.0000 </r>
+      </set>
+      <set comment="kpoint 54">
+       <r>   -6.5342    1.0000 </r>
+       <r>   -5.4257    1.0000 </r>
+       <r>    0.6578    1.0000 </r>
+       <r>    2.7666    1.0000 </r>
+       <r>    2.9480    1.0000 </r>
+       <r>    7.5199    0.0000 </r>
+       <r>    7.9088    0.0000 </r>
+       <r>   10.5208    0.0000 </r>
+       <r>   10.6803    0.0000 </r>
+       <r>   12.7810    0.0000 </r>
+       <r>   13.7754    0.0000 </r>
+       <r>   15.6361    0.0000 </r>
+       <r>   17.9958    0.0000 </r>
+       <r>   18.2630    0.0000 </r>
+       <r>   18.6260    0.0000 </r>
+       <r>   18.8663    0.0000 </r>
+      </set>
+      <set comment="kpoint 55">
+       <r>   -7.4031    1.0000 </r>
+       <r>   -4.8681    1.0000 </r>
+       <r>    2.5903    1.0000 </r>
+       <r>    3.4075    1.0000 </r>
+       <r>    4.1998    1.0000 </r>
+       <r>    6.1291    0.0000 </r>
+       <r>    7.0794    0.0000 </r>
+       <r>    7.6085    0.0000 </r>
+       <r>   10.9822    0.0000 </r>
+       <r>   13.6273    0.0000 </r>
+       <r>   14.5279    0.0000 </r>
+       <r>   15.0444    0.0000 </r>
+       <r>   15.3039    0.0000 </r>
+       <r>   16.9818    0.0000 </r>
+       <r>   17.1817    0.0000 </r>
+       <r>   17.9872    0.0000 </r>
+      </set>
+      <set comment="kpoint 56">
+       <r>   -7.0484    1.0000 </r>
+       <r>   -5.0880    1.0000 </r>
+       <r>    1.4893    1.0000 </r>
+       <r>    2.4822    1.0000 </r>
+       <r>    4.7860    1.0000 </r>
+       <r>    5.5905    0.0000 </r>
+       <r>    8.2231    0.0000 </r>
+       <r>    9.1713    0.0000 </r>
+       <r>   11.0637    0.0000 </r>
+       <r>   12.6883    0.0000 </r>
+       <r>   14.3331    0.0000 </r>
+       <r>   15.2623    0.0000 </r>
+       <r>   16.5397    0.0000 </r>
+       <r>   16.7034    0.0000 </r>
+       <r>   18.5331    0.0000 </r>
+       <r>   18.8038    0.0000 </r>
+      </set>
+      <set comment="kpoint 57">
+       <r>   -6.6165    1.0000 </r>
+       <r>   -5.2908    1.0000 </r>
+       <r>    0.6903    1.0000 </r>
+       <r>    1.6728    1.0000 </r>
+       <r>    4.3587    1.0000 </r>
+       <r>    6.1660    0.0000 </r>
+       <r>    9.3143    0.0000 </r>
+       <r>   10.4514    0.0000 </r>
+       <r>   11.0653    0.0000 </r>
+       <r>   11.9736    0.0000 </r>
+       <r>   14.8336    0.0000 </r>
+       <r>   15.5267    0.0000 </r>
+       <r>   16.8003    0.0000 </r>
+       <r>   17.1837    0.0000 </r>
+       <r>   18.5184    0.0000 </r>
+       <r>   19.2851    0.0000 </r>
+      </set>
+      <set comment="kpoint 58">
+       <r>   -6.8884    1.0000 </r>
+       <r>   -5.1627    1.0000 </r>
+       <r>    1.0337    1.0000 </r>
+       <r>    2.9192    1.0000 </r>
+       <r>    3.2114    1.0000 </r>
+       <r>    7.3808    0.0000 </r>
+       <r>    7.7614    0.0000 </r>
+       <r>    9.8753    0.0000 </r>
+       <r>   10.6668    0.0000 </r>
+       <r>   13.1488    0.0000 </r>
+       <r>   13.9359    0.0000 </r>
+       <r>   15.8345    0.0000 </r>
+       <r>   16.8943    0.0000 </r>
+       <r>   17.4835    0.0000 </r>
+       <r>   17.8389    0.0000 </r>
+       <r>   17.8686    0.0000 </r>
+      </set>
+      <set comment="kpoint 59">
+       <r>   -7.3728    1.0000 </r>
+       <r>   -5.0942    1.0000 </r>
+       <r>    3.9037    1.0000 </r>
+       <r>    4.2879    1.0000 </r>
+       <r>    4.2880    1.0000 </r>
+       <r>    5.8256    0.0000 </r>
+       <r>    5.8260    0.0000 </r>
+       <r>    6.0622    0.0000 </r>
+       <r>   12.1395    0.0000 </r>
+       <r>   13.9648    0.0000 </r>
+       <r>   13.9653    0.0000 </r>
+       <r>   15.1155    0.0000 </r>
+       <r>   15.6091    0.0000 </r>
+       <r>   15.6096    0.0000 </r>
+       <r>   18.5435    0.0000 </r>
+       <r>   18.5435    0.0000 </r>
+      </set>
+      <set comment="kpoint 60">
+       <r>   -7.1770    1.0000 </r>
+       <r>   -5.1970    1.0000 </r>
+       <r>    2.3658    1.0000 </r>
+       <r>    3.8406    1.0000 </r>
+       <r>    4.3078    1.0000 </r>
+       <r>    5.9064    0.0000 </r>
+       <r>    6.3546    0.0000 </r>
+       <r>    7.9012    0.0000 </r>
+       <r>   11.9541    0.0000 </r>
+       <r>   13.3092    0.0000 </r>
+       <r>   13.7377    0.0000 </r>
+       <r>   15.4266    0.0000 </r>
+       <r>   16.1530    0.0000 </r>
+       <r>   16.4314    0.0000 </r>
+       <r>   17.8097    0.0000 </r>
+       <r>   19.0241    0.0000 </r>
+      </set>
+     </set>
+     <set comment="spin 2">
+      <set comment="kpoint 1">
+       <r>   -8.6395    1.0000 </r>
+       <r>   -2.7008    1.0000 </r>
+       <r>    3.5522    1.0000 </r>
+       <r>    3.5816    1.0000 </r>
+       <r>    3.5829    1.0000 </r>
+       <r>    7.6389    0.0000 </r>
+       <r>    7.6907    0.0000 </r>
+       <r>    7.6913    0.0000 </r>
+       <r>   10.8573    0.0000 </r>
+       <r>   11.2076    0.0000 </r>
+       <r>   11.2081    0.0000 </r>
+       <r>   12.1176    0.0000 </r>
+       <r>   12.3568    0.0000 </r>
+       <r>   13.4333    0.0000 </r>
+       <r>   13.4346    0.0000 </r>
+       <r>   21.8950    0.0000 </r>
+      </set>
+      <set comment="kpoint 2">
+       <r>   -8.4440    1.0000 </r>
+       <r>   -3.1676    1.0000 </r>
+       <r>    3.1351    1.0000 </r>
+       <r>    3.7888    1.0000 </r>
+       <r>    3.9922    1.0000 </r>
+       <r>    6.7927    0.0000 </r>
+       <r>    6.9909    0.0000 </r>
+       <r>    7.9378    0.0000 </r>
+       <r>   10.5828    0.0000 </r>
+       <r>   11.2141    0.0000 </r>
+       <r>   11.3947    0.0000 </r>
+       <r>   12.9710    0.0000 </r>
+       <r>   13.7448    0.0000 </r>
+       <r>   14.4007    0.0000 </r>
+       <r>   14.6553    0.0000 </r>
+       <r>   19.6841    0.0000 </r>
+      </set>
+      <set comment="kpoint 3">
+       <r>   -7.9524    1.0000 </r>
+       <r>   -4.1244    1.0000 </r>
+       <r>    2.9052    1.0000 </r>
+       <r>    3.8923    1.0000 </r>
+       <r>    4.4405    1.0000 </r>
+       <r>    5.7474    0.0000 </r>
+       <r>    6.2633    0.0000 </r>
+       <r>    7.4760    0.0000 </r>
+       <r>   10.8001    0.0000 </r>
+       <r>   11.8486    0.0000 </r>
+       <r>   12.2311    0.0000 </r>
+       <r>   14.7401    0.0000 </r>
+       <r>   15.9531    0.0000 </r>
+       <r>   16.3253    0.0000 </r>
+       <r>   16.4884    0.0000 </r>
+       <r>   17.5668    0.0000 </r>
+      </set>
+      <set comment="kpoint 4">
+       <r>   -7.2035    1.0000 </r>
+       <r>   -5.2508    1.0000 </r>
+       <r>    2.9708    1.0000 </r>
+       <r>    3.7906    1.0000 </r>
+       <r>    4.6760    1.0000 </r>
+       <r>    5.0836    0.0000 </r>
+       <r>    5.9274    0.0000 </r>
+       <r>    6.6809    0.0000 </r>
+       <r>   12.0393    0.0000 </r>
+       <r>   13.0690    0.0000 </r>
+       <r>   13.4427    0.0000 </r>
+       <r>   14.6901    0.0000 </r>
+       <r>   16.3713    0.0000 </r>
+       <r>   17.1277    0.0000 </r>
+       <r>   17.9440    0.0000 </r>
+       <r>   18.6324    0.0000 </r>
+      </set>
+      <set comment="kpoint 5">
+       <r>   -6.6556    1.0000 </r>
+       <r>   -5.9081    1.0000 </r>
+       <r>    3.3167    1.0000 </r>
+       <r>    3.5207    1.0000 </r>
+       <r>    4.1807    1.0000 </r>
+       <r>    5.5014    0.0000 </r>
+       <r>    5.9981    0.0000 </r>
+       <r>    6.1262    0.0000 </r>
+       <r>   12.4027    0.0000 </r>
+       <r>   14.0816    0.0000 </r>
+       <r>   14.5179    0.0000 </r>
+       <r>   14.7200    0.0000 </r>
+       <r>   15.3783    0.0000 </r>
+       <r>   15.3860    0.0000 </r>
+       <r>   19.2554    0.0000 </r>
+       <r>   19.9026    0.0000 </r>
+      </set>
+      <set comment="kpoint 6">
+       <r>   -7.4335    1.0000 </r>
+       <r>   -4.9225    1.0000 </r>
+       <r>    3.3020    1.0000 </r>
+       <r>    3.6399    1.0000 </r>
+       <r>    3.9810    1.0000 </r>
+       <r>    5.6104    0.0000 </r>
+       <r>    6.2306    0.0000 </r>
+       <r>    6.6949    0.0000 </r>
+       <r>   11.0238    0.0000 </r>
+       <r>   12.9198    0.0000 </r>
+       <r>   13.3633    0.0000 </r>
+       <r>   15.8011    0.0000 </r>
+       <r>   16.6067    0.0000 </r>
+       <r>   17.2268    0.0000 </r>
+       <r>   17.3826    0.0000 </r>
+       <r>   17.8147    0.0000 </r>
+      </set>
+      <set comment="kpoint 7">
+       <r>   -8.1176    1.0000 </r>
+       <r>   -3.7985    1.0000 </r>
+       <r>    3.2531    1.0000 </r>
+       <r>    3.4490    1.0000 </r>
+       <r>    4.2135    1.0000 </r>
+       <r>    5.8789    0.0000 </r>
+       <r>    7.0541    0.0000 </r>
+       <r>    7.4084    0.0000 </r>
+       <r>   10.2734    0.0000 </r>
+       <r>   11.6818    0.0000 </r>
+       <r>   12.1245    0.0000 </r>
+       <r>   14.3977    0.0000 </r>
+       <r>   15.0217    0.0000 </r>
+       <r>   15.2230    0.0000 </r>
+       <r>   16.5916    0.0000 </r>
+       <r>   19.2504    0.0000 </r>
+      </set>
+      <set comment="kpoint 8">
+       <r>   -8.5287    1.0000 </r>
+       <r>   -2.9469    1.0000 </r>
+       <r>    3.3680    1.0000 </r>
+       <r>    3.3706    1.0000 </r>
+       <r>    4.0141    1.0000 </r>
+       <r>    6.7790    0.0000 </r>
+       <r>    7.7017    0.0000 </r>
+       <r>    7.8854    0.0000 </r>
+       <r>   10.4188    0.0000 </r>
+       <r>   11.1896    0.0000 </r>
+       <r>   11.4650    0.0000 </r>
+       <r>   12.5088    0.0000 </r>
+       <r>   13.2085    0.0000 </r>
+       <r>   13.5903    0.0000 </r>
+       <r>   14.5858    0.0000 </r>
+       <r>   21.6163    0.0000 </r>
+      </set>
+      <set comment="kpoint 9">
+       <r>   -8.3633    1.0000 </r>
+       <r>   -3.2986    1.0000 </r>
+       <r>    2.9990    1.0000 </r>
+       <r>    3.1074    1.0000 </r>
+       <r>    4.8766    1.0000 </r>
+       <r>    5.6355    0.0000 </r>
+       <r>    7.8818    0.0000 </r>
+       <r>    8.1103    0.0000 </r>
+       <r>   10.2441    0.0000 </r>
+       <r>   11.6867    0.0000 </r>
+       <r>   12.1435    0.0000 </r>
+       <r>   12.7471    0.0000 </r>
+       <r>   13.6298    0.0000 </r>
+       <r>   13.8766    0.0000 </r>
+       <r>   16.0876    0.0000 </r>
+       <r>   20.0589    0.0000 </r>
+      </set>
+      <set comment="kpoint 10">
+       <r>   -7.9899    1.0000 </r>
+       <r>   -3.9232    1.0000 </r>
+       <r>    2.4440    1.0000 </r>
+       <r>    3.0378    1.0000 </r>
+       <r>    4.2666    1.0000 </r>
+       <r>    6.0804    0.0000 </r>
+       <r>    7.4839    0.0000 </r>
+       <r>    8.3740    0.0000 </r>
+       <r>   10.0659    0.0000 </r>
+       <r>   12.4447    0.0000 </r>
+       <r>   12.7656    0.0000 </r>
+       <r>   13.6684    0.0000 </r>
+       <r>   14.7025    0.0000 </r>
+       <r>   15.6718    0.0000 </r>
+       <r>   17.2018    0.0000 </r>
+       <r>   18.2109    0.0000 </r>
+      </set>
+      <set comment="kpoint 11">
+       <r>   -7.3522    1.0000 </r>
+       <r>   -4.8619    1.0000 </r>
+       <r>    2.2406    1.0000 </r>
+       <r>    2.6134    1.0000 </r>
+       <r>    4.0017    1.0000 </r>
+       <r>    6.1873    0.0000 </r>
+       <r>    7.3720    0.0000 </r>
+       <r>    8.0449    0.0000 </r>
+       <r>   10.5095    0.0000 </r>
+       <r>   13.4542    0.0000 </r>
+       <r>   13.8829    0.0000 </r>
+       <r>   14.7230    0.0000 </r>
+       <r>   15.4512    0.0000 </r>
+       <r>   17.1236    0.0000 </r>
+       <r>   17.4375    0.0000 </r>
+       <r>   18.3078    0.0000 </r>
+      </set>
+      <set comment="kpoint 12">
+       <r>   -6.5867    1.0000 </r>
+       <r>   -5.7985    1.0000 </r>
+       <r>    2.1016    1.0000 </r>
+       <r>    2.4632    1.0000 </r>
+       <r>    4.2560    1.0000 </r>
+       <r>    5.6289    0.0000 </r>
+       <r>    7.3204    0.0000 </r>
+       <r>    7.8871    0.0000 </r>
+       <r>   11.8556    0.0000 </r>
+       <r>   12.6015    0.0000 </r>
+       <r>   14.7066    0.0000 </r>
+       <r>   15.0451    0.0000 </r>
+       <r>   15.7991    0.0000 </r>
+       <r>   17.5282    0.0000 </r>
+       <r>   18.6097    0.0000 </r>
+       <r>   18.7128    0.0000 </r>
+      </set>
+      <set comment="kpoint 13">
+       <r>   -6.9870    1.0000 </r>
+       <r>   -5.3437    1.0000 </r>
+       <r>    1.9164    1.0000 </r>
+       <r>    3.0639    1.0000 </r>
+       <r>    4.3981    1.0000 </r>
+       <r>    5.4586    0.0000 </r>
+       <r>    6.6005    0.0000 </r>
+       <r>    8.4042    0.0000 </r>
+       <r>   11.0318    0.0000 </r>
+       <r>   13.0458    0.0000 </r>
+       <r>   14.0064    0.0000 </r>
+       <r>   15.4365    0.0000 </r>
+       <r>   15.8386    0.0000 </r>
+       <r>   17.5956    0.0000 </r>
+       <r>   17.9062    0.0000 </r>
+       <r>   19.2851    0.0000 </r>
+      </set>
+      <set comment="kpoint 14">
+       <r>   -7.7246    1.0000 </r>
+       <r>   -4.3598    1.0000 </r>
+       <r>    2.1622    1.0000 </r>
+       <r>    3.9050    1.0000 </r>
+       <r>    4.0273    1.0000 </r>
+       <r>    5.9101    0.0000 </r>
+       <r>    6.1739    0.0000 </r>
+       <r>    8.6090    0.0000 </r>
+       <r>   10.2432    0.0000 </r>
+       <r>   12.0912    0.0000 </r>
+       <r>   13.7723    0.0000 </r>
+       <r>   13.8855    0.0000 </r>
+       <r>   15.9387    0.0000 </r>
+       <r>   16.7965    0.0000 </r>
+       <r>   17.4023    0.0000 </r>
+       <r>   18.6396    0.0000 </r>
+      </set>
+      <set comment="kpoint 15">
+       <r>   -8.2266    1.0000 </r>
+       <r>   -3.5610    1.0000 </r>
+       <r>    2.8548    1.0000 </r>
+       <r>    3.4676    1.0000 </r>
+       <r>    4.5608    1.0000 </r>
+       <r>    5.7531    0.0000 </r>
+       <r>    7.1356    0.0000 </r>
+       <r>    8.1200    0.0000 </r>
+       <r>   10.1169    0.0000 </r>
+       <r>   11.5910    0.0000 </r>
+       <r>   12.2408    0.0000 </r>
+       <r>   13.2323    0.0000 </r>
+       <r>   14.4003    0.0000 </r>
+       <r>   15.1150    0.0000 </r>
+       <r>   16.3126    0.0000 </r>
+       <r>   19.3825    0.0000 </r>
+      </set>
+      <set comment="kpoint 16">
+       <r>   -7.7556    1.0000 </r>
+       <r>   -4.0707    1.0000 </r>
+       <r>    1.9817    1.0000 </r>
+       <r>    2.4195    1.0000 </r>
+       <r>    3.0380    1.0000 </r>
+       <r>    7.6324    0.0000 </r>
+       <r>    8.0522    0.0000 </r>
+       <r>    8.8915    0.0000 </r>
+       <r>   10.0687    0.0000 </r>
+       <r>   13.3465    0.0000 </r>
+       <r>   13.5970    0.0000 </r>
+       <r>   13.7698    0.0000 </r>
+       <r>   14.3527    0.0000 </r>
+       <r>   16.0935    0.0000 </r>
+       <r>   17.6393    0.0000 </r>
+       <r>   17.7902    0.0000 </r>
+      </set>
+      <set comment="kpoint 17">
+       <r>   -7.2794    1.0000 </r>
+       <r>   -4.6033    1.0000 </r>
+       <r>    1.3351    1.0000 </r>
+       <r>    1.9334    1.0000 </r>
+       <r>    2.8631    1.0000 </r>
+       <r>    7.7963    0.0000 </r>
+       <r>    8.6921    0.0000 </r>
+       <r>    9.2045    0.0000 </r>
+       <r>   10.0829    0.0000 </r>
+       <r>   14.0115    0.0000 </r>
+       <r>   14.5895    0.0000 </r>
+       <r>   15.0477    0.0000 </r>
+       <r>   15.1739    0.0000 </r>
+       <r>   16.0795    0.0000 </r>
+       <r>   17.5409    0.0000 </r>
+       <r>   17.9572    0.0000 </r>
+      </set>
+      <set comment="kpoint 18">
+       <r>   -6.6324    1.0000 </r>
+       <r>   -5.3909    1.0000 </r>
+       <r>    0.8563    1.0000 </r>
+       <r>    1.8482    1.0000 </r>
+       <r>    3.2323    1.0000 </r>
+       <r>    7.1849    0.0000 </r>
+       <r>    8.6534    0.0000 </r>
+       <r>    9.8783    0.0000 </r>
+       <r>   10.2578    0.0000 </r>
+       <r>   13.0612    0.0000 </r>
+       <r>   14.8824    0.0000 </r>
+       <r>   15.7765    0.0000 </r>
+       <r>   16.4522    0.0000 </r>
+       <r>   17.1381    0.0000 </r>
+       <r>   17.8761    0.0000 </r>
+       <r>   18.1990    0.0000 </r>
+      </set>
+      <set comment="kpoint 19">
+       <r>   -6.3561    1.0000 </r>
+       <r>   -5.7946    1.0000 </r>
+       <r>    0.8297    1.0000 </r>
+       <r>    2.2986    1.0000 </r>
+       <r>    3.7756    1.0000 </r>
+       <r>    6.2638    0.0000 </r>
+       <r>    7.8891    0.0000 </r>
+       <r>   10.0627    0.0000 </r>
+       <r>   11.3788    0.0000 </r>
+       <r>   12.0321    0.0000 </r>
+       <r>   13.6060    0.0000 </r>
+       <r>   15.2430    0.0000 </r>
+       <r>   17.8489    0.0000 </r>
+       <r>   18.1885    0.0000 </r>
+       <r>   18.6408    0.0000 </r>
+       <r>   19.0885    0.0000 </r>
+      </set>
+      <set comment="kpoint 20">
+       <r>   -7.0771    1.0000 </r>
+       <r>   -5.1395    1.0000 </r>
+       <r>    1.4050    1.0000 </r>
+       <r>    3.1634    1.0000 </r>
+       <r>    4.1791    1.0000 </r>
+       <r>    5.6333    0.0000 </r>
+       <r>    6.8277    0.0000 </r>
+       <r>    9.3299    0.0000 </r>
+       <r>   10.7951    0.0000 </r>
+       <r>   12.7439    0.0000 </r>
+       <r>   13.8011    0.0000 </r>
+       <r>   14.5480    0.0000 </r>
+       <r>   15.9428    0.0000 </r>
+       <r>   17.9443    0.0000 </r>
+       <r>   18.7709    0.0000 </r>
+       <r>   19.4394    0.0000 </r>
+      </set>
+      <set comment="kpoint 21">
+       <r>   -7.6401    1.0000 </r>
+       <r>   -4.5566    1.0000 </r>
+       <r>    2.5589    1.0000 </r>
+       <r>    3.6322    1.0000 </r>
+       <r>    4.3109    1.0000 </r>
+       <r>    5.6417    0.0000 </r>
+       <r>    6.2852    0.0000 </r>
+       <r>    7.8160    0.0000 </r>
+       <r>   10.6241    0.0000 </r>
+       <r>   12.1639    0.0000 </r>
+       <r>   13.5969    0.0000 </r>
+       <r>   14.9228    0.0000 </r>
+       <r>   16.0330    0.0000 </r>
+       <r>   17.1219    0.0000 </r>
+       <r>   17.4127    0.0000 </r>
+       <r>   17.7078    0.0000 </r>
+      </set>
+      <set comment="kpoint 22">
+       <r>   -7.0268    1.0000 </r>
+       <r>   -4.6399    1.0000 </r>
+       <r>    0.5223    1.0000 </r>
+       <r>    1.9330    1.0000 </r>
+       <r>    2.0953    1.0000 </r>
+       <r>    7.7321    0.0000 </r>
+       <r>    9.6517    0.0000 </r>
+       <r>   10.3452    0.0000 </r>
+       <r>   10.8160    0.0000 </r>
+       <r>   14.3026    0.0000 </r>
+       <r>   14.8185    0.0000 </r>
+       <r>   15.9099    0.0000 </r>
+       <r>   16.1461    0.0000 </r>
+       <r>   16.2154    0.0000 </r>
+       <r>   16.5031    0.0000 </r>
+       <r>   17.9890    0.0000 </r>
+      </set>
+      <set comment="kpoint 23">
+       <r>   -6.6772    1.0000 </r>
+       <r>   -5.0143    1.0000 </r>
+       <r>    0.1867    1.0000 </r>
+       <r>    1.6502    1.0000 </r>
+       <r>    2.3992    1.0000 </r>
+       <r>    7.9257    0.0000 </r>
+       <r>    9.1377    0.0000 </r>
+       <r>   10.4120    0.0000 </r>
+       <r>   11.4897    0.0000 </r>
+       <r>   14.0269    0.0000 </r>
+       <r>   15.2249    0.0000 </r>
+       <r>   15.8886    0.0000 </r>
+       <r>   16.5018    0.0000 </r>
+       <r>   16.9856    0.0000 </r>
+       <r>   17.1374    0.0000 </r>
+       <r>   17.7313    0.0000 </r>
+      </set>
+      <set comment="kpoint 24">
+       <r>   -6.3310    1.0000 </r>
+       <r>   -5.6005    1.0000 </r>
+       <r>    0.3837    1.0000 </r>
+       <r>    1.8761    1.0000 </r>
+       <r>    2.9770    1.0000 </r>
+       <r>    7.3892    0.0000 </r>
+       <r>    8.8211    0.0000 </r>
+       <r>   10.1765    0.0000 </r>
+       <r>   10.9112    0.0000 </r>
+       <r>   12.8169    0.0000 </r>
+       <r>   14.5610    0.0000 </r>
+       <r>   16.0373    0.0000 </r>
+       <r>   16.8959    0.0000 </r>
+       <r>   17.0728    0.0000 </r>
+       <r>   18.3722    0.0000 </r>
+       <r>   18.8311    0.0000 </r>
+      </set>
+      <set comment="kpoint 25">
+       <r>   -6.3093    1.0000 </r>
+       <r>   -5.9414    1.0000 </r>
+       <r>    1.1722    1.0000 </r>
+       <r>    2.6334    1.0000 </r>
+       <r>    3.6672    1.0000 </r>
+       <r>    6.0845    0.0000 </r>
+       <r>    7.6536    0.0000 </r>
+       <r>    9.2546    0.0000 </r>
+       <r>   11.5913    0.0000 </r>
+       <r>   12.3318    0.0000 </r>
+       <r>   13.7105    0.0000 </r>
+       <r>   15.5242    0.0000 </r>
+       <r>   16.7811    0.0000 </r>
+       <r>   17.6953    0.0000 </r>
+       <r>   18.3960    0.0000 </r>
+       <r>   18.8279    0.0000 </r>
+      </set>
+      <set comment="kpoint 26">
+       <r>   -6.8343    1.0000 </r>
+       <r>   -5.6325    1.0000 </r>
+       <r>    2.4682    1.0000 </r>
+       <r>    3.8097    1.0000 </r>
+       <r>    3.8305    1.0000 </r>
+       <r>    5.6220    0.0000 </r>
+       <r>    6.0447    0.0000 </r>
+       <r>    7.3512    0.0000 </r>
+       <r>   11.9744    0.0000 </r>
+       <r>   13.2856    0.0000 </r>
+       <r>   14.1212    0.0000 </r>
+       <r>   15.0725    0.0000 </r>
+       <r>   15.3480    0.0000 </r>
+       <r>   17.1157    0.0000 </r>
+       <r>   18.0478    0.0000 </r>
+       <r>   19.3970    0.0000 </r>
+      </set>
+      <set comment="kpoint 27">
+       <r>   -6.7544    1.0000 </r>
+       <r>   -4.8415    1.0000 </r>
+       <r>    0.1408    1.0000 </r>
+       <r>    1.8185    1.0000 </r>
+       <r>    1.9298    1.0000 </r>
+       <r>    7.6517    0.0000 </r>
+       <r>    9.8406    0.0000 </r>
+       <r>   10.5275    0.0000 </r>
+       <r>   11.6934    0.0000 </r>
+       <r>   14.8636    0.0000 </r>
+       <r>   15.2516    0.0000 </r>
+       <r>   15.5651    0.0000 </r>
+       <r>   15.9634    0.0000 </r>
+       <r>   16.8836    0.0000 </r>
+       <r>   17.1075    0.0000 </r>
+       <r>   17.7750    0.0000 </r>
+      </set>
+      <set comment="kpoint 28">
+       <r>   -6.8598    1.0000 </r>
+       <r>   -4.9258    1.0000 </r>
+       <r>    0.6002    1.0000 </r>
+       <r>    1.8476    1.0000 </r>
+       <r>    2.4173    1.0000 </r>
+       <r>    7.8918    0.0000 </r>
+       <r>    8.9103    0.0000 </r>
+       <r>   10.1707    0.0000 </r>
+       <r>   10.5623    0.0000 </r>
+       <r>   14.2838    0.0000 </r>
+       <r>   14.9014    0.0000 </r>
+       <r>   15.8045    0.0000 </r>
+       <r>   16.1344    0.0000 </r>
+       <r>   16.2082    0.0000 </r>
+       <r>   17.1671    0.0000 </r>
+       <r>   18.2880    0.0000 </r>
+      </set>
+      <set comment="kpoint 29">
+       <r>   -6.9106    1.0000 </r>
+       <r>   -5.2368    1.0000 </r>
+       <r>    1.4082    1.0000 </r>
+       <r>    2.5152    1.0000 </r>
+       <r>    3.1461    1.0000 </r>
+       <r>    6.8589    0.0000 </r>
+       <r>    8.0773    0.0000 </r>
+       <r>    8.8061    0.0000 </r>
+       <r>   10.3188    0.0000 </r>
+       <r>   13.8925    0.0000 </r>
+       <r>   14.3983    0.0000 </r>
+       <r>   15.0997    0.0000 </r>
+       <r>   15.8808    0.0000 </r>
+       <r>   16.3349    0.0000 </r>
+       <r>   18.0251    0.0000 </r>
+       <r>   19.2760    0.0000 </r>
+      </set>
+      <set comment="kpoint 30">
+       <r>   -7.3141    1.0000 </r>
+       <r>   -4.4715    1.0000 </r>
+       <r>    1.3175    1.0000 </r>
+       <r>    2.1048    1.0000 </r>
+       <r>    2.3021    1.0000 </r>
+       <r>    7.7566    0.0000 </r>
+       <r>    9.1933    0.0000 </r>
+       <r>    9.2951    0.0000 </r>
+       <r>   10.0906    0.0000 </r>
+       <r>   13.8856    0.0000 </r>
+       <r>   14.2302    0.0000 </r>
+       <r>   14.8368    0.0000 </r>
+       <r>   15.5410    0.0000 </r>
+       <r>   17.4264    0.0000 </r>
+       <r>   17.5636    0.0000 </r>
+       <r>   17.7476    0.0000 </r>
+      </set>
+      <set comment="kpoint 31">
+       <r>   -7.5936    1.0000 </r>
+       <r>   -4.3585    1.0000 </r>
+       <r>    1.9569    1.0000 </r>
+       <r>    2.7451    1.0000 </r>
+       <r>    2.9921    1.0000 </r>
+       <r>    7.4828    0.0000 </r>
+       <r>    7.6134    0.0000 </r>
+       <r>    8.5640    0.0000 </r>
+       <r>    9.9216    0.0000 </r>
+       <r>   13.3243    0.0000 </r>
+       <r>   13.7871    0.0000 </r>
+       <r>   14.1168    0.0000 </r>
+       <r>   15.2972    0.0000 </r>
+       <r>   17.0285    0.0000 </r>
+       <r>   17.2225    0.0000 </r>
+       <r>   17.6712    0.0000 </r>
+      </set>
+      <set comment="kpoint 32">
+       <r>   -8.0470    1.0000 </r>
+       <r>   -3.7480    1.0000 </r>
+       <r>    2.6251    1.0000 </r>
+       <r>    2.7086    1.0000 </r>
+       <r>    3.9065    1.0000 </r>
+       <r>    6.3760    0.0000 </r>
+       <r>    7.8494    0.0000 </r>
+       <r>    8.5147    0.0000 </r>
+       <r>    9.8746    0.0000 </r>
+       <r>   12.4683    0.0000 </r>
+       <r>   12.7572    0.0000 </r>
+       <r>   13.2593    0.0000 </r>
+       <r>   14.1582    0.0000 </r>
+       <r>   15.2283    0.0000 </r>
+       <r>   18.0854    0.0000 </r>
+       <r>   19.3751    0.0000 </r>
+      </set>
+      <set comment="kpoint 33">
+       <r>   -8.3889    1.0000 </r>
+       <r>   -3.3646    1.0000 </r>
+       <r>    3.7030    1.0000 </r>
+       <r>    3.7045    1.0000 </r>
+       <r>    3.7814    1.0000 </r>
+       <r>    7.0234    0.0000 </r>
+       <r>    7.0237    0.0000 </r>
+       <r>    7.0267    0.0000 </r>
+       <r>   10.5600    0.0000 </r>
+       <r>   11.6004    0.0000 </r>
+       <r>   11.6007    0.0000 </r>
+       <r>   13.5444    0.0000 </r>
+       <r>   14.1209    0.0000 </r>
+       <r>   14.6117    0.0000 </r>
+       <r>   14.6129    0.0000 </r>
+       <r>   19.6943    0.0000 </r>
+      </set>
+      <set comment="kpoint 34">
+       <r>   -8.1208    1.0000 </r>
+       <r>   -3.8416    1.0000 </r>
+       <r>    2.5397    1.0000 </r>
+       <r>    4.2419    1.0000 </r>
+       <r>    4.6306    1.0000 </r>
+       <r>    5.8251    0.0000 </r>
+       <r>    5.9977    0.0000 </r>
+       <r>    8.3939    0.0000 </r>
+       <r>   10.7156    0.0000 </r>
+       <r>   11.4947    0.0000 </r>
+       <r>   12.6707    0.0000 </r>
+       <r>   13.4373    0.0000 </r>
+       <r>   15.0672    0.0000 </r>
+       <r>   15.8595    0.0000 </r>
+       <r>   16.2760    0.0000 </r>
+       <r>   17.5548    0.0000 </r>
+      </set>
+      <set comment="kpoint 35">
+       <r>   -7.5780    1.0000 </r>
+       <r>   -4.6090    1.0000 </r>
+       <r>    1.7752    1.0000 </r>
+       <r>    3.9966    1.0000 </r>
+       <r>    4.5381    1.0000 </r>
+       <r>    5.6305    0.0000 </r>
+       <r>    5.9383    0.0000 </r>
+       <r>    9.0112    0.0000 </r>
+       <r>   11.0820    0.0000 </r>
+       <r>   11.9934    0.0000 </r>
+       <r>   13.6654    0.0000 </r>
+       <r>   14.3154    0.0000 </r>
+       <r>   14.8102    0.0000 </r>
+       <r>   17.3913    0.0000 </r>
+       <r>   18.2445    0.0000 </r>
+       <r>   18.6952    0.0000 </r>
+      </set>
+      <set comment="kpoint 36">
+       <r>   -6.8401    1.0000 </r>
+       <r>   -5.4938    1.0000 </r>
+       <r>    1.5731    1.0000 </r>
+       <r>    3.3014    1.0000 </r>
+       <r>    3.7242    1.0000 </r>
+       <r>    6.2559    0.0000 </r>
+       <r>    6.5713    0.0000 </r>
+       <r>    8.6764    0.0000 </r>
+       <r>   12.0546    0.0000 </r>
+       <r>   12.4056    0.0000 </r>
+       <r>   13.1036    0.0000 </r>
+       <r>   15.8702    0.0000 </r>
+       <r>   16.0544    0.0000 </r>
+       <r>   17.5795    0.0000 </r>
+       <r>   18.1630    0.0000 </r>
+       <r>   19.7484    0.0000 </r>
+      </set>
+      <set comment="kpoint 37">
+       <r>   -6.7378    1.0000 </r>
+       <r>   -5.5658    1.0000 </r>
+       <r>    1.8897    1.0000 </r>
+       <r>    2.7941    1.0000 </r>
+       <r>    3.1459    1.0000 </r>
+       <r>    6.8729    0.0000 </r>
+       <r>    7.3192    0.0000 </r>
+       <r>    7.9992    0.0000 </r>
+       <r>   10.6442    0.0000 </r>
+       <r>   14.1003    0.0000 </r>
+       <r>   14.5861    0.0000 </r>
+       <r>   15.1766    0.0000 </r>
+       <r>   15.7864    0.0000 </r>
+       <r>   17.6400    0.0000 </r>
+       <r>   17.9372    0.0000 </r>
+       <r>   18.8315    0.0000 </r>
+      </set>
+      <set comment="kpoint 38">
+       <r>   -7.4680    1.0000 </r>
+       <r>   -4.6124    1.0000 </r>
+       <r>    2.4830    1.0000 </r>
+       <r>    2.5927    1.0000 </r>
+       <r>    2.9791    1.0000 </r>
+       <r>    7.2580    0.0000 </r>
+       <r>    7.4618    0.0000 </r>
+       <r>    8.0631    0.0000 </r>
+       <r>    9.8110    0.0000 </r>
+       <r>   13.5535    0.0000 </r>
+       <r>   13.8668    0.0000 </r>
+       <r>   14.9605    0.0000 </r>
+       <r>   15.6794    0.0000 </r>
+       <r>   17.1781    0.0000 </r>
+       <r>   17.3291    0.0000 </r>
+       <r>   17.7003    0.0000 </r>
+      </set>
+      <set comment="kpoint 39">
+       <r>   -7.9731    1.0000 </r>
+       <r>   -4.0693    1.0000 </r>
+       <r>    2.8627    1.0000 </r>
+       <r>    3.0702    1.0000 </r>
+       <r>    4.4209    1.0000 </r>
+       <r>    5.8795    0.0000 </r>
+       <r>    7.5917    0.0000 </r>
+       <r>    7.6002    0.0000 </r>
+       <r>   10.2488    0.0000 </r>
+       <r>   12.5249    0.0000 </r>
+       <r>   13.0994    0.0000 </r>
+       <r>   14.3083    0.0000 </r>
+       <r>   14.8604    0.0000 </r>
+       <r>   15.6476    0.0000 </r>
+       <r>   17.3041    0.0000 </r>
+       <r>   17.4670    0.0000 </r>
+      </set>
+      <set comment="kpoint 40">
+       <r>   -7.5608    1.0000 </r>
+       <r>   -4.5382    1.0000 </r>
+       <r>    1.7984    1.0000 </r>
+       <r>    2.7533    1.0000 </r>
+       <r>    4.1500    1.0000 </r>
+       <r>    6.2120    0.0000 </r>
+       <r>    7.4901    0.0000 </r>
+       <r>    8.9289    0.0000 </r>
+       <r>   10.4629    0.0000 </r>
+       <r>   13.0828    0.0000 </r>
+       <r>   13.7164    0.0000 </r>
+       <r>   14.4573    0.0000 </r>
+       <r>   14.9840    0.0000 </r>
+       <r>   16.9110    0.0000 </r>
+       <r>   17.2535    0.0000 </r>
+       <r>   18.1145    0.0000 </r>
+      </set>
+      <set comment="kpoint 41">
+       <r>   -6.9396    1.0000 </r>
+       <r>   -5.1925    1.0000 </r>
+       <r>    1.1907    1.0000 </r>
+       <r>    1.9455    1.0000 </r>
+       <r>    4.7448    1.0000 </r>
+       <r>    5.4347    0.0000 </r>
+       <r>    8.4162    0.0000 </r>
+       <r>    9.6306    0.0000 </r>
+       <r>   10.9607    0.0000 </r>
+       <r>   12.4263    0.0000 </r>
+       <r>   13.8424    0.0000 </r>
+       <r>   14.9331    0.0000 </r>
+       <r>   16.4643    0.0000 </r>
+       <r>   17.7876    0.0000 </r>
+       <r>   18.8618    0.0000 </r>
+       <r>   19.1087    0.0000 </r>
+      </set>
+      <set comment="kpoint 42">
+       <r>   -6.4553    1.0000 </r>
+       <r>   -5.6702    1.0000 </r>
+       <r>    1.1491    1.0000 </r>
+       <r>    1.5492    1.0000 </r>
+       <r>    4.2361    1.0000 </r>
+       <r>    5.8715    0.0000 </r>
+       <r>    9.0028    0.0000 </r>
+       <r>    9.3995    0.0000 </r>
+       <r>   10.8995    0.0000 </r>
+       <r>   12.1903    0.0000 </r>
+       <r>   15.1023    0.0000 </r>
+       <r>   15.3782    0.0000 </r>
+       <r>   17.0449    0.0000 </r>
+       <r>   17.3169    0.0000 </r>
+       <r>   18.5994    0.0000 </r>
+       <r>   18.7523    0.0000 </r>
+      </set>
+      <set comment="kpoint 43">
+       <r>   -6.9871    1.0000 </r>
+       <r>   -5.0644    1.0000 </r>
+       <r>    1.3742    1.0000 </r>
+       <r>    1.9207    1.0000 </r>
+       <r>    3.4650    1.0000 </r>
+       <r>    6.7222    0.0000 </r>
+       <r>    8.5736    0.0000 </r>
+       <r>    8.9464    0.0000 </r>
+       <r>   10.3481    0.0000 </r>
+       <r>   13.9134    0.0000 </r>
+       <r>   14.0133    0.0000 </r>
+       <r>   14.9668    0.0000 </r>
+       <r>   16.0420    0.0000 </r>
+       <r>   17.5965    0.0000 </r>
+       <r>   18.2176    0.0000 </r>
+       <r>   18.4050    0.0000 </r>
+      </set>
+      <set comment="kpoint 44">
+       <r>   -7.3125    1.0000 </r>
+       <r>   -4.6781    1.0000 </r>
+       <r>    1.3873    1.0000 </r>
+       <r>    2.4340    1.0000 </r>
+       <r>    2.8185    1.0000 </r>
+       <r>    7.7841    0.0000 </r>
+       <r>    8.4205    0.0000 </r>
+       <r>    8.9926    0.0000 </r>
+       <r>    9.9976    0.0000 </r>
+       <r>   14.2828    0.0000 </r>
+       <r>   14.9083    0.0000 </r>
+       <r>   14.9941    0.0000 </r>
+       <r>   15.3042    0.0000 </r>
+       <r>   16.1108    0.0000 </r>
+       <r>   16.2238    0.0000 </r>
+       <r>   17.9443    0.0000 </r>
+      </set>
+      <set comment="kpoint 45">
+       <r>   -6.8818    1.0000 </r>
+       <r>   -5.0272    1.0000 </r>
+       <r>    0.7664    1.0000 </r>
+       <r>    1.4759    1.0000 </r>
+       <r>    3.4733    1.0000 </r>
+       <r>    7.0621    0.0000 </r>
+       <r>    9.0704    0.0000 </r>
+       <r>   10.1689    0.0000 </r>
+       <r>   10.6591    0.0000 </r>
+       <r>   13.1072    0.0000 </r>
+       <r>   14.7498    0.0000 </r>
+       <r>   15.6522    0.0000 </r>
+       <r>   16.4463    0.0000 </r>
+       <r>   16.7307    0.0000 </r>
+       <r>   17.7170    0.0000 </r>
+       <r>   18.1681    0.0000 </r>
+      </set>
+      <set comment="kpoint 46">
+       <r>   -6.3762    1.0000 </r>
+       <r>   -5.5400    1.0000 </r>
+       <r>    0.6068    1.0000 </r>
+       <r>    0.9797    1.0000 </r>
+       <r>    4.3483    1.0000 </r>
+       <r>    5.9880    0.0000 </r>
+       <r>    9.8133    0.0000 </r>
+       <r>   10.4304    0.0000 </r>
+       <r>   11.0404    0.0000 </r>
+       <r>   11.9335    0.0000 </r>
+       <r>   15.5383    0.0000 </r>
+       <r>   15.8206    0.0000 </r>
+       <r>   16.5191    0.0000 </r>
+       <r>   16.7601    0.0000 </r>
+       <r>   18.0172    0.0000 </r>
+       <r>   18.2572    0.0000 </r>
+      </set>
+      <set comment="kpoint 47">
+       <r>   -6.3560    1.0000 </r>
+       <r>   -5.6627    1.0000 </r>
+       <r>    0.7375    1.0000 </r>
+       <r>    1.4355    1.0000 </r>
+       <r>    4.2180    1.0000 </r>
+       <r>    5.8721    0.0000 </r>
+       <r>    9.5513    0.0000 </r>
+       <r>    9.8053    0.0000 </r>
+       <r>   10.9929    0.0000 </r>
+       <r>   12.0984    0.0000 </r>
+       <r>   14.9201    0.0000 </r>
+       <r>   15.3762    0.0000 </r>
+       <r>   16.4736    0.0000 </r>
+       <r>   17.2242    0.0000 </r>
+       <r>   18.5784    0.0000 </r>
+       <r>   18.9705    0.0000 </r>
+      </set>
+      <set comment="kpoint 48">
+       <r>   -6.7165    1.0000 </r>
+       <r>   -5.0747    1.0000 </r>
+       <r>    0.2621    1.0000 </r>
+       <r>    2.0980    1.0000 </r>
+       <r>    2.3219    1.0000 </r>
+       <r>    7.9678    0.0000 </r>
+       <r>    8.9784    0.0000 </r>
+       <r>   10.0369    0.0000 </r>
+       <r>   11.3154    0.0000 </r>
+       <r>   13.9982    0.0000 </r>
+       <r>   14.4980    0.0000 </r>
+       <r>   16.0990    0.0000 </r>
+       <r>   16.4348    0.0000 </r>
+       <r>   16.7095    0.0000 </r>
+       <r>   17.7740    0.0000 </r>
+       <r>   18.0909    0.0000 </r>
+      </set>
+      <set comment="kpoint 49">
+       <r>   -6.5211    1.0000 </r>
+       <r>   -5.3127    1.0000 </r>
+       <r>    0.3689    1.0000 </r>
+       <r>    1.3485    1.0000 </r>
+       <r>    3.2609    1.0000 </r>
+       <r>    7.2203    0.0000 </r>
+       <r>    9.0118    0.0000 </r>
+       <r>   10.7139    0.0000 </r>
+       <r>   11.0708    0.0000 </r>
+       <r>   12.8898    0.0000 </r>
+       <r>   15.3596    0.0000 </r>
+       <r>   15.8549    0.0000 </r>
+       <r>   16.4570    0.0000 </r>
+       <r>   17.0663    0.0000 </r>
+       <r>   17.8556    0.0000 </r>
+       <r>   18.3571    0.0000 </r>
+      </set>
+      <set comment="kpoint 50">
+       <r>   -6.7660    1.0000 </r>
+       <r>   -5.1388    1.0000 </r>
+       <r>    0.7521    1.0000 </r>
+       <r>    2.1585    1.0000 </r>
+       <r>    2.3684    1.0000 </r>
+       <r>    7.8173    0.0000 </r>
+       <r>    8.7566    0.0000 </r>
+       <r>    9.8445    0.0000 </r>
+       <r>   10.1440    0.0000 </r>
+       <r>   14.3495    0.0000 </r>
+       <r>   14.8528    0.0000 </r>
+       <r>   15.7057    0.0000 </r>
+       <r>   16.1930    0.0000 </r>
+       <r>   17.1251    0.0000 </r>
+       <r>   17.1740    0.0000 </r>
+       <r>   18.7896    0.0000 </r>
+      </set>
+      <set comment="kpoint 51">
+       <r>   -7.9300    1.0000 </r>
+       <r>   -4.3234    1.0000 </r>
+       <r>    3.9593    1.0000 </r>
+       <r>    3.9606    1.0000 </r>
+       <r>    4.0041    1.0000 </r>
+       <r>    6.1482    0.0000 </r>
+       <r>    6.1487    0.0000 </r>
+       <r>    6.3449    0.0000 </r>
+       <r>   11.1557    0.0000 </r>
+       <r>   12.4895    0.0000 </r>
+       <r>   12.4899    0.0000 </r>
+       <r>   15.4794    0.0000 </r>
+       <r>   16.2284    0.0000 </r>
+       <r>   16.2928    0.0000 </r>
+       <r>   16.2936    0.0000 </r>
+       <r>   17.6058    0.0000 </r>
+      </set>
+      <set comment="kpoint 52">
+       <r>   -7.6275    1.0000 </r>
+       <r>   -4.6827    1.0000 </r>
+       <r>    2.3172    1.0000 </r>
+       <r>    4.2853    1.0000 </r>
+       <r>    4.6405    1.0000 </r>
+       <r>    5.5508    0.0000 </r>
+       <r>    5.6037    0.0000 </r>
+       <r>    8.1642    0.0000 </r>
+       <r>   11.3062    0.0000 </r>
+       <r>   12.2996    0.0000 </r>
+       <r>   14.0246    0.0000 </r>
+       <r>   14.8484    0.0000 </r>
+       <r>   15.0173    0.0000 </r>
+       <r>   17.2273    0.0000 </r>
+       <r>   17.8233    0.0000 </r>
+       <r>   17.9514    0.0000 </r>
+      </set>
+      <set comment="kpoint 53">
+       <r>   -7.1103    1.0000 </r>
+       <r>   -5.1076    1.0000 </r>
+       <r>    1.1377    1.0000 </r>
+       <r>    3.3540    1.0000 </r>
+       <r>    3.6967    1.0000 </r>
+       <r>    6.5938    0.0000 </r>
+       <r>    6.6603    0.0000 </r>
+       <r>    9.8031    0.0000 </r>
+       <r>   11.8726    0.0000 </r>
+       <r>   12.3190    0.0000 </r>
+       <r>   12.6288    0.0000 </r>
+       <r>   14.4850    0.0000 </r>
+       <r>   16.5780    0.0000 </r>
+       <r>   18.5775    0.0000 </r>
+       <r>   18.7987    0.0000 </r>
+       <r>   19.2636    0.0000 </r>
+      </set>
+      <set comment="kpoint 54">
+       <r>   -6.5865    1.0000 </r>
+       <r>   -5.4786    1.0000 </r>
+       <r>    0.6187    1.0000 </r>
+       <r>    2.5844    1.0000 </r>
+       <r>    2.8874    1.0000 </r>
+       <r>    7.4763    0.0000 </r>
+       <r>    7.8047    0.0000 </r>
+       <r>   10.4915    0.0000 </r>
+       <r>   10.6068    0.0000 </r>
+       <r>   12.8140    0.0000 </r>
+       <r>   13.5543    0.0000 </r>
+       <r>   15.5913    0.0000 </r>
+       <r>   17.8267    0.0000 </r>
+       <r>   18.1868    0.0000 </r>
+       <r>   18.5841    0.0000 </r>
+       <r>   18.6416    0.0000 </r>
+      </set>
+      <set comment="kpoint 55">
+       <r>   -7.4658    1.0000 </r>
+       <r>   -4.9039    1.0000 </r>
+       <r>    2.7073    1.0000 </r>
+       <r>    3.2868    1.0000 </r>
+       <r>    3.9680    1.0000 </r>
+       <r>    6.2244    0.0000 </r>
+       <r>    6.8263    0.0000 </r>
+       <r>    7.3406    0.0000 </r>
+       <r>   11.0396    0.0000 </r>
+       <r>   13.5732    0.0000 </r>
+       <r>   14.3873    0.0000 </r>
+       <r>   14.9341    0.0000 </r>
+       <r>   15.1855    0.0000 </r>
+       <r>   16.9531    0.0000 </r>
+       <r>   17.0268    0.0000 </r>
+       <r>   18.0265    0.0000 </r>
+      </set>
+      <set comment="kpoint 56">
+       <r>   -7.1083    1.0000 </r>
+       <r>   -5.1280    1.0000 </r>
+       <r>    1.5564    1.0000 </r>
+       <r>    2.2675    1.0000 </r>
+       <r>    4.7058    1.0000 </r>
+       <r>    5.4604    0.0000 </r>
+       <r>    8.1894    0.0000 </r>
+       <r>    8.9303    0.0000 </r>
+       <r>   11.1282    0.0000 </r>
+       <r>   12.6005    0.0000 </r>
+       <r>   14.1969    0.0000 </r>
+       <r>   15.1821    0.0000 </r>
+       <r>   16.4108    0.0000 </r>
+       <r>   16.6358    0.0000 </r>
+       <r>   18.4542    0.0000 </r>
+       <r>   18.6680    0.0000 </r>
+      </set>
+      <set comment="kpoint 57">
+       <r>   -6.6712    1.0000 </r>
+       <r>   -5.3374    1.0000 </r>
+       <r>    0.6886    1.0000 </r>
+       <r>    1.4945    1.0000 </r>
+       <r>    4.2805    1.0000 </r>
+       <r>    6.0534    0.0000 </r>
+       <r>    9.2394    0.0000 </r>
+       <r>   10.3866    0.0000 </r>
+       <r>   11.0107    0.0000 </r>
+       <r>   11.9274    0.0000 </r>
+       <r>   14.7167    0.0000 </r>
+       <r>   15.4093    0.0000 </r>
+       <r>   16.7130    0.0000 </r>
+       <r>   17.1337    0.0000 </r>
+       <r>   18.4646    0.0000 </r>
+       <r>   19.0735    0.0000 </r>
+      </set>
+      <set comment="kpoint 58">
+       <r>   -6.9466    1.0000 </r>
+       <r>   -5.2045    1.0000 </r>
+       <r>    1.0370    1.0000 </r>
+       <r>    2.7589    1.0000 </r>
+       <r>    3.0981    1.0000 </r>
+       <r>    7.3729    0.0000 </r>
+       <r>    7.5850    0.0000 </r>
+       <r>    9.7119    0.0000 </r>
+       <r>   10.6912    0.0000 </r>
+       <r>   13.1443    0.0000 </r>
+       <r>   13.7722    0.0000 </r>
+       <r>   15.7061    0.0000 </r>
+       <r>   16.7996    0.0000 </r>
+       <r>   17.4949    0.0000 </r>
+       <r>   17.6733    0.0000 </r>
+       <r>   17.7714    0.0000 </r>
+      </set>
+      <set comment="kpoint 59">
+       <r>   -7.4369    1.0000 </r>
+       <r>   -5.1280    1.0000 </r>
+       <r>    4.1259    1.0000 </r>
+       <r>    4.3091    1.0000 </r>
+       <r>    4.3094    1.0000 </r>
+       <r>    5.4295    0.0000 </r>
+       <r>    5.4299    0.0000 </r>
+       <r>    5.9189    0.0000 </r>
+       <r>   12.3256    0.0000 </r>
+       <r>   13.8016    0.0000 </r>
+       <r>   13.8020    0.0000 </r>
+       <r>   15.0300    0.0000 </r>
+       <r>   15.4817    0.0000 </r>
+       <r>   15.4821    0.0000 </r>
+       <r>   18.4380    0.0000 </r>
+       <r>   18.4391    0.0000 </r>
+      </set>
+      <set comment="kpoint 60">
+       <r>   -7.2399    1.0000 </r>
+       <r>   -5.2329    1.0000 </r>
+       <r>    2.4284    1.0000 </r>
+       <r>    3.7468    1.0000 </r>
+       <r>    4.1400    1.0000 </r>
+       <r>    5.9563    0.0000 </r>
+       <r>    6.0860    0.0000 </r>
+       <r>    7.6572    0.0000 </r>
+       <r>   12.1521    0.0000 </r>
+       <r>   13.1257    0.0000 </r>
+       <r>   13.5749    0.0000 </r>
+       <r>   15.4183    0.0000 </r>
+       <r>   16.0190    0.0000 </r>
+       <r>   16.2167    0.0000 </r>
+       <r>   17.7879    0.0000 </r>
+       <r>   18.9386    0.0000 </r>
+      </set>
+     </set>
+    </set>
+   </array>
+  </eigenvalues>
+  <separator name="orbital magnetization" >
+   <v name="MAGDIPOLOUT">      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <dos>
+   <i name="efermi">      4.95251546 </i>
+   <total>
+    <array>
+     <dimension dim="1">gridpoints</dimension>
+     <dimension dim="2">spin</dimension>
+     <field>energy</field>
+     <field>total</field>
+     <field>integrated</field>
+     <set>
+      <set comment="spin 1">
+       <r>   -10.1718     0.0000     0.0000 </r>
+       <r>   -10.0594     0.0000     0.0000 </r>
+       <r>    -9.9471     0.0000     0.0000 </r>
+       <r>    -9.8347     0.0000     0.0000 </r>
+       <r>    -9.7223     0.0000     0.0000 </r>
+       <r>    -9.6100     0.0000     0.0000 </r>
+       <r>    -9.4976     0.0000     0.0000 </r>
+       <r>    -9.3852     0.0000     0.0000 </r>
+       <r>    -9.2729     0.0000     0.0000 </r>
+       <r>    -9.1605     0.0000     0.0000 </r>
+       <r>    -9.0481     0.0000     0.0000 </r>
+       <r>    -8.9357     0.0000     0.0000 </r>
+       <r>    -8.8234     0.0000     0.0000 </r>
+       <r>    -8.7110     0.0000     0.0000 </r>
+       <r>    -8.5986     0.0000     0.0000 </r>
+       <r>    -8.4863     0.0761     0.0034 </r>
+       <r>    -8.3739     0.1268     0.0151 </r>
+       <r>    -8.2615     0.1589     0.0311 </r>
+       <r>    -8.1491     0.1971     0.0512 </r>
+       <r>    -8.0368     0.2256     0.0749 </r>
+       <r>    -7.9244     0.2516     0.1018 </r>
+       <r>    -7.8120     0.2817     0.1317 </r>
+       <r>    -7.6997     0.3150     0.1652 </r>
+       <r>    -7.5873     0.3466     0.2024 </r>
+       <r>    -7.4749     0.3861     0.2434 </r>
+       <r>    -7.3626     0.4431     0.2896 </r>
+       <r>    -7.2502     0.5064     0.3436 </r>
+       <r>    -7.1378     0.5318     0.4014 </r>
+       <r>    -7.0254     0.5739     0.4640 </r>
+       <r>    -6.9131     0.6117     0.5301 </r>
+       <r>    -6.8007     0.7187     0.6043 </r>
+       <r>    -6.6883     1.0445     0.7002 </r>
+       <r>    -6.5760     0.8279     0.8121 </r>
+       <r>    -6.4636     0.5844     0.8909 </r>
+       <r>    -6.3512     0.4923     0.9497 </r>
+       <r>    -6.2389     0.0000     1.0000 </r>
+       <r>    -6.1265     0.0000     1.0000 </r>
+       <r>    -6.0141     0.0000     1.0000 </r>
+       <r>    -5.9017     0.0000     1.0000 </r>
+       <r>    -5.7894     0.1442     1.0051 </r>
+       <r>    -5.6770     0.4841     1.0411 </r>
+       <r>    -5.5646     0.6675     1.1079 </r>
+       <r>    -5.4523     0.6557     1.1818 </r>
+       <r>    -5.3399     0.6554     1.2549 </r>
+       <r>    -5.2275     0.6961     1.3291 </r>
+       <r>    -5.1152     0.9937     1.4270 </r>
+       <r>    -5.0028     0.6313     1.5097 </r>
+       <r>    -4.8904     0.6093     1.5789 </r>
+       <r>    -4.7780     0.5249     1.6425 </r>
+       <r>    -4.6657     0.4408     1.6966 </r>
+       <r>    -4.5533     0.3505     1.7413 </r>
+       <r>    -4.4409     0.3005     1.7775 </r>
+       <r>    -4.3286     0.2612     1.8090 </r>
+       <r>    -4.2162     0.2353     1.8368 </r>
+       <r>    -4.1038     0.2119     1.8620 </r>
+       <r>    -3.9915     0.1871     1.8844 </r>
+       <r>    -3.8791     0.1610     1.9040 </r>
+       <r>    -3.7667     0.1424     1.9209 </r>
+       <r>    -3.6543     0.1260     1.9360 </r>
+       <r>    -3.5420     0.1100     1.9493 </r>
+       <r>    -3.4296     0.0958     1.9608 </r>
+       <r>    -3.3172     0.0824     1.9708 </r>
+       <r>    -3.2049     0.0692     1.9794 </r>
+       <r>    -3.0925     0.0570     1.9864 </r>
+       <r>    -2.9801     0.0456     1.9922 </r>
+       <r>    -2.8677     0.0329     1.9967 </r>
+       <r>    -2.7554     0.0150     1.9994 </r>
+       <r>    -2.6430     0.0000     2.0000 </r>
+       <r>    -2.5306     0.0000     2.0000 </r>
+       <r>    -2.4183     0.0000     2.0000 </r>
+       <r>    -2.3059     0.0000     2.0000 </r>
+       <r>    -2.1935     0.0000     2.0000 </r>
+       <r>    -2.0812     0.0000     2.0000 </r>
+       <r>    -1.9688     0.0000     2.0000 </r>
+       <r>    -1.8564     0.0000     2.0000 </r>
+       <r>    -1.7440     0.0000     2.0000 </r>
+       <r>    -1.6317     0.0000     2.0000 </r>
+       <r>    -1.5193     0.0000     2.0000 </r>
+       <r>    -1.4069     0.0000     2.0000 </r>
+       <r>    -1.2946     0.0000     2.0000 </r>
+       <r>    -1.1822     0.0000     2.0000 </r>
+       <r>    -1.0698     0.0000     2.0000 </r>
+       <r>    -0.9575     0.0000     2.0000 </r>
+       <r>    -0.8451     0.0000     2.0000 </r>
+       <r>    -0.7327     0.0000     2.0000 </r>
+       <r>    -0.6203     0.0000     2.0000 </r>
+       <r>    -0.5080     0.0000     2.0000 </r>
+       <r>    -0.3956     0.0000     2.0000 </r>
+       <r>    -0.2832     0.0000     2.0000 </r>
+       <r>    -0.1709     0.0000     2.0000 </r>
+       <r>    -0.0585     0.0000     2.0000 </r>
+       <r>     0.0539     0.0000     2.0000 </r>
+       <r>     0.1662     0.0000     2.0000 </r>
+       <r>     0.2786     0.1193     2.0029 </r>
+       <r>     0.3910     0.1939     2.0213 </r>
+       <r>     0.5034     0.2810     2.0478 </r>
+       <r>     0.6157     0.3455     2.0829 </r>
+       <r>     0.7281     0.4682     2.1310 </r>
+       <r>     0.8405     0.4304     2.1786 </r>
+       <r>     0.9528     0.4286     2.2273 </r>
+       <r>     1.0652     0.4166     2.2745 </r>
+       <r>     1.1776     0.4390     2.3227 </r>
+       <r>     1.2899     0.4768     2.3740 </r>
+       <r>     1.4023     0.5077     2.4295 </r>
+       <r>     1.5147     0.5426     2.4884 </r>
+       <r>     1.6271     0.5864     2.5516 </r>
+       <r>     1.7394     0.6497     2.6201 </r>
+       <r>     1.8518     0.8741     2.7076 </r>
+       <r>     1.9642     0.8228     2.8043 </r>
+       <r>     2.0765     0.8300     2.8967 </r>
+       <r>     2.1889     0.8402     2.9905 </r>
+       <r>     2.3013     0.8447     3.0853 </r>
+       <r>     2.4137     0.8396     3.1801 </r>
+       <r>     2.5260     0.8301     3.2740 </r>
+       <r>     2.6384     0.8306     3.3671 </r>
+       <r>     2.7508     0.8394     3.4610 </r>
+       <r>     2.8631     0.8341     3.5551 </r>
+       <r>     2.9755     0.8411     3.6493 </r>
+       <r>     3.0879     0.8393     3.7438 </r>
+       <r>     3.2002     0.8287     3.8377 </r>
+       <r>     3.3126     0.7978     3.9292 </r>
+       <r>     3.4250     0.7686     4.0166 </r>
+       <r>     3.5374     0.8747     4.1126 </r>
+       <r>     3.6497     0.9051     4.2134 </r>
+       <r>     3.7621     0.9495     4.3178 </r>
+       <r>     3.8745     0.8241     4.4172 </r>
+       <r>     3.9868     0.8055     4.5076 </r>
+       <r>     4.0992     0.9163     4.6026 </r>
+       <r>     4.2116     0.9199     4.7080 </r>
+       <r>     4.3239     0.7992     4.8120 </r>
+       <r>     4.4363     0.6294     4.8933 </r>
+       <r>     4.5487     0.4234     4.9534 </r>
+       <r>     4.6611     0.1983     4.9891 </r>
+       <r>     4.7734     0.0241     4.9991 </r>
+       <r>     4.8858     0.0004     5.0000 </r>
+       <r>     4.9982     0.0002     5.0000 </r>
+       <r>     5.1105     0.0058     5.0003 </r>
+       <r>     5.2229     0.0192     5.0016 </r>
+       <r>     5.3353     0.0406     5.0049 </r>
+       <r>     5.4476     0.0697     5.0110 </r>
+       <r>     5.5600     0.1412     5.0220 </r>
+       <r>     5.6724     0.3617     5.0486 </r>
+       <r>     5.7848     0.5430     5.1010 </r>
+       <r>     5.8971     0.9260     5.1834 </r>
+       <r>     6.0095     0.7759     5.2787 </r>
+       <r>     6.1219     0.8752     5.3708 </r>
+       <r>     6.2342     0.7814     5.4663 </r>
+       <r>     6.3466     0.7765     5.5543 </r>
+       <r>     6.4590     0.7144     5.6377 </r>
+       <r>     6.5713     0.6724     5.7155 </r>
+       <r>     6.6837     0.6449     5.7894 </r>
+       <r>     6.7961     0.6274     5.8608 </r>
+       <r>     6.9085     0.6180     5.9309 </r>
+       <r>     7.0208     0.6099     5.9998 </r>
+       <r>     7.1332     0.6128     6.0684 </r>
+       <r>     7.2456     0.6228     6.1378 </r>
+       <r>     7.3579     0.6414     6.2087 </r>
+       <r>     7.4703     0.6671     6.2822 </r>
+       <r>     7.5827     0.6831     6.3581 </r>
+       <r>     7.6951     0.7345     6.4372 </r>
+       <r>     7.8074     0.8744     6.5254 </r>
+       <r>     7.9198     0.8240     6.6269 </r>
+       <r>     8.0322     0.5766     6.7051 </r>
+       <r>     8.1445     0.6518     6.7723 </r>
+       <r>     8.2569     0.5940     6.8444 </r>
+       <r>     8.3693     0.6211     6.9126 </r>
+       <r>     8.4816     0.6164     6.9832 </r>
+       <r>     8.5940     0.6179     7.0520 </r>
+       <r>     8.7064     0.5854     7.1216 </r>
+       <r>     8.8188     0.6267     7.1894 </r>
+       <r>     8.9311     0.6624     7.2624 </r>
+       <r>     9.0435     0.6676     7.3371 </r>
+       <r>     9.1559     0.7310     7.4166 </r>
+       <r>     9.2682     0.5628     7.4863 </r>
+       <r>     9.3806     0.5039     7.5462 </r>
+       <r>     9.4930     0.4574     7.6001 </r>
+       <r>     9.6053     0.4178     7.6492 </r>
+       <r>     9.7177     0.3832     7.6941 </r>
+       <r>     9.8301     0.3557     7.7359 </r>
+       <r>     9.9425     0.4630     7.7772 </r>
+       <r>    10.0548     0.7296     7.8441 </r>
+       <r>    10.1672     0.8705     7.9326 </r>
+       <r>    10.2796     0.9929     8.0356 </r>
+       <r>    10.3919     1.0123     8.1507 </r>
+       <r>    10.5043     0.8721     8.2601 </r>
+       <r>    10.6167     0.6508     8.3438 </r>
+       <r>    10.7290     0.5813     8.4117 </r>
+       <r>    10.8414     0.6188     8.4784 </r>
+       <r>    10.9538     0.7327     8.5536 </r>
+       <r>    11.0662     1.0066     8.6574 </r>
+       <r>    11.1785     0.5224     8.7401 </r>
+       <r>    11.2909     0.5276     8.7987 </r>
+       <r>    11.4033     0.4821     8.8544 </r>
+       <r>    11.5156     0.4726     8.9083 </r>
+       <r>    11.6280     0.4125     8.9575 </r>
+       <r>    11.7404     0.3382     9.0010 </r>
+       <r>    11.8527     0.2990     9.0362 </r>
+       <r>    11.9651     0.4397     9.0730 </r>
+       <r>    12.0775     0.4981     9.1236 </r>
+       <r>    12.1899     0.5584     9.1825 </r>
+       <r>    12.3022     0.5944     9.2465 </r>
+       <r>    12.4146     0.6611     9.3178 </r>
+       <r>    12.5270     0.6632     9.3929 </r>
+       <r>    12.6393     0.6588     9.4670 </r>
+       <r>    12.7517     0.6586     9.5410 </r>
+       <r>    12.8641     0.6571     9.6148 </r>
+       <r>    12.9765     0.6592     9.6888 </r>
+       <r>    13.0888     0.6620     9.7630 </r>
+       <r>    13.2012     0.6648     9.8375 </r>
+       <r>    13.3136     0.6691     9.9125 </r>
+       <r>    13.4259     0.6777     9.9880 </r>
+       <r>    13.5383     0.6925    10.0650 </r>
+       <r>    13.6507     0.7937    10.1466 </r>
+       <r>    13.7630     0.8869    10.2405 </r>
+       <r>    13.8754     1.2519    10.3640 </r>
+       <r>    13.9878     1.0702    10.4909 </r>
+       <r>    14.1002     0.9831    10.6063 </r>
+       <r>    14.2125     0.9483    10.7144 </r>
+       <r>    14.3249     0.8840    10.8178 </r>
+       <r>    14.4373     0.8425    10.9142 </r>
+       <r>    14.5496     0.8434    11.0086 </r>
+       <r>    14.6620     0.8705    11.1050 </r>
+       <r>    14.7744     0.9529    11.2066 </r>
+       <r>    14.8867     1.1241    11.3224 </r>
+       <r>    14.9991     1.2127    11.4527 </r>
+       <r>    15.1115     1.2404    11.5924 </r>
+       <r>    15.2239     1.2507    11.7317 </r>
+       <r>    15.3362     1.2863    11.8747 </r>
+       <r>    15.4486     1.1114    12.0107 </r>
+       <r>    15.5610     1.0209    12.1319 </r>
+       <r>    15.6733     0.9930    12.2433 </r>
+       <r>    15.7857     1.1231    12.3616 </r>
+       <r>    15.8981     1.2129    12.4938 </r>
+       <r>    16.0104     1.1674    12.6260 </r>
+       <r>    16.1228     0.7516    12.7333 </r>
+       <r>    16.2352     0.7305    12.8155 </r>
+       <r>    16.3476     0.7558    12.8990 </r>
+       <r>    16.4599     0.7589    12.9839 </r>
+       <r>    16.5723     1.1526    13.0963 </r>
+       <r>    16.6847     1.0689    13.2207 </r>
+       <r>    16.7970     0.9150    13.3332 </r>
+       <r>    16.9094     1.0577    13.4412 </r>
+       <r>    17.0218     1.1500    13.5669 </r>
+       <r>    17.1341     1.0419    13.6939 </r>
+       <r>    17.2465     1.1784    13.8100 </r>
+       <r>    17.3589     0.9855    13.9205 </r>
+       <r>    17.4713     1.0200    14.0326 </r>
+       <r>    17.5836     1.1251    14.1525 </r>
+       <r>    17.6960     1.0631    14.2796 </r>
+       <r>    17.8084     1.0426    14.3917 </r>
+       <r>    17.9207     1.1086    14.5100 </r>
+       <r>    18.0331     1.2086    14.6420 </r>
+       <r>    18.1455     1.1799    14.7768 </r>
+       <r>    18.2579     1.1149    14.9058 </r>
+       <r>    18.3702     1.1323    15.0308 </r>
+       <r>    18.4826     1.1834    15.1609 </r>
+       <r>    18.5950     1.2120    15.2974 </r>
+       <r>    18.7073     1.2265    15.4363 </r>
+       <r>    18.8197     0.8556    15.5547 </r>
+       <r>    18.9321     0.7703    15.6415 </r>
+       <r>    19.0444     0.6521    15.7254 </r>
+       <r>    19.1568     0.5888    15.7938 </r>
+       <r>    19.2692     0.4710    15.8550 </r>
+       <r>    19.3816     0.3219    15.8979 </r>
+       <r>    19.4939     0.2245    15.9288 </r>
+       <r>    19.6063     0.0961    15.9467 </r>
+       <r>    19.7187     0.0710    15.9559 </r>
+       <r>    19.8310     0.0532    15.9628 </r>
+       <r>    19.9434     0.0383    15.9680 </r>
+       <r>    20.0558     0.0262    15.9715 </r>
+       <r>    20.1681     0.0245    15.9744 </r>
+       <r>    20.2805     0.0229    15.9771 </r>
+       <r>    20.3929     0.0213    15.9795 </r>
+       <r>    20.5053     0.0197    15.9818 </r>
+       <r>    20.6176     0.0183    15.9840 </r>
+       <r>    20.7300     0.0168    15.9859 </r>
+       <r>    20.8424     0.0154    15.9878 </r>
+       <r>    20.9547     0.0141    15.9894 </r>
+       <r>    21.0671     0.0128    15.9909 </r>
+       <r>    21.1795     0.0116    15.9923 </r>
+       <r>    21.2918     0.0104    15.9935 </r>
+       <r>    21.4042     0.0093    15.9946 </r>
+       <r>    21.5166     0.0082    15.9956 </r>
+       <r>    21.6290     0.0072    15.9965 </r>
+       <r>    21.7413     0.0063    15.9973 </r>
+       <r>    21.8537     0.0135    15.9981 </r>
+       <r>    21.9661     0.0103    15.9998 </r>
+       <r>    22.0784     0.0000    16.0000 </r>
+       <r>    22.1908     0.0000    16.0000 </r>
+       <r>    22.3032     0.0000    16.0000 </r>
+       <r>    22.4156     0.0000    16.0000 </r>
+       <r>    22.5279     0.0000    16.0000 </r>
+       <r>    22.6403     0.0000    16.0000 </r>
+       <r>    22.7527     0.0000    16.0000 </r>
+       <r>    22.8650     0.0000    16.0000 </r>
+       <r>    22.9774     0.0000    16.0000 </r>
+       <r>    23.0898     0.0000    16.0000 </r>
+       <r>    23.2021     0.0000    16.0000 </r>
+       <r>    23.3145     0.0000    16.0000 </r>
+       <r>    23.4269     0.0000    16.0000 </r>
+       <r>    23.5393     0.0000    16.0000 </r>
+      </set>
+      <set comment="spin 2">
+       <r>   -10.1718     0.0000     0.0000 </r>
+       <r>   -10.0594     0.0000     0.0000 </r>
+       <r>    -9.9471     0.0000     0.0000 </r>
+       <r>    -9.8347     0.0000     0.0000 </r>
+       <r>    -9.7223     0.0000     0.0000 </r>
+       <r>    -9.6100     0.0000     0.0000 </r>
+       <r>    -9.4976     0.0000     0.0000 </r>
+       <r>    -9.3852     0.0000     0.0000 </r>
+       <r>    -9.2729     0.0000     0.0000 </r>
+       <r>    -9.1605     0.0000     0.0000 </r>
+       <r>    -9.0481     0.0000     0.0000 </r>
+       <r>    -8.9357     0.0000     0.0000 </r>
+       <r>    -8.8234     0.0000     0.0000 </r>
+       <r>    -8.7110     0.0000     0.0000 </r>
+       <r>    -8.5986     0.0375     0.0008 </r>
+       <r>    -8.4863     0.1075     0.0097 </r>
+       <r>    -8.3739     0.1435     0.0241 </r>
+       <r>    -8.2615     0.1807     0.0423 </r>
+       <r>    -8.1491     0.2127     0.0645 </r>
+       <r>    -8.0368     0.2399     0.0900 </r>
+       <r>    -7.9244     0.2667     0.1184 </r>
+       <r>    -7.8120     0.2987     0.1501 </r>
+       <r>    -7.6997     0.3315     0.1856 </r>
+       <r>    -7.5873     0.3640     0.2245 </r>
+       <r>    -7.4749     0.4102     0.2680 </r>
+       <r>    -7.3626     0.4831     0.3180 </r>
+       <r>    -7.2502     0.5061     0.3743 </r>
+       <r>    -7.1378     0.5546     0.4337 </r>
+       <r>    -7.0254     0.5799     0.4975 </r>
+       <r>    -6.9131     0.6509     0.5660 </r>
+       <r>    -6.8007     0.8323     0.6469 </r>
+       <r>    -6.6883     1.0254     0.7582 </r>
+       <r>    -6.5760     0.7027     0.8526 </r>
+       <r>    -6.4636     0.5146     0.9195 </r>
+       <r>    -6.3512     0.8776     0.9800 </r>
+       <r>    -6.2389     0.0000     1.0000 </r>
+       <r>    -6.1265     0.0000     1.0000 </r>
+       <r>    -6.0141     0.0000     1.0000 </r>
+       <r>    -5.9017     0.0333     1.0006 </r>
+       <r>    -5.7894     0.3274     1.0184 </r>
+       <r>    -5.6770     0.5818     1.0710 </r>
+       <r>    -5.5646     0.6481     1.1431 </r>
+       <r>    -5.4523     0.6399     1.2151 </r>
+       <r>    -5.3399     0.6374     1.2874 </r>
+       <r>    -5.2275     0.7514     1.3635 </r>
+       <r>    -5.1152     0.7122     1.4649 </r>
+       <r>    -5.0028     0.6049     1.5371 </r>
+       <r>    -4.8904     0.5689     1.6049 </r>
+       <r>    -4.7780     0.4882     1.6644 </r>
+       <r>    -4.6657     0.4093     1.7148 </r>
+       <r>    -4.5533     0.3242     1.7555 </r>
+       <r>    -4.4409     0.2836     1.7896 </r>
+       <r>    -4.3286     0.2489     1.8194 </r>
+       <r>    -4.2162     0.2252     1.8460 </r>
+       <r>    -4.1038     0.2026     1.8700 </r>
+       <r>    -3.9915     0.1767     1.8914 </r>
+       <r>    -3.8791     0.1525     1.9098 </r>
+       <r>    -3.7667     0.1361     1.9260 </r>
+       <r>    -3.6543     0.1198     1.9404 </r>
+       <r>    -3.5420     0.1044     1.9530 </r>
+       <r>    -3.4296     0.0909     1.9640 </r>
+       <r>    -3.3172     0.0779     1.9734 </r>
+       <r>    -3.2049     0.0651     1.9815 </r>
+       <r>    -3.0925     0.0533     1.9881 </r>
+       <r>    -2.9801     0.0423     1.9935 </r>
+       <r>    -2.8677     0.0285     1.9975 </r>
+       <r>    -2.7554     0.0102     1.9997 </r>
+       <r>    -2.6430     0.0000     2.0000 </r>
+       <r>    -2.5306     0.0000     2.0000 </r>
+       <r>    -2.4183     0.0000     2.0000 </r>
+       <r>    -2.3059     0.0000     2.0000 </r>
+       <r>    -2.1935     0.0000     2.0000 </r>
+       <r>    -2.0812     0.0000     2.0000 </r>
+       <r>    -1.9688     0.0000     2.0000 </r>
+       <r>    -1.8564     0.0000     2.0000 </r>
+       <r>    -1.7440     0.0000     2.0000 </r>
+       <r>    -1.6317     0.0000     2.0000 </r>
+       <r>    -1.5193     0.0000     2.0000 </r>
+       <r>    -1.4069     0.0000     2.0000 </r>
+       <r>    -1.2946     0.0000     2.0000 </r>
+       <r>    -1.1822     0.0000     2.0000 </r>
+       <r>    -1.0698     0.0000     2.0000 </r>
+       <r>    -0.9575     0.0000     2.0000 </r>
+       <r>    -0.8451     0.0000     2.0000 </r>
+       <r>    -0.7327     0.0000     2.0000 </r>
+       <r>    -0.6203     0.0000     2.0000 </r>
+       <r>    -0.5080     0.0000     2.0000 </r>
+       <r>    -0.3956     0.0000     2.0000 </r>
+       <r>    -0.2832     0.0000     2.0000 </r>
+       <r>    -0.1709     0.0000     2.0000 </r>
+       <r>    -0.0585     0.0000     2.0000 </r>
+       <r>     0.0539     0.0000     2.0000 </r>
+       <r>     0.1662     0.1070     2.0017 </r>
+       <r>     0.2786     0.1956     2.0185 </r>
+       <r>     0.3910     0.2646     2.0442 </r>
+       <r>     0.5034     0.3416     2.0779 </r>
+       <r>     0.6157     0.4577     2.1223 </r>
+       <r>     0.7281     0.4202     2.1757 </r>
+       <r>     0.8405     0.4107     2.2213 </r>
+       <r>     0.9528     0.4124     2.2677 </r>
+       <r>     1.0652     0.4297     2.3147 </r>
+       <r>     1.1776     0.4506     2.3641 </r>
+       <r>     1.2899     0.4903     2.4169 </r>
+       <r>     1.4023     0.5374     2.4745 </r>
+       <r>     1.5147     0.5780     2.5376 </r>
+       <r>     1.6271     0.6381     2.6057 </r>
+       <r>     1.7394     0.8358     2.6878 </r>
+       <r>     1.8518     0.9100     2.7883 </r>
+       <r>     1.9642     0.8095     2.8816 </r>
+       <r>     2.0765     0.8021     2.9721 </r>
+       <r>     2.1889     0.8136     3.0624 </r>
+       <r>     2.3013     0.8345     3.1552 </r>
+       <r>     2.4137     0.8233     3.2486 </r>
+       <r>     2.5260     0.8236     3.3413 </r>
+       <r>     2.6384     0.8255     3.4338 </r>
+       <r>     2.7508     0.8285     3.5268 </r>
+       <r>     2.8631     0.8346     3.6203 </r>
+       <r>     2.9755     0.8282     3.7140 </r>
+       <r>     3.0879     0.7966     3.8055 </r>
+       <r>     3.2002     0.7737     3.8938 </r>
+       <r>     3.3126     0.7432     3.9787 </r>
+       <r>     3.4250     0.8902     4.0669 </r>
+       <r>     3.5374     0.8802     4.1669 </r>
+       <r>     3.6497     0.9268     4.2683 </r>
+       <r>     3.7621     0.8372     4.3697 </r>
+       <r>     3.8745     0.7194     4.4539 </r>
+       <r>     3.9868     0.7841     4.5375 </r>
+       <r>     4.0992     0.9935     4.6361 </r>
+       <r>     4.2116     1.0339     4.7535 </r>
+       <r>     4.3239     0.8312     4.8601 </r>
+       <r>     4.4363     0.5451     4.9349 </r>
+       <r>     4.5487     0.2634     4.9805 </r>
+       <r>     4.6611     0.0573     4.9970 </r>
+       <r>     4.7734     0.0073     4.9997 </r>
+       <r>     4.8858     0.0000     5.0000 </r>
+       <r>     4.9982     0.0000     5.0000 </r>
+       <r>     5.1105     0.0005     5.0000 </r>
+       <r>     5.2229     0.0128     5.0006 </r>
+       <r>     5.3353     0.0418     5.0035 </r>
+       <r>     5.4476     0.0893     5.0106 </r>
+       <r>     5.5600     0.4221     5.0360 </r>
+       <r>     5.6724     0.5025     5.0913 </r>
+       <r>     5.7848     0.8132     5.1652 </r>
+       <r>     5.8971     0.8290     5.2603 </r>
+       <r>     6.0095     1.0085     5.3599 </r>
+       <r>     6.1219     0.7984     5.4590 </r>
+       <r>     6.2342     0.7578     5.5442 </r>
+       <r>     6.3466     0.7151     5.6273 </r>
+       <r>     6.4590     0.6731     5.7052 </r>
+       <r>     6.5713     0.6429     5.7790 </r>
+       <r>     6.6837     0.6224     5.8501 </r>
+       <r>     6.7961     0.6093     5.9191 </r>
+       <r>     6.9085     0.6056     5.9872 </r>
+       <r>     7.0208     0.6086     6.0554 </r>
+       <r>     7.1332     0.6260     6.1245 </r>
+       <r>     7.2456     0.6416     6.1957 </r>
+       <r>     7.3579     0.6634     6.2690 </r>
+       <r>     7.4703     0.6892     6.3450 </r>
+       <r>     7.5827     0.7441     6.4253 </r>
+       <r>     7.6951     1.1452     6.5148 </r>
+       <r>     7.8074     0.9178     6.6264 </r>
+       <r>     7.9198     0.6414     6.7146 </r>
+       <r>     8.0322     0.5858     6.7816 </r>
+       <r>     8.1445     0.5840     6.8470 </r>
+       <r>     8.2569     0.5983     6.9136 </r>
+       <r>     8.3693     0.5941     6.9808 </r>
+       <r>     8.4816     0.6087     7.0482 </r>
+       <r>     8.5940     0.5732     7.1159 </r>
+       <r>     8.7064     0.5985     7.1812 </r>
+       <r>     8.8188     0.6494     7.2514 </r>
+       <r>     8.9311     0.6699     7.3253 </r>
+       <r>     9.0435     0.7125     7.4016 </r>
+       <r>     9.1559     0.5729     7.4737 </r>
+       <r>     9.2682     0.5062     7.5341 </r>
+       <r>     9.3806     0.4535     7.5879 </r>
+       <r>     9.4930     0.4100     7.6363 </r>
+       <r>     9.6053     0.3752     7.6804 </r>
+       <r>     9.7177     0.3364     7.7205 </r>
+       <r>     9.8301     0.2966     7.7556 </r>
+       <r>     9.9425     0.4862     7.7975 </r>
+       <r>    10.0548     0.7827     7.8676 </r>
+       <r>    10.1672     0.9597     7.9645 </r>
+       <r>    10.2796     1.0002     8.0757 </r>
+       <r>    10.3919     1.0081     8.1884 </r>
+       <r>    10.5043     0.8185     8.2936 </r>
+       <r>    10.6167     0.6476     8.3744 </r>
+       <r>    10.7290     0.6054     8.4430 </r>
+       <r>    10.8414     0.6810     8.5147 </r>
+       <r>    10.9538     0.8860     8.5994 </r>
+       <r>    11.0662     0.6754     8.7135 </r>
+       <r>    11.1785     0.4971     8.7776 </r>
+       <r>    11.2909     0.5010     8.8405 </r>
+       <r>    11.4033     0.4922     8.8965 </r>
+       <r>    11.5156     0.4093     8.9465 </r>
+       <r>    11.6280     0.3528     8.9896 </r>
+       <r>    11.7404     0.3216     9.0267 </r>
+       <r>    11.8527     0.3195     9.0627 </r>
+       <r>    11.9651     0.3697     9.1017 </r>
+       <r>    12.0775     0.4956     9.1508 </r>
+       <r>    12.1899     0.5647     9.2097 </r>
+       <r>    12.3022     0.6226     9.2767 </r>
+       <r>    12.4146     0.6891     9.3502 </r>
+       <r>    12.5270     0.6800     9.4272 </r>
+       <r>    12.6393     0.6770     9.5033 </r>
+       <r>    12.7517     0.6858     9.5798 </r>
+       <r>    12.8641     0.6855     9.6568 </r>
+       <r>    12.9765     0.6868     9.7339 </r>
+       <r>    13.0888     0.6874     9.8112 </r>
+       <r>    13.2012     0.6859     9.8883 </r>
+       <r>    13.3136     0.6866     9.9653 </r>
+       <r>    13.4259     0.6959    10.0429 </r>
+       <r>    13.5383     0.7444    10.1241 </r>
+       <r>    13.6507     0.8627    10.2114 </r>
+       <r>    13.7630     1.0773    10.3201 </r>
+       <r>    13.8754     1.1047    10.4468 </r>
+       <r>    13.9878     1.0138    10.5669 </r>
+       <r>    14.1002     0.9602    10.6767 </r>
+       <r>    14.2125     0.9181    10.7826 </r>
+       <r>    14.3249     0.8596    10.8821 </r>
+       <r>    14.4373     0.8717    10.9788 </r>
+       <r>    14.5496     0.8840    11.0779 </r>
+       <r>    14.6620     0.9130    11.1783 </r>
+       <r>    14.7744     1.0816    11.2902 </r>
+       <r>    14.8867     1.1248    11.4138 </r>
+       <r>    14.9991     1.2962    11.5498 </r>
+       <r>    15.1115     1.1877    11.6867 </r>
+       <r>    15.2239     1.2606    11.8232 </r>
+       <r>    15.3362     1.1509    11.9602 </r>
+       <r>    15.4486     1.0659    12.0865 </r>
+       <r>    15.5610     1.0020    12.2016 </r>
+       <r>    15.6733     1.0771    12.3179 </r>
+       <r>    15.7857     1.2391    12.4474 </r>
+       <r>    15.8981     1.1928    12.5862 </r>
+       <r>    16.0104     0.7332    12.7036 </r>
+       <r>    16.1228     0.7646    12.7821 </r>
+       <r>    16.2352     0.7599    12.8671 </r>
+       <r>    16.3476     0.7743    12.9534 </r>
+       <r>    16.4599     1.2384    13.0465 </r>
+       <r>    16.5723     1.1099    13.1841 </r>
+       <r>    16.6847     0.9654    13.3016 </r>
+       <r>    16.7970     0.9674    13.4056 </r>
+       <r>    16.9094     1.1545    13.5247 </r>
+       <r>    17.0218     1.1624    13.6557 </r>
+       <r>    17.1341     1.2581    13.7857 </r>
+       <r>    17.2465     1.1023    13.9074 </r>
+       <r>    17.3589     1.1900    14.0384 </r>
+       <r>    17.4713     1.1226    14.1689 </r>
+       <r>    17.5836     1.0445    14.2930 </r>
+       <r>    17.6960     0.8463    14.3940 </r>
+       <r>    17.8084     1.0475    14.5020 </r>
+       <r>    17.9207     1.2053    14.6276 </r>
+       <r>    18.0331     1.3179    14.7723 </r>
+       <r>    18.1455     1.2312    14.9161 </r>
+       <r>    18.2579     1.2008    15.0522 </r>
+       <r>    18.3702     1.2473    15.1900 </r>
+       <r>    18.4826     1.2391    15.3336 </r>
+       <r>    18.5950     1.1075    15.4669 </r>
+       <r>    18.7073     0.8827    15.5754 </r>
+       <r>    18.8197     0.6948    15.6660 </r>
+       <r>    18.9321     0.7258    15.7490 </r>
+       <r>    19.0444     0.5276    15.8180 </r>
+       <r>    19.1568     0.3923    15.8691 </r>
+       <r>    19.2692     0.3036    15.9078 </r>
+       <r>    19.3816     0.1742    15.9360 </r>
+       <r>    19.4939     0.0879    15.9488 </r>
+       <r>    19.6063     0.0670    15.9575 </r>
+       <r>    19.7187     0.0492    15.9640 </r>
+       <r>    19.8310     0.0346    15.9687 </r>
+       <r>    19.9434     0.0261    15.9719 </r>
+       <r>    20.0558     0.0244    15.9748 </r>
+       <r>    20.1681     0.0228    15.9774 </r>
+       <r>    20.2805     0.0212    15.9799 </r>
+       <r>    20.3929     0.0197    15.9822 </r>
+       <r>    20.5053     0.0182    15.9843 </r>
+       <r>    20.6176     0.0168    15.9863 </r>
+       <r>    20.7300     0.0154    15.9881 </r>
+       <r>    20.8424     0.0141    15.9898 </r>
+       <r>    20.9547     0.0128    15.9913 </r>
+       <r>    21.0671     0.0116    15.9926 </r>
+       <r>    21.1795     0.0104    15.9939 </r>
+       <r>    21.2918     0.0093    15.9950 </r>
+       <r>    21.4042     0.0082    15.9959 </r>
+       <r>    21.5166     0.0071    15.9968 </r>
+       <r>    21.6290     0.0075    15.9976 </r>
+       <r>    21.7413     0.0123    15.9988 </r>
+       <r>    21.8537     0.0054    15.9999 </r>
+       <r>    21.9661     0.0000    16.0000 </r>
+       <r>    22.0784     0.0000    16.0000 </r>
+       <r>    22.1908     0.0000    16.0000 </r>
+       <r>    22.3032     0.0000    16.0000 </r>
+       <r>    22.4156     0.0000    16.0000 </r>
+       <r>    22.5279     0.0000    16.0000 </r>
+       <r>    22.6403     0.0000    16.0000 </r>
+       <r>    22.7527     0.0000    16.0000 </r>
+       <r>    22.8650     0.0000    16.0000 </r>
+       <r>    22.9774     0.0000    16.0000 </r>
+       <r>    23.0898     0.0000    16.0000 </r>
+       <r>    23.2021     0.0000    16.0000 </r>
+       <r>    23.3145     0.0000    16.0000 </r>
+       <r>    23.4269     0.0000    16.0000 </r>
+       <r>    23.5393     0.0000    16.0000 </r>
+      </set>
+     </set>
+    </array>
+   </total>
+   <partial>
+    <array>
+     <dimension dim="1">gridpoints</dimension>
+     <dimension dim="2">spin</dimension>
+     <dimension dim="3">ion</dimension>
+     <field>energy</field>
+     <field>    s</field>
+     <field>   py</field>
+     <field>   pz</field>
+     <field>   px</field>
+     <field>  dxy</field>
+     <field>  dyz</field>
+     <field>  dz2</field>
+     <field>  dxz</field>
+     <field>x2-y2</field>
+     <set>
+      <set comment="ion 1">
+       <set comment="spin 1">
+        <r>   -10.1718     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>   -10.0594     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.9471     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.8347     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.7223     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.6100     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.4976     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.3852     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.2729     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.1605     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.0481     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.9357     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.8234     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.7110     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.5986     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.4863     0.0296     0.0000     0.0001     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.3739     0.0493     0.0002     0.0002     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.2615     0.0618     0.0003     0.0003     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.1491     0.0767     0.0004     0.0005     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.0368     0.0878     0.0006     0.0006     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.9244     0.0980     0.0008     0.0007     0.0014     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.8120     0.1098     0.0009     0.0008     0.0018     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.6997     0.1230     0.0011     0.0010     0.0022     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.5873     0.1355     0.0012     0.0012     0.0026     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.4749     0.1514     0.0015     0.0014     0.0031     0.0002     0.0001     0.0000     0.0000     0.0000 </r>
+        <r>    -7.3626     0.1744     0.0018     0.0019     0.0036     0.0002     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>    -7.2502     0.2000     0.0021     0.0025     0.0040     0.0003     0.0001     0.0001     0.0001     0.0001 </r>
+        <r>    -7.1378     0.2105     0.0022     0.0025     0.0044     0.0004     0.0001     0.0001     0.0001     0.0001 </r>
+        <r>    -7.0254     0.2279     0.0023     0.0027     0.0048     0.0005     0.0001     0.0001     0.0001     0.0001 </r>
+        <r>    -6.9131     0.2438     0.0025     0.0026     0.0054     0.0006     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -6.8007     0.2877     0.0029     0.0029     0.0064     0.0008     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -6.6883     0.4200     0.0045     0.0039     0.0087     0.0014     0.0003     0.0004     0.0002     0.0002 </r>
+        <r>    -6.5760     0.3340     0.0037     0.0032     0.0068     0.0011     0.0003     0.0003     0.0002     0.0002 </r>
+        <r>    -6.4636     0.2359     0.0034     0.0020     0.0045     0.0008     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -6.3512     0.1992     0.0033     0.0015     0.0033     0.0008     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -6.2389     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.1265     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.0141     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.9017     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.7894     0.0578     0.0020     0.0002     0.0011     0.0002     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>    -5.6770     0.1939     0.0057     0.0006     0.0047     0.0005     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -5.5646     0.2694     0.0060     0.0010     0.0070     0.0009     0.0004     0.0003     0.0001     0.0001 </r>
+        <r>    -5.4523     0.2655     0.0050     0.0013     0.0070     0.0009     0.0004     0.0003     0.0002     0.0001 </r>
+        <r>    -5.3399     0.2664     0.0045     0.0016     0.0066     0.0010     0.0004     0.0003     0.0002     0.0001 </r>
+        <r>    -5.2275     0.2834     0.0041     0.0025     0.0066     0.0010     0.0004     0.0003     0.0002     0.0001 </r>
+        <r>    -5.1152     0.4002     0.0042     0.0076     0.0081     0.0013     0.0004     0.0004     0.0002     0.0002 </r>
+        <r>    -5.0028     0.2580     0.0036     0.0035     0.0056     0.0010     0.0002     0.0003     0.0001     0.0001 </r>
+        <r>    -4.8904     0.2513     0.0033     0.0029     0.0055     0.0011     0.0002     0.0003     0.0001     0.0002 </r>
+        <r>    -4.7780     0.2170     0.0029     0.0024     0.0050     0.0009     0.0002     0.0003     0.0001     0.0001 </r>
+        <r>    -4.6657     0.1824     0.0025     0.0020     0.0044     0.0007     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -4.5533     0.1456     0.0022     0.0014     0.0037     0.0005     0.0001     0.0001     0.0001     0.0001 </r>
+        <r>    -4.4409     0.1253     0.0019     0.0012     0.0033     0.0004     0.0001     0.0001     0.0000     0.0001 </r>
+        <r>    -4.3286     0.1094     0.0015     0.0011     0.0030     0.0003     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>    -4.2162     0.0988     0.0014     0.0009     0.0027     0.0002     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>    -4.1038     0.0892     0.0013     0.0008     0.0024     0.0002     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>    -3.9915     0.0792     0.0013     0.0007     0.0021     0.0001     0.0001     0.0000     0.0000     0.0000 </r>
+        <r>    -3.8791     0.0686     0.0011     0.0006     0.0017     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.7667     0.0610     0.0009     0.0005     0.0015     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.6543     0.0543     0.0007     0.0004     0.0014     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.5420     0.0477     0.0005     0.0004     0.0012     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.4296     0.0418     0.0005     0.0003     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.3172     0.0362     0.0004     0.0003     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.2049     0.0307     0.0003     0.0002     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.0925     0.0255     0.0002     0.0002     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.9801     0.0206     0.0001     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.8677     0.0150     0.0001     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.7554     0.0069     0.0000     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.6430     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.5306     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.4183     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.3059     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.1935     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.0812     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.9688     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.8564     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.7440     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.6317     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.5193     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.4069     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.2946     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.1822     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.0698     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.9575     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.8451     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.7327     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.6203     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.5080     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.3956     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.2832     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.1709     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.0585     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.0539     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.1662     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.2786     0.0009     0.0108     0.0007     0.0219     0.0001     0.0000     0.0001     0.0000     0.0000 </r>
+        <r>     0.3910     0.0013     0.0174     0.0024     0.0350     0.0002     0.0001     0.0002     0.0001     0.0001 </r>
+        <r>     0.5034     0.0016     0.0253     0.0062     0.0485     0.0003     0.0001     0.0003     0.0002     0.0002 </r>
+        <r>     0.6157     0.0018     0.0312     0.0112     0.0566     0.0005     0.0002     0.0004     0.0002     0.0002 </r>
+        <r>     0.7281     0.0023     0.0421     0.0232     0.0700     0.0008     0.0003     0.0006     0.0003     0.0003 </r>
+        <r>     0.8405     0.0023     0.0389     0.0230     0.0628     0.0008     0.0003     0.0006     0.0003     0.0004 </r>
+        <r>     0.9528     0.0026     0.0383     0.0264     0.0598     0.0009     0.0004     0.0006     0.0003     0.0004 </r>
+        <r>     1.0652     0.0028     0.0369     0.0281     0.0564     0.0010     0.0004     0.0006     0.0003     0.0004 </r>
+        <r>     1.1776     0.0031     0.0393     0.0323     0.0568     0.0010     0.0005     0.0007     0.0003     0.0005 </r>
+        <r>     1.2899     0.0035     0.0432     0.0381     0.0589     0.0012     0.0006     0.0008     0.0003     0.0005 </r>
+        <r>     1.4023     0.0039     0.0466     0.0432     0.0601     0.0013     0.0006     0.0009     0.0004     0.0005 </r>
+        <r>     1.5147     0.0044     0.0505     0.0492     0.0611     0.0013     0.0007     0.0010     0.0004     0.0006 </r>
+        <r>     1.6271     0.0048     0.0556     0.0559     0.0633     0.0014     0.0009     0.0011     0.0005     0.0006 </r>
+        <r>     1.7394     0.0053     0.0630     0.0652     0.0671     0.0015     0.0010     0.0013     0.0006     0.0007 </r>
+        <r>     1.8518     0.0066     0.0829     0.1054     0.0774     0.0016     0.0014     0.0018     0.0008     0.0009 </r>
+        <r>     1.9642     0.0069     0.0810     0.0933     0.0759     0.0017     0.0014     0.0017     0.0009     0.0009 </r>
+        <r>     2.0765     0.0073     0.0896     0.0856     0.0786     0.0018     0.0015     0.0017     0.0009     0.0010 </r>
+        <r>     2.1889     0.0077     0.0958     0.0827     0.0796     0.0019     0.0016     0.0017     0.0010     0.0011 </r>
+        <r>     2.3013     0.0083     0.0974     0.0839     0.0789     0.0020     0.0017     0.0018     0.0011     0.0012 </r>
+        <r>     2.4137     0.0088     0.0961     0.0850     0.0778     0.0020     0.0018     0.0019     0.0011     0.0012 </r>
+        <r>     2.5260     0.0093     0.0943     0.0866     0.0754     0.0021     0.0019     0.0019     0.0012     0.0013 </r>
+        <r>     2.6384     0.0097     0.0956     0.0894     0.0727     0.0021     0.0020     0.0019     0.0013     0.0014 </r>
+        <r>     2.7508     0.0101     0.0980     0.0924     0.0709     0.0021     0.0021     0.0020     0.0014     0.0014 </r>
+        <r>     2.8631     0.0106     0.0977     0.0943     0.0681     0.0021     0.0021     0.0021     0.0015     0.0015 </r>
+        <r>     2.9755     0.0111     0.0996     0.0965     0.0671     0.0022     0.0022     0.0021     0.0016     0.0015 </r>
+        <r>     3.0879     0.0115     0.0986     0.0973     0.0678     0.0022     0.0023     0.0022     0.0016     0.0015 </r>
+        <r>     3.2002     0.0119     0.0953     0.0998     0.0659     0.0022     0.0023     0.0022     0.0018     0.0015 </r>
+        <r>     3.3126     0.0123     0.0910     0.1001     0.0603     0.0022     0.0023     0.0022     0.0018     0.0015 </r>
+        <r>     3.4250     0.0127     0.0882     0.0996     0.0541     0.0022     0.0023     0.0022     0.0019     0.0014 </r>
+        <r>     3.5374     0.0142     0.1085     0.1116     0.0583     0.0025     0.0026     0.0025     0.0023     0.0017 </r>
+        <r>     3.6497     0.0157     0.1071     0.1176     0.0624     0.0027     0.0029     0.0027     0.0025     0.0017 </r>
+        <r>     3.7621     0.0172     0.1077     0.1255     0.0671     0.0031     0.0034     0.0031     0.0028     0.0018 </r>
+        <r>     3.8745     0.0162     0.0852     0.1128     0.0615     0.0025     0.0032     0.0028     0.0023     0.0016 </r>
+        <r>     3.9868     0.0176     0.0746     0.1117     0.0650     0.0023     0.0034     0.0027     0.0021     0.0015 </r>
+        <r>     4.0992     0.0218     0.0779     0.1331     0.0732     0.0025     0.0042     0.0032     0.0022     0.0017 </r>
+        <r>     4.2116     0.0238     0.0728     0.1314     0.0787     0.0026     0.0045     0.0030     0.0019     0.0018 </r>
+        <r>     4.3239     0.0229     0.0564     0.1046     0.0803     0.0027     0.0041     0.0023     0.0012     0.0015 </r>
+        <r>     4.4363     0.0193     0.0410     0.0729     0.0737     0.0025     0.0033     0.0016     0.0007     0.0012 </r>
+        <r>     4.5487     0.0139     0.0256     0.0430     0.0550     0.0018     0.0023     0.0010     0.0004     0.0008 </r>
+        <r>     4.6611     0.0067     0.0122     0.0186     0.0269     0.0008     0.0011     0.0004     0.0002     0.0004 </r>
+        <r>     4.7734     0.0007     0.0017     0.0019     0.0038     0.0001     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>     4.8858     0.0000     0.0000     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.9982     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.1105     0.0002     0.0002     0.0006     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.2229     0.0008     0.0007     0.0019     0.0024     0.0001     0.0002     0.0001     0.0001     0.0001 </r>
+        <r>     5.3353     0.0017     0.0016     0.0039     0.0050     0.0002     0.0003     0.0002     0.0001     0.0001 </r>
+        <r>     5.4476     0.0029     0.0027     0.0068     0.0086     0.0003     0.0006     0.0003     0.0002     0.0002 </r>
+        <r>     5.5600     0.0055     0.0068     0.0141     0.0148     0.0005     0.0015     0.0007     0.0005     0.0005 </r>
+        <r>     5.6724     0.0129     0.0229     0.0398     0.0315     0.0010     0.0043     0.0019     0.0013     0.0008 </r>
+        <r>     5.7848     0.0192     0.0355     0.0595     0.0504     0.0016     0.0063     0.0026     0.0018     0.0011 </r>
+        <r>     5.8971     0.0316     0.0629     0.0957     0.0931     0.0033     0.0092     0.0045     0.0035     0.0017 </r>
+        <r>     6.0095     0.0258     0.0568     0.0804     0.0764     0.0030     0.0082     0.0037     0.0026     0.0015 </r>
+        <r>     6.1219     0.0262     0.0727     0.0951     0.0733     0.0035     0.0097     0.0048     0.0033     0.0017 </r>
+        <r>     6.2342     0.0221     0.0685     0.0855     0.0622     0.0035     0.0086     0.0045     0.0032     0.0015 </r>
+        <r>     6.3466     0.0201     0.0696     0.0888     0.0566     0.0036     0.0087     0.0049     0.0035     0.0015 </r>
+        <r>     6.4590     0.0177     0.0655     0.0821     0.0514     0.0036     0.0079     0.0048     0.0032     0.0014 </r>
+        <r>     6.5713     0.0159     0.0628     0.0777     0.0477     0.0037     0.0073     0.0048     0.0030     0.0013 </r>
+        <r>     6.6837     0.0146     0.0609     0.0749     0.0456     0.0039     0.0069     0.0049     0.0029     0.0013 </r>
+        <r>     6.7961     0.0135     0.0596     0.0731     0.0444     0.0041     0.0066     0.0051     0.0028     0.0013 </r>
+        <r>     6.9085     0.0127     0.0584     0.0727     0.0440     0.0043     0.0063     0.0053     0.0028     0.0014 </r>
+        <r>     7.0208     0.0120     0.0579     0.0717     0.0432     0.0046     0.0061     0.0056     0.0028     0.0014 </r>
+        <r>     7.1332     0.0115     0.0577     0.0717     0.0444     0.0048     0.0060     0.0060     0.0028     0.0015 </r>
+        <r>     7.2456     0.0112     0.0576     0.0726     0.0463     0.0051     0.0060     0.0065     0.0028     0.0015 </r>
+        <r>     7.3579     0.0109     0.0583     0.0754     0.0477     0.0056     0.0060     0.0073     0.0028     0.0016 </r>
+        <r>     7.4703     0.0106     0.0592     0.0796     0.0484     0.0062     0.0060     0.0084     0.0029     0.0017 </r>
+        <r>     7.5827     0.0103     0.0598     0.0819     0.0485     0.0068     0.0059     0.0096     0.0030     0.0018 </r>
+        <r>     7.6951     0.0103     0.0624     0.0878     0.0518     0.0080     0.0058     0.0117     0.0031     0.0021 </r>
+        <r>     7.8074     0.0109     0.0660     0.1044     0.0559     0.0110     0.0058     0.0195     0.0033     0.0026 </r>
+        <r>     7.9198     0.0085     0.0636     0.0931     0.0508     0.0115     0.0052     0.0202     0.0031     0.0026 </r>
+        <r>     8.0322     0.0060     0.0617     0.0519     0.0498     0.0065     0.0043     0.0081     0.0029     0.0021 </r>
+        <r>     8.1445     0.0058     0.0842     0.0488     0.0634     0.0057     0.0046     0.0055     0.0035     0.0023 </r>
+        <r>     8.2569     0.0058     0.0723     0.0438     0.0608     0.0056     0.0044     0.0057     0.0034     0.0025 </r>
+        <r>     8.3693     0.0059     0.0757     0.0439     0.0647     0.0060     0.0045     0.0064     0.0037     0.0028 </r>
+        <r>     8.4816     0.0059     0.0747     0.0421     0.0650     0.0062     0.0044     0.0068     0.0037     0.0029 </r>
+        <r>     8.5940     0.0059     0.0745     0.0420     0.0646     0.0065     0.0044     0.0073     0.0037     0.0030 </r>
+        <r>     8.7064     0.0058     0.0695     0.0417     0.0592     0.0065     0.0041     0.0073     0.0035     0.0030 </r>
+        <r>     8.8188     0.0061     0.0741     0.0429     0.0633     0.0070     0.0045     0.0086     0.0038     0.0034 </r>
+        <r>     8.9311     0.0064     0.0788     0.0435     0.0664     0.0073     0.0049     0.0097     0.0040     0.0037 </r>
+        <r>     9.0435     0.0064     0.0803     0.0411     0.0660     0.0074     0.0047     0.0108     0.0039     0.0038 </r>
+        <r>     9.1559     0.0061     0.0894     0.0386     0.0729     0.0087     0.0053     0.0137     0.0043     0.0041 </r>
+        <r>     9.2682     0.0047     0.0655     0.0334     0.0582     0.0071     0.0035     0.0097     0.0034     0.0034 </r>
+        <r>     9.3806     0.0042     0.0569     0.0315     0.0528     0.0065     0.0030     0.0083     0.0031     0.0032 </r>
+        <r>     9.4930     0.0037     0.0503     0.0294     0.0490     0.0061     0.0026     0.0072     0.0029     0.0031 </r>
+        <r>     9.6053     0.0033     0.0445     0.0276     0.0456     0.0057     0.0023     0.0063     0.0028     0.0029 </r>
+        <r>     9.7177     0.0030     0.0394     0.0262     0.0421     0.0055     0.0020     0.0057     0.0026     0.0028 </r>
+        <r>     9.8301     0.0028     0.0347     0.0260     0.0384     0.0053     0.0019     0.0054     0.0025     0.0026 </r>
+        <r>     9.9425     0.0029     0.0292     0.0351     0.0357     0.0070     0.0024     0.0111     0.0045     0.0049 </r>
+        <r>    10.0548     0.0037     0.0358     0.0578     0.0427     0.0105     0.0045     0.0238     0.0066     0.0080 </r>
+        <r>    10.1672     0.0045     0.0425     0.0596     0.0515     0.0139     0.0054     0.0295     0.0077     0.0108 </r>
+        <r>    10.2796     0.0047     0.0413     0.0650     0.0485     0.0149     0.0067     0.0307     0.0099     0.0198 </r>
+        <r>    10.3919     0.0048     0.0399     0.0698     0.0476     0.0146     0.0074     0.0327     0.0101     0.0188 </r>
+        <r>    10.5043     0.0040     0.0337     0.0481     0.0438     0.0124     0.0070     0.0291     0.0097     0.0168 </r>
+        <r>    10.6167     0.0029     0.0237     0.0222     0.0365     0.0092     0.0057     0.0230     0.0081     0.0141 </r>
+        <r>    10.7290     0.0025     0.0219     0.0151     0.0375     0.0079     0.0051     0.0208     0.0076     0.0128 </r>
+        <r>    10.8414     0.0026     0.0255     0.0156     0.0446     0.0079     0.0053     0.0219     0.0083     0.0129 </r>
+        <r>    10.9538     0.0029     0.0321     0.0191     0.0566     0.0088     0.0063     0.0253     0.0105     0.0145 </r>
+        <r>    11.0662     0.0036     0.0541     0.0275     0.0904     0.0112     0.0087     0.0287     0.0148     0.0205 </r>
+        <r>    11.1785     0.0018     0.0269     0.0104     0.0454     0.0071     0.0042     0.0176     0.0068     0.0104 </r>
+        <r>    11.2909     0.0016     0.0223     0.0081     0.0373     0.0083     0.0062     0.0206     0.0104     0.0114 </r>
+        <r>    11.4033     0.0015     0.0189     0.0060     0.0313     0.0075     0.0064     0.0176     0.0112     0.0126 </r>
+        <r>    11.5156     0.0015     0.0156     0.0046     0.0251     0.0075     0.0074     0.0174     0.0132     0.0150 </r>
+        <r>    11.6280     0.0013     0.0124     0.0035     0.0189     0.0068     0.0072     0.0156     0.0130     0.0127 </r>
+        <r>    11.7404     0.0011     0.0060     0.0026     0.0072     0.0059     0.0074     0.0131     0.0134     0.0117 </r>
+        <r>    11.8527     0.0010     0.0040     0.0022     0.0049     0.0051     0.0076     0.0109     0.0137     0.0107 </r>
+        <r>    11.9651     0.0013     0.0091     0.0042     0.0115     0.0075     0.0096     0.0153     0.0167     0.0154 </r>
+        <r>    12.0775     0.0015     0.0097     0.0035     0.0127     0.0093     0.0110     0.0162     0.0190     0.0187 </r>
+        <r>    12.1899     0.0020     0.0103     0.0033     0.0143     0.0108     0.0120     0.0169     0.0208     0.0224 </r>
+        <r>    12.3022     0.0027     0.0095     0.0040     0.0151     0.0106     0.0126     0.0168     0.0233     0.0246 </r>
+        <r>    12.4146     0.0034     0.0094     0.0051     0.0169     0.0114     0.0135     0.0171     0.0266     0.0276 </r>
+        <r>    12.5270     0.0040     0.0088     0.0056     0.0161     0.0112     0.0142     0.0163     0.0276     0.0279 </r>
+        <r>    12.6393     0.0048     0.0085     0.0055     0.0155     0.0111     0.0147     0.0147     0.0282     0.0279 </r>
+        <r>    12.7517     0.0059     0.0086     0.0054     0.0152     0.0115     0.0152     0.0135     0.0285     0.0273 </r>
+        <r>    12.8641     0.0070     0.0088     0.0055     0.0151     0.0120     0.0151     0.0128     0.0280     0.0265 </r>
+        <r>    12.9765     0.0079     0.0090     0.0056     0.0154     0.0126     0.0152     0.0125     0.0276     0.0258 </r>
+        <r>    13.0888     0.0086     0.0091     0.0058     0.0158     0.0132     0.0154     0.0124     0.0271     0.0252 </r>
+        <r>    13.2012     0.0091     0.0091     0.0061     0.0164     0.0138     0.0156     0.0126     0.0265     0.0249 </r>
+        <r>    13.3136     0.0094     0.0092     0.0062     0.0168     0.0143     0.0159     0.0128     0.0261     0.0250 </r>
+        <r>    13.4259     0.0099     0.0095     0.0065     0.0170     0.0152     0.0162     0.0136     0.0257     0.0249 </r>
+        <r>    13.5383     0.0103     0.0102     0.0067     0.0173     0.0163     0.0166     0.0144     0.0255     0.0254 </r>
+        <r>    13.6507     0.0109     0.0126     0.0071     0.0188     0.0235     0.0200     0.0172     0.0295     0.0277 </r>
+        <r>    13.7630     0.0117     0.0160     0.0077     0.0209     0.0265     0.0228     0.0204     0.0315     0.0307 </r>
+        <r>    13.8754     0.0162     0.0294     0.0094     0.0290     0.0502     0.0289     0.0345     0.0366     0.0395 </r>
+        <r>    13.9878     0.0132     0.0233     0.0091     0.0229     0.0340     0.0299     0.0260     0.0350     0.0373 </r>
+        <r>    14.1002     0.0124     0.0189     0.0090     0.0201     0.0268     0.0314     0.0211     0.0348     0.0366 </r>
+        <r>    14.2125     0.0123     0.0169     0.0091     0.0195     0.0239     0.0328     0.0192     0.0348     0.0353 </r>
+        <r>    14.3249     0.0105     0.0148     0.0084     0.0180     0.0216     0.0337     0.0181     0.0340     0.0329 </r>
+        <r>    14.4373     0.0094     0.0130     0.0080     0.0169     0.0202     0.0350     0.0172     0.0340     0.0313 </r>
+        <r>    14.5496     0.0094     0.0115     0.0082     0.0170     0.0198     0.0381     0.0164     0.0352     0.0312 </r>
+        <r>    14.6620     0.0098     0.0107     0.0088     0.0178     0.0197     0.0423     0.0158     0.0375     0.0321 </r>
+        <r>    14.7744     0.0108     0.0118     0.0098     0.0200     0.0212     0.0482     0.0166     0.0419     0.0359 </r>
+        <r>    14.8867     0.0127     0.0127     0.0118     0.0233     0.0240     0.0613     0.0194     0.0496     0.0432 </r>
+        <r>    14.9991     0.0140     0.0138     0.0141     0.0262     0.0263     0.0622     0.0235     0.0534     0.0440 </r>
+        <r>    15.1115     0.0145     0.0149     0.0155     0.0290     0.0278     0.0612     0.0268     0.0501     0.0438 </r>
+        <r>    15.2239     0.0151     0.0154     0.0163     0.0298     0.0290     0.0626     0.0283     0.0470     0.0420 </r>
+        <r>    15.3362     0.0157     0.0166     0.0175     0.0310     0.0325     0.0604     0.0308     0.0446     0.0423 </r>
+        <r>    15.4486     0.0135     0.0154     0.0143     0.0266     0.0307     0.0464     0.0287     0.0399     0.0338 </r>
+        <r>    15.5610     0.0128     0.0153     0.0134     0.0216     0.0309     0.0399     0.0283     0.0380     0.0294 </r>
+        <r>    15.6733     0.0129     0.0149     0.0132     0.0189     0.0321     0.0384     0.0289     0.0389     0.0277 </r>
+        <r>    15.7857     0.0174     0.0173     0.0151     0.0201     0.0390     0.0402     0.0342     0.0455     0.0302 </r>
+        <r>    15.8981     0.0185     0.0209     0.0152     0.0208     0.0441     0.0412     0.0414     0.0494     0.0325 </r>
+        <r>    16.0104     0.0137     0.0273     0.0129     0.0213     0.0403     0.0374     0.0524     0.0427     0.0311 </r>
+        <r>    16.1228     0.0085     0.0125     0.0084     0.0109     0.0231     0.0314     0.0250     0.0343     0.0277 </r>
+        <r>    16.2352     0.0089     0.0111     0.0081     0.0102     0.0225     0.0378     0.0207     0.0346     0.0281 </r>
+        <r>    16.3476     0.0105     0.0108     0.0085     0.0099     0.0239     0.0435     0.0186     0.0379     0.0296 </r>
+        <r>    16.4599     0.0113     0.0105     0.0091     0.0099     0.0251     0.0453     0.0167     0.0400     0.0297 </r>
+        <r>    16.5723     0.0211     0.0139     0.0142     0.0159     0.0517     0.0671     0.0217     0.0576     0.0428 </r>
+        <r>    16.6847     0.0198     0.0137     0.0132     0.0160     0.0521     0.0586     0.0223     0.0515     0.0396 </r>
+        <r>    16.7970     0.0153     0.0127     0.0118     0.0131     0.0397     0.0484     0.0201     0.0481     0.0331 </r>
+        <r>    16.9094     0.0171     0.0147     0.0129     0.0146     0.0429     0.0538     0.0229     0.0532     0.0400 </r>
+        <r>    17.0218     0.0177     0.0169     0.0130     0.0153     0.0446     0.0596     0.0247     0.0554     0.0461 </r>
+        <r>    17.1341     0.0139     0.0176     0.0118     0.0140     0.0380     0.0544     0.0239     0.0538     0.0415 </r>
+        <r>    17.2465     0.0129     0.0187     0.0138     0.0136     0.0411     0.0536     0.0244     0.0615     0.0626 </r>
+        <r>    17.3589     0.0132     0.0177     0.0112     0.0140     0.0359     0.0486     0.0228     0.0577     0.0395 </r>
+        <r>    17.4713     0.0142     0.0178     0.0116     0.0145     0.0373     0.0514     0.0229     0.0626     0.0403 </r>
+        <r>    17.5836     0.0165     0.0190     0.0131     0.0164     0.0414     0.0583     0.0254     0.0698     0.0449 </r>
+        <r>    17.6960     0.0158     0.0169     0.0128     0.0149     0.0432     0.0541     0.0243     0.0655     0.0463 </r>
+        <r>    17.8084     0.0155     0.0141     0.0110     0.0119     0.0440     0.0549     0.0219     0.0639     0.0533 </r>
+        <r>    17.9207     0.0162     0.0135     0.0117     0.0115     0.0481     0.0566     0.0236     0.0652     0.0605 </r>
+        <r>    18.0331     0.0189     0.0131     0.0129     0.0117     0.0551     0.0592     0.0268     0.0716     0.0698 </r>
+        <r>    18.1455     0.0190     0.0121     0.0129     0.0116     0.0563     0.0563     0.0266     0.0734     0.0722 </r>
+        <r>    18.2579     0.0184     0.0111     0.0129     0.0115     0.0562     0.0529     0.0252     0.0699     0.0713 </r>
+        <r>    18.3702     0.0190     0.0115     0.0138     0.0120     0.0659     0.0535     0.0259     0.0680     0.0735 </r>
+        <r>    18.4826     0.0200     0.0122     0.0147     0.0124     0.0759     0.0556     0.0276     0.0689     0.0790 </r>
+        <r>    18.5950     0.0207     0.0127     0.0155     0.0128     0.0763     0.0578     0.0289     0.0706     0.0858 </r>
+        <r>    18.7073     0.0210     0.0130     0.0157     0.0134     0.0752     0.0578     0.0286     0.0710     0.0941 </r>
+        <r>    18.8197     0.0143     0.0086     0.0115     0.0088     0.0554     0.0406     0.0205     0.0493     0.0580 </r>
+        <r>    18.9321     0.0140     0.0080     0.0106     0.0077     0.0536     0.0395     0.0223     0.0526     0.0420 </r>
+        <r>    19.0444     0.0097     0.0066     0.0090     0.0064     0.0428     0.0380     0.0148     0.0445     0.0360 </r>
+        <r>    19.1568     0.0086     0.0060     0.0085     0.0059     0.0397     0.0386     0.0132     0.0360     0.0292 </r>
+        <r>    19.2692     0.0070     0.0048     0.0066     0.0046     0.0324     0.0349     0.0094     0.0258     0.0208 </r>
+        <r>    19.3816     0.0047     0.0032     0.0045     0.0033     0.0203     0.0233     0.0054     0.0180     0.0139 </r>
+        <r>    19.4939     0.0032     0.0021     0.0031     0.0025     0.0140     0.0149     0.0038     0.0127     0.0099 </r>
+        <r>    19.6063     0.0015     0.0008     0.0011     0.0013     0.0053     0.0050     0.0019     0.0059     0.0044 </r>
+        <r>    19.7187     0.0010     0.0005     0.0008     0.0010     0.0038     0.0036     0.0014     0.0041     0.0033 </r>
+        <r>    19.8310     0.0007     0.0004     0.0005     0.0007     0.0028     0.0025     0.0011     0.0030     0.0025 </r>
+        <r>    19.9434     0.0004     0.0002     0.0003     0.0004     0.0021     0.0015     0.0008     0.0021     0.0019 </r>
+        <r>    20.0558     0.0002     0.0001     0.0001     0.0002     0.0016     0.0005     0.0006     0.0015     0.0014 </r>
+        <r>    20.1681     0.0001     0.0001     0.0001     0.0002     0.0015     0.0005     0.0006     0.0014     0.0014 </r>
+        <r>    20.2805     0.0001     0.0001     0.0001     0.0002     0.0014     0.0004     0.0005     0.0013     0.0013 </r>
+        <r>    20.3929     0.0001     0.0001     0.0001     0.0002     0.0012     0.0004     0.0005     0.0013     0.0012 </r>
+        <r>    20.5053     0.0001     0.0001     0.0001     0.0002     0.0011     0.0003     0.0005     0.0012     0.0011 </r>
+        <r>    20.6176     0.0001     0.0001     0.0001     0.0002     0.0010     0.0003     0.0004     0.0011     0.0010 </r>
+        <r>    20.7300     0.0001     0.0001     0.0001     0.0001     0.0009     0.0003     0.0004     0.0010     0.0009 </r>
+        <r>    20.8424     0.0001     0.0001     0.0001     0.0001     0.0008     0.0002     0.0003     0.0009     0.0009 </r>
+        <r>    20.9547     0.0001     0.0001     0.0001     0.0001     0.0007     0.0002     0.0003     0.0009     0.0008 </r>
+        <r>    21.0671     0.0001     0.0001     0.0001     0.0001     0.0006     0.0002     0.0003     0.0008     0.0007 </r>
+        <r>    21.1795     0.0001     0.0000     0.0000     0.0001     0.0006     0.0001     0.0002     0.0007     0.0007 </r>
+        <r>    21.2918     0.0001     0.0000     0.0000     0.0001     0.0005     0.0001     0.0002     0.0006     0.0006 </r>
+        <r>    21.4042     0.0000     0.0000     0.0000     0.0001     0.0004     0.0001     0.0002     0.0006     0.0005 </r>
+        <r>    21.5166     0.0000     0.0000     0.0000     0.0001     0.0003     0.0001     0.0002     0.0005     0.0005 </r>
+        <r>    21.6290     0.0000     0.0000     0.0000     0.0001     0.0003     0.0001     0.0001     0.0004     0.0004 </r>
+        <r>    21.7413     0.0000     0.0000     0.0000     0.0000     0.0002     0.0000     0.0001     0.0004     0.0004 </r>
+        <r>    21.8537     0.0000     0.0000     0.0000     0.0001     0.0004     0.0001     0.0004     0.0006     0.0008 </r>
+        <r>    21.9661     0.0000     0.0000     0.0000     0.0000     0.0003     0.0001     0.0003     0.0004     0.0006 </r>
+        <r>    22.0784     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.1908     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.3032     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.4156     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.5279     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.6403     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.7527     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.8650     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.9774     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.0898     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.2021     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.3145     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.4269     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.5393     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+       </set>
+       <set comment="spin 2">
+        <r>   -10.1718     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>   -10.0594     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.9471     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.8347     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.7223     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.6100     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.4976     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.3852     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.2729     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.1605     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.0481     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.9357     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.8234     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.7110     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.5986     0.0148     0.0000     0.0001     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.4863     0.0423     0.0001     0.0002     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.3739     0.0564     0.0003     0.0003     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.2615     0.0710     0.0004     0.0004     0.0008     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.1491     0.0835     0.0005     0.0005     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.0368     0.0942     0.0008     0.0006     0.0013     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.9244     0.1048     0.0009     0.0007     0.0017     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.8120     0.1176     0.0011     0.0009     0.0020     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.6997     0.1306     0.0012     0.0010     0.0025     0.0001     0.0001     0.0000     0.0001     0.0000 </r>
+        <r>    -7.5873     0.1437     0.0014     0.0012     0.0029     0.0001     0.0001     0.0001     0.0001     0.0000 </r>
+        <r>    -7.4749     0.1624     0.0017     0.0016     0.0034     0.0002     0.0001     0.0001     0.0001     0.0000 </r>
+        <r>    -7.3626     0.1919     0.0021     0.0022     0.0040     0.0002     0.0001     0.0001     0.0001     0.0000 </r>
+        <r>    -7.2502     0.2015     0.0023     0.0022     0.0043     0.0003     0.0001     0.0001     0.0001     0.0001 </r>
+        <r>    -7.1378     0.2215     0.0024     0.0025     0.0048     0.0004     0.0002     0.0001     0.0001     0.0001 </r>
+        <r>    -7.0254     0.2324     0.0026     0.0024     0.0052     0.0005     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -6.9131     0.2619     0.0028     0.0025     0.0060     0.0006     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -6.8007     0.3362     0.0040     0.0030     0.0075     0.0009     0.0003     0.0003     0.0002     0.0002 </r>
+        <r>    -6.6883     0.4159     0.0047     0.0037     0.0090     0.0013     0.0004     0.0004     0.0002     0.0002 </r>
+        <r>    -6.5760     0.2857     0.0038     0.0024     0.0059     0.0009     0.0003     0.0003     0.0002     0.0001 </r>
+        <r>    -6.4636     0.2095     0.0035     0.0016     0.0038     0.0007     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -6.3512     0.3573     0.0088     0.0017     0.0052     0.0012     0.0004     0.0004     0.0002     0.0002 </r>
+        <r>    -6.2389     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.1265     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.0141     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.9017     0.0135     0.0006     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.7894     0.1319     0.0046     0.0004     0.0031     0.0003     0.0001     0.0001     0.0001     0.0001 </r>
+        <r>    -5.6770     0.2354     0.0067     0.0008     0.0065     0.0006     0.0002     0.0003     0.0002     0.0001 </r>
+        <r>    -5.5646     0.2638     0.0059     0.0011     0.0077     0.0007     0.0003     0.0003     0.0002     0.0001 </r>
+        <r>    -5.4523     0.2619     0.0052     0.0014     0.0070     0.0008     0.0003     0.0004     0.0002     0.0001 </r>
+        <r>    -5.3399     0.2618     0.0046     0.0018     0.0068     0.0008     0.0003     0.0004     0.0002     0.0001 </r>
+        <r>    -5.2275     0.3087     0.0044     0.0034     0.0071     0.0009     0.0003     0.0005     0.0002     0.0001 </r>
+        <r>    -5.1152     0.2930     0.0041     0.0042     0.0064     0.0009     0.0003     0.0006     0.0001     0.0001 </r>
+        <r>    -5.0028     0.2508     0.0036     0.0031     0.0057     0.0008     0.0002     0.0005     0.0001     0.0001 </r>
+        <r>    -4.8904     0.2373     0.0033     0.0026     0.0055     0.0008     0.0002     0.0005     0.0001     0.0001 </r>
+        <r>    -4.7780     0.2040     0.0029     0.0022     0.0050     0.0006     0.0002     0.0004     0.0001     0.0001 </r>
+        <r>    -4.6657     0.1713     0.0026     0.0017     0.0044     0.0005     0.0001     0.0003     0.0001     0.0001 </r>
+        <r>    -4.5533     0.1362     0.0022     0.0013     0.0037     0.0003     0.0001     0.0002     0.0001     0.0001 </r>
+        <r>    -4.4409     0.1195     0.0019     0.0011     0.0034     0.0002     0.0001     0.0002     0.0000     0.0000 </r>
+        <r>    -4.3286     0.1053     0.0016     0.0010     0.0030     0.0002     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>    -4.2162     0.0956     0.0015     0.0009     0.0027     0.0002     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>    -4.1038     0.0862     0.0014     0.0008     0.0024     0.0001     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>    -3.9915     0.0756     0.0013     0.0006     0.0020     0.0001     0.0000     0.0001     0.0000     0.0000 </r>
+        <r>    -3.8791     0.0657     0.0011     0.0005     0.0017     0.0001     0.0000     0.0001     0.0000     0.0000 </r>
+        <r>    -3.7667     0.0589     0.0009     0.0004     0.0016     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.6543     0.0522     0.0007     0.0004     0.0014     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.5420     0.0458     0.0006     0.0003     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.4296     0.0401     0.0005     0.0003     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.3172     0.0346     0.0004     0.0002     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.2049     0.0292     0.0003     0.0002     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.0925     0.0241     0.0002     0.0001     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.9801     0.0193     0.0001     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.8677     0.0131     0.0000     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.7554     0.0047     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.6430     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.5306     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.4183     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.3059     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.1935     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.0812     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.9688     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.8564     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.7440     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.6317     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.5193     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.4069     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.2946     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.1822     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.0698     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.9575     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.8451     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.7327     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.6203     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.5080     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.3956     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.2832     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.1709     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.0585     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.0539     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.1662     0.0008     0.0102     0.0003     0.0203     0.0002     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.2786     0.0013     0.0187     0.0010     0.0370     0.0003     0.0000     0.0001     0.0001     0.0002 </r>
+        <r>     0.3910     0.0016     0.0257     0.0033     0.0483     0.0004     0.0001     0.0002     0.0001     0.0003 </r>
+        <r>     0.5034     0.0019     0.0338     0.0077     0.0591     0.0005     0.0001     0.0004     0.0002     0.0005 </r>
+        <r>     0.6157     0.0023     0.0461     0.0139     0.0756     0.0007     0.0002     0.0007     0.0003     0.0008 </r>
+        <r>     0.7281     0.0024     0.0417     0.0184     0.0646     0.0007     0.0002     0.0007     0.0002     0.0007 </r>
+        <r>     0.8405     0.0026     0.0403     0.0219     0.0599     0.0007     0.0002     0.0008     0.0002     0.0008 </r>
+        <r>     0.9528     0.0028     0.0403     0.0238     0.0588     0.0008     0.0002     0.0008     0.0003     0.0008 </r>
+        <r>     1.0652     0.0031     0.0420     0.0276     0.0590     0.0008     0.0002     0.0009     0.0003     0.0009 </r>
+        <r>     1.1776     0.0035     0.0442     0.0318     0.0592     0.0009     0.0003     0.0010     0.0003     0.0009 </r>
+        <r>     1.2899     0.0039     0.0484     0.0385     0.0609     0.0010     0.0003     0.0011     0.0003     0.0009 </r>
+        <r>     1.4023     0.0044     0.0538     0.0449     0.0639     0.0012     0.0004     0.0012     0.0004     0.0009 </r>
+        <r>     1.5147     0.0049     0.0604     0.0481     0.0676     0.0013     0.0005     0.0013     0.0005     0.0011 </r>
+        <r>     1.6271     0.0053     0.0701     0.0535     0.0723     0.0014     0.0006     0.0014     0.0005     0.0012 </r>
+        <r>     1.7394     0.0063     0.1001     0.0728     0.0878     0.0016     0.0008     0.0018     0.0007     0.0014 </r>
+        <r>     1.8518     0.0071     0.1131     0.0786     0.0936     0.0017     0.0009     0.0020     0.0008     0.0015 </r>
+        <r>     1.9642     0.0071     0.1013     0.0667     0.0857     0.0017     0.0010     0.0018     0.0008     0.0015 </r>
+        <r>     2.0765     0.0076     0.0944     0.0764     0.0801     0.0018     0.0011     0.0019     0.0008     0.0015 </r>
+        <r>     2.1889     0.0082     0.0911     0.0866     0.0769     0.0019     0.0012     0.0019     0.0009     0.0015 </r>
+        <r>     2.3013     0.0088     0.0921     0.0932     0.0764     0.0020     0.0013     0.0020     0.0009     0.0015 </r>
+        <r>     2.4137     0.0093     0.0931     0.0906     0.0749     0.0020     0.0015     0.0021     0.0009     0.0015 </r>
+        <r>     2.5260     0.0096     0.0943     0.0927     0.0727     0.0021     0.0016     0.0021     0.0010     0.0016 </r>
+        <r>     2.6384     0.0099     0.0952     0.0962     0.0705     0.0021     0.0018     0.0022     0.0010     0.0016 </r>
+        <r>     2.7508     0.0103     0.0949     0.0999     0.0687     0.0021     0.0019     0.0023     0.0010     0.0015 </r>
+        <r>     2.8631     0.0107     0.0961     0.1019     0.0684     0.0022     0.0021     0.0024     0.0010     0.0015 </r>
+        <r>     2.9755     0.0109     0.0960     0.1000     0.0694     0.0022     0.0022     0.0024     0.0010     0.0015 </r>
+        <r>     3.0879     0.0111     0.0910     0.0973     0.0672     0.0022     0.0023     0.0024     0.0010     0.0013 </r>
+        <r>     3.2002     0.0114     0.0878     0.0968     0.0638     0.0022     0.0025     0.0024     0.0010     0.0012 </r>
+        <r>     3.3126     0.0117     0.0852     0.0959     0.0573     0.0022     0.0026     0.0023     0.0010     0.0010 </r>
+        <r>     3.4250     0.0133     0.1119     0.1142     0.0645     0.0024     0.0030     0.0027     0.0011     0.0011 </r>
+        <r>     3.5374     0.0148     0.1089     0.1132     0.0626     0.0026     0.0034     0.0029     0.0012     0.0012 </r>
+        <r>     3.6497     0.0171     0.1086     0.1207     0.0678     0.0029     0.0040     0.0033     0.0013     0.0014 </r>
+        <r>     3.7621     0.0165     0.0912     0.1144     0.0605     0.0026     0.0039     0.0030     0.0012     0.0013 </r>
+        <r>     3.8745     0.0154     0.0690     0.1034     0.0537     0.0023     0.0037     0.0022     0.0011     0.0011 </r>
+        <r>     3.9868     0.0185     0.0675     0.1126     0.0629     0.0026     0.0043     0.0022     0.0012     0.0013 </r>
+        <r>     4.0992     0.0257     0.0783     0.1435     0.0816     0.0036     0.0056     0.0027     0.0018     0.0017 </r>
+        <r>     4.2116     0.0289     0.0765     0.1428     0.0930     0.0042     0.0060     0.0027     0.0018     0.0020 </r>
+        <r>     4.3239     0.0253     0.0568     0.1072     0.0849     0.0037     0.0048     0.0020     0.0013     0.0018 </r>
+        <r>     4.4363     0.0179     0.0333     0.0616     0.0657     0.0028     0.0031     0.0013     0.0007     0.0014 </r>
+        <r>     4.5487     0.0092     0.0151     0.0264     0.0349     0.0014     0.0016     0.0006     0.0002     0.0007 </r>
+        <r>     4.6611     0.0017     0.0041     0.0058     0.0076     0.0003     0.0003     0.0002     0.0001     0.0001 </r>
+        <r>     4.7734     0.0002     0.0005     0.0005     0.0013     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.8858     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.9982     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.1105     0.0000     0.0000     0.0001     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.2229     0.0005     0.0006     0.0014     0.0015     0.0000     0.0001     0.0000     0.0001     0.0000 </r>
+        <r>     5.3353     0.0016     0.0018     0.0044     0.0049     0.0002     0.0004     0.0001     0.0002     0.0001 </r>
+        <r>     5.4476     0.0034     0.0040     0.0094     0.0104     0.0003     0.0008     0.0003     0.0004     0.0003 </r>
+        <r>     5.5600     0.0143     0.0288     0.0480     0.0345     0.0012     0.0050     0.0020     0.0025     0.0016 </r>
+        <r>     5.6724     0.0168     0.0387     0.0550     0.0434     0.0014     0.0061     0.0024     0.0026     0.0021 </r>
+        <r>     5.7848     0.0272     0.0628     0.0815     0.0809     0.0031     0.0091     0.0036     0.0037     0.0030 </r>
+        <r>     5.8971     0.0272     0.0666     0.0794     0.0871     0.0038     0.0089     0.0035     0.0034     0.0034 </r>
+        <r>     6.0095     0.0301     0.0891     0.1046     0.0899     0.0050     0.0115     0.0050     0.0046     0.0045 </r>
+        <r>     6.1219     0.0228     0.0735     0.0836     0.0687     0.0045     0.0087     0.0039     0.0038     0.0036 </r>
+        <r>     6.2342     0.0197     0.0719     0.0842     0.0580     0.0046     0.0085     0.0041     0.0038     0.0034 </r>
+        <r>     6.3466     0.0181     0.0675     0.0814     0.0538     0.0045     0.0081     0.0041     0.0036     0.0033 </r>
+        <r>     6.4590     0.0163     0.0647     0.0773     0.0496     0.0046     0.0075     0.0041     0.0034     0.0032 </r>
+        <r>     6.5713     0.0149     0.0626     0.0745     0.0467     0.0047     0.0070     0.0042     0.0032     0.0031 </r>
+        <r>     6.6837     0.0139     0.0609     0.0726     0.0449     0.0049     0.0067     0.0043     0.0031     0.0030 </r>
+        <r>     6.7961     0.0130     0.0594     0.0716     0.0440     0.0051     0.0064     0.0045     0.0031     0.0030 </r>
+        <r>     6.9085     0.0124     0.0589     0.0716     0.0435     0.0054     0.0062     0.0048     0.0031     0.0030 </r>
+        <r>     7.0208     0.0120     0.0590     0.0724     0.0435     0.0057     0.0061     0.0052     0.0031     0.0031 </r>
+        <r>     7.1332     0.0118     0.0587     0.0751     0.0458     0.0061     0.0061     0.0057     0.0032     0.0033 </r>
+        <r>     7.2456     0.0115     0.0591     0.0776     0.0466     0.0066     0.0060     0.0065     0.0033     0.0034 </r>
+        <r>     7.3579     0.0113     0.0597     0.0811     0.0474     0.0072     0.0060     0.0077     0.0034     0.0035 </r>
+        <r>     7.4703     0.0111     0.0607     0.0845     0.0484     0.0081     0.0061     0.0091     0.0035     0.0036 </r>
+        <r>     7.5827     0.0111     0.0639     0.0905     0.0524     0.0097     0.0061     0.0110     0.0037     0.0039 </r>
+        <r>     7.6951     0.0126     0.0922     0.1215     0.0981     0.0146     0.0088     0.0193     0.0054     0.0084 </r>
+        <r>     7.8074     0.0098     0.0714     0.1076     0.0542     0.0158     0.0058     0.0223     0.0043     0.0048 </r>
+        <r>     7.9198     0.0064     0.0740     0.0588     0.0564     0.0094     0.0050     0.0064     0.0038     0.0037 </r>
+        <r>     8.0322     0.0060     0.0721     0.0468     0.0588     0.0082     0.0049     0.0043     0.0037     0.0034 </r>
+        <r>     8.1445     0.0060     0.0710     0.0448     0.0604     0.0085     0.0050     0.0047     0.0036     0.0034 </r>
+        <r>     8.2569     0.0060     0.0730     0.0434     0.0633     0.0089     0.0052     0.0052     0.0037     0.0034 </r>
+        <r>     8.3693     0.0060     0.0724     0.0410     0.0640     0.0092     0.0051     0.0056     0.0038     0.0032 </r>
+        <r>     8.4816     0.0060     0.0749     0.0413     0.0649     0.0096     0.0052     0.0062     0.0039     0.0032 </r>
+        <r>     8.5940     0.0059     0.0697     0.0405     0.0594     0.0093     0.0049     0.0063     0.0035     0.0030 </r>
+        <r>     8.7064     0.0062     0.0726     0.0408     0.0620     0.0099     0.0052     0.0072     0.0038     0.0030 </r>
+        <r>     8.8188     0.0067     0.0799     0.0418     0.0665     0.0107     0.0058     0.0087     0.0042     0.0031 </r>
+        <r>     8.9311     0.0069     0.0836     0.0396     0.0689     0.0111     0.0058     0.0099     0.0042     0.0031 </r>
+        <r>     9.0435     0.0065     0.0904     0.0371     0.0727     0.0121     0.0064     0.0125     0.0045     0.0031 </r>
+        <r>     9.1559     0.0051     0.0699     0.0321     0.0607     0.0101     0.0047     0.0094     0.0035     0.0027 </r>
+        <r>     9.2682     0.0044     0.0595     0.0303     0.0545     0.0091     0.0041     0.0080     0.0031     0.0026 </r>
+        <r>     9.3806     0.0039     0.0517     0.0281     0.0502     0.0081     0.0036     0.0068     0.0028     0.0025 </r>
+        <r>     9.4930     0.0035     0.0451     0.0262     0.0467     0.0073     0.0032     0.0058     0.0026     0.0025 </r>
+        <r>     9.6053     0.0032     0.0395     0.0249     0.0435     0.0067     0.0029     0.0052     0.0024     0.0025 </r>
+        <r>     9.7177     0.0028     0.0335     0.0233     0.0397     0.0061     0.0026     0.0046     0.0022     0.0024 </r>
+        <r>     9.8301     0.0025     0.0261     0.0222     0.0352     0.0055     0.0022     0.0040     0.0020     0.0024 </r>
+        <r>     9.9425     0.0032     0.0284     0.0370     0.0382     0.0076     0.0032     0.0120     0.0046     0.0066 </r>
+        <r>    10.0548     0.0041     0.0354     0.0615     0.0462     0.0116     0.0054     0.0262     0.0069     0.0112 </r>
+        <r>    10.1672     0.0051     0.0388     0.0618     0.0510     0.0149     0.0063     0.0311     0.0086     0.0221 </r>
+        <r>    10.2796     0.0054     0.0405     0.0686     0.0515     0.0150     0.0071     0.0339     0.0087     0.0214 </r>
+        <r>    10.3919     0.0053     0.0418     0.0697     0.0540     0.0148     0.0071     0.0333     0.0092     0.0210 </r>
+        <r>    10.5043     0.0042     0.0297     0.0446     0.0410     0.0121     0.0064     0.0290     0.0086     0.0186 </r>
+        <r>    10.6167     0.0032     0.0234     0.0205     0.0362     0.0100     0.0053     0.0241     0.0078     0.0166 </r>
+        <r>    10.7290     0.0028     0.0244     0.0159     0.0393     0.0091     0.0046     0.0222     0.0074     0.0159 </r>
+        <r>    10.8414     0.0030     0.0300     0.0176     0.0483     0.0099     0.0049     0.0243     0.0087     0.0176 </r>
+        <r>    10.9538     0.0038     0.0433     0.0237     0.0666     0.0123     0.0064     0.0297     0.0120     0.0228 </r>
+        <r>    11.0662     0.0027     0.0338     0.0144     0.0527     0.0105     0.0042     0.0246     0.0083     0.0170 </r>
+        <r>    11.1785     0.0019     0.0256     0.0091     0.0392     0.0083     0.0030     0.0181     0.0059     0.0131 </r>
+        <r>    11.2909     0.0019     0.0210     0.0068     0.0321     0.0087     0.0053     0.0194     0.0103     0.0152 </r>
+        <r>    11.4033     0.0019     0.0171     0.0054     0.0259     0.0083     0.0065     0.0194     0.0127     0.0182 </r>
+        <r>    11.5156     0.0017     0.0115     0.0043     0.0182     0.0072     0.0065     0.0163     0.0126     0.0149 </r>
+        <r>    11.6280     0.0015     0.0077     0.0035     0.0118     0.0062     0.0066     0.0139     0.0128     0.0135 </r>
+        <r>    11.7404     0.0014     0.0045     0.0029     0.0052     0.0056     0.0072     0.0126     0.0139     0.0134 </r>
+        <r>    11.8527     0.0015     0.0044     0.0025     0.0048     0.0056     0.0077     0.0121     0.0148     0.0139 </r>
+        <r>    11.9651     0.0016     0.0051     0.0030     0.0082     0.0065     0.0087     0.0130     0.0163     0.0164 </r>
+        <r>    12.0775     0.0020     0.0075     0.0036     0.0145     0.0094     0.0108     0.0170     0.0189     0.0219 </r>
+        <r>    12.1899     0.0028     0.0083     0.0049     0.0152     0.0110     0.0123     0.0179     0.0211     0.0255 </r>
+        <r>    12.3022     0.0040     0.0084     0.0053     0.0165     0.0118     0.0137     0.0186     0.0236     0.0285 </r>
+        <r>    12.4146     0.0051     0.0083     0.0059     0.0181     0.0126     0.0153     0.0197     0.0267     0.0312 </r>
+        <r>    12.5270     0.0058     0.0080     0.0058     0.0173     0.0122     0.0157     0.0179     0.0275     0.0311 </r>
+        <r>    12.6393     0.0068     0.0081     0.0057     0.0165     0.0123     0.0161     0.0166     0.0282     0.0307 </r>
+        <r>    12.7517     0.0079     0.0083     0.0058     0.0162     0.0127     0.0168     0.0156     0.0292     0.0304 </r>
+        <r>    12.8641     0.0088     0.0086     0.0060     0.0158     0.0133     0.0169     0.0151     0.0288     0.0300 </r>
+        <r>    12.9765     0.0096     0.0087     0.0063     0.0157     0.0138     0.0172     0.0148     0.0285     0.0296 </r>
+        <r>    13.0888     0.0102     0.0088     0.0066     0.0160     0.0143     0.0173     0.0149     0.0280     0.0293 </r>
+        <r>    13.2012     0.0107     0.0088     0.0068     0.0163     0.0148     0.0173     0.0151     0.0273     0.0292 </r>
+        <r>    13.3136     0.0113     0.0089     0.0070     0.0164     0.0156     0.0174     0.0153     0.0267     0.0290 </r>
+        <r>    13.4259     0.0118     0.0094     0.0072     0.0166     0.0166     0.0177     0.0160     0.0265     0.0292 </r>
+        <r>    13.5383     0.0125     0.0104     0.0076     0.0171     0.0202     0.0217     0.0183     0.0281     0.0304 </r>
+        <r>    13.6507     0.0136     0.0138     0.0082     0.0187     0.0256     0.0242     0.0226     0.0326     0.0341 </r>
+        <r>    13.7630     0.0162     0.0216     0.0093     0.0228     0.0410     0.0289     0.0321     0.0368     0.0391 </r>
+        <r>    13.8754     0.0157     0.0244     0.0094     0.0232     0.0434     0.0313     0.0293     0.0372     0.0407 </r>
+        <r>    13.9878     0.0145     0.0199     0.0096     0.0203     0.0333     0.0330     0.0235     0.0375     0.0396 </r>
+        <r>    14.1002     0.0145     0.0171     0.0098     0.0189     0.0290     0.0341     0.0198     0.0374     0.0383 </r>
+        <r>    14.2125     0.0136     0.0158     0.0095     0.0180     0.0275     0.0351     0.0184     0.0373     0.0361 </r>
+        <r>    14.3249     0.0117     0.0141     0.0089     0.0165     0.0253     0.0356     0.0173     0.0368     0.0337 </r>
+        <r>    14.4373     0.0119     0.0129     0.0093     0.0168     0.0253     0.0391     0.0167     0.0383     0.0339 </r>
+        <r>    14.5496     0.0119     0.0117     0.0098     0.0173     0.0250     0.0425     0.0157     0.0402     0.0345 </r>
+        <r>    14.6620     0.0126     0.0111     0.0103     0.0178     0.0245     0.0482     0.0150     0.0430     0.0355 </r>
+        <r>    14.7744     0.0149     0.0133     0.0118     0.0231     0.0285     0.0608     0.0180     0.0516     0.0423 </r>
+        <r>    14.8867     0.0152     0.0135     0.0120     0.0254     0.0294     0.0622     0.0207     0.0518     0.0450 </r>
+        <r>    14.9991     0.0172     0.0159     0.0148     0.0299     0.0341     0.0693     0.0251     0.0581     0.0538 </r>
+        <r>    15.1115     0.0168     0.0152     0.0146     0.0284     0.0326     0.0627     0.0266     0.0473     0.0462 </r>
+        <r>    15.2239     0.0183     0.0168     0.0162     0.0306     0.0360     0.0644     0.0301     0.0468     0.0485 </r>
+        <r>    15.3362     0.0167     0.0166     0.0154     0.0284     0.0362     0.0489     0.0291     0.0395     0.0449 </r>
+        <r>    15.4486     0.0163     0.0158     0.0130     0.0236     0.0351     0.0442     0.0277     0.0399     0.0395 </r>
+        <r>    15.5610     0.0156     0.0148     0.0126     0.0210     0.0354     0.0397     0.0282     0.0397     0.0360 </r>
+        <r>    15.6733     0.0191     0.0161     0.0141     0.0206     0.0402     0.0402     0.0318     0.0453     0.0376 </r>
+        <r>    15.7857     0.0233     0.0196     0.0161     0.0221     0.0480     0.0428     0.0396     0.0565     0.0430 </r>
+        <r>    15.8981     0.0181     0.0248     0.0138     0.0216     0.0468     0.0386     0.0500     0.0496     0.0421 </r>
+        <r>    16.0104     0.0081     0.0137     0.0090     0.0131     0.0261     0.0288     0.0267     0.0306     0.0342 </r>
+        <r>    16.1228     0.0092     0.0115     0.0088     0.0116     0.0263     0.0386     0.0224     0.0376     0.0373 </r>
+        <r>    16.2352     0.0103     0.0112     0.0090     0.0114     0.0281     0.0425     0.0203     0.0375     0.0363 </r>
+        <r>    16.3476     0.0114     0.0108     0.0095     0.0113     0.0299     0.0464     0.0186     0.0402     0.0358 </r>
+        <r>    16.4599     0.0220     0.0148     0.0157     0.0180     0.0540     0.0844     0.0221     0.0668     0.0547 </r>
+        <r>    16.5723     0.0216     0.0135     0.0135     0.0180     0.0629     0.0629     0.0241     0.0563     0.0444 </r>
+        <r>    16.6847     0.0176     0.0126     0.0121     0.0148     0.0515     0.0549     0.0219     0.0520     0.0373 </r>
+        <r>    16.7970     0.0170     0.0129     0.0119     0.0141     0.0466     0.0532     0.0222     0.0526     0.0389 </r>
+        <r>    16.9094     0.0201     0.0155     0.0132     0.0160     0.0524     0.0612     0.0257     0.0600     0.0510 </r>
+        <r>    17.0218     0.0189     0.0169     0.0132     0.0157     0.0514     0.0613     0.0257     0.0600     0.0549 </r>
+        <r>    17.1341     0.0170     0.0211     0.0142     0.0154     0.0457     0.0596     0.0273     0.0706     0.0773 </r>
+        <r>    17.2465     0.0175     0.0194     0.0124     0.0162     0.0464     0.0532     0.0255     0.0666     0.0584 </r>
+        <r>    17.3589     0.0215     0.0203     0.0132     0.0181     0.0497     0.0576     0.0269     0.0724     0.0644 </r>
+        <r>    17.4713     0.0217     0.0197     0.0130     0.0174     0.0457     0.0535     0.0265     0.0687     0.0612 </r>
+        <r>    17.5836     0.0202     0.0180     0.0129     0.0160     0.0431     0.0491     0.0265     0.0650     0.0571 </r>
+        <r>    17.6960     0.0169     0.0127     0.0105     0.0109     0.0379     0.0432     0.0205     0.0490     0.0468 </r>
+        <r>    17.8084     0.0195     0.0131     0.0117     0.0123     0.0463     0.0545     0.0233     0.0635     0.0631 </r>
+        <r>    17.9207     0.0216     0.0136     0.0132     0.0132     0.0533     0.0594     0.0274     0.0710     0.0771 </r>
+        <r>    18.0331     0.0242     0.0142     0.0151     0.0134     0.0625     0.0630     0.0320     0.0781     0.0893 </r>
+        <r>    18.1455     0.0243     0.0140     0.0154     0.0133     0.0696     0.0611     0.0306     0.0705     0.0836 </r>
+        <r>    18.2579     0.0244     0.0140     0.0156     0.0136     0.0734     0.0604     0.0304     0.0680     0.0847 </r>
+        <r>    18.3702     0.0259     0.0149     0.0167     0.0144     0.0759     0.0643     0.0321     0.0716     0.0935 </r>
+        <r>    18.4826     0.0255     0.0157     0.0167     0.0144     0.0752     0.0636     0.0318     0.0681     0.1011 </r>
+        <r>    18.5950     0.0221     0.0140     0.0151     0.0126     0.0681     0.0551     0.0309     0.0609     0.0867 </r>
+        <r>    18.7073     0.0179     0.0117     0.0123     0.0097     0.0587     0.0449     0.0269     0.0507     0.0583 </r>
+        <r>    18.8197     0.0136     0.0096     0.0099     0.0076     0.0478     0.0371     0.0199     0.0424     0.0411 </r>
+        <r>    18.9321     0.0145     0.0092     0.0100     0.0081     0.0528     0.0482     0.0189     0.0460     0.0396 </r>
+        <r>    19.0444     0.0099     0.0068     0.0074     0.0060     0.0369     0.0356     0.0123     0.0319     0.0259 </r>
+        <r>    19.1568     0.0074     0.0051     0.0055     0.0045     0.0272     0.0279     0.0084     0.0224     0.0183 </r>
+        <r>    19.2692     0.0056     0.0038     0.0043     0.0036     0.0200     0.0218     0.0059     0.0173     0.0143 </r>
+        <r>    19.3816     0.0032     0.0021     0.0024     0.0022     0.0099     0.0115     0.0034     0.0106     0.0087 </r>
+        <r>    19.4939     0.0017     0.0010     0.0010     0.0013     0.0051     0.0047     0.0022     0.0049     0.0049 </r>
+        <r>    19.6063     0.0013     0.0007     0.0007     0.0010     0.0038     0.0035     0.0017     0.0037     0.0039 </r>
+        <r>    19.7187     0.0008     0.0005     0.0005     0.0007     0.0028     0.0024     0.0013     0.0027     0.0030 </r>
+        <r>    19.8310     0.0004     0.0003     0.0003     0.0004     0.0021     0.0013     0.0010     0.0019     0.0023 </r>
+        <r>    19.9434     0.0002     0.0002     0.0001     0.0002     0.0017     0.0006     0.0008     0.0015     0.0019 </r>
+        <r>    20.0558     0.0002     0.0002     0.0001     0.0002     0.0016     0.0005     0.0007     0.0014     0.0018 </r>
+        <r>    20.1681     0.0001     0.0002     0.0001     0.0002     0.0015     0.0005     0.0007     0.0013     0.0017 </r>
+        <r>    20.2805     0.0001     0.0001     0.0001     0.0002     0.0013     0.0004     0.0006     0.0012     0.0015 </r>
+        <r>    20.3929     0.0001     0.0001     0.0001     0.0002     0.0012     0.0004     0.0006     0.0011     0.0014 </r>
+        <r>    20.5053     0.0001     0.0001     0.0001     0.0002     0.0011     0.0003     0.0005     0.0011     0.0013 </r>
+        <r>    20.6176     0.0001     0.0001     0.0001     0.0001     0.0010     0.0003     0.0005     0.0010     0.0012 </r>
+        <r>    20.7300     0.0001     0.0001     0.0001     0.0001     0.0009     0.0003     0.0005     0.0009     0.0011 </r>
+        <r>    20.8424     0.0001     0.0001     0.0001     0.0001     0.0008     0.0002     0.0004     0.0009     0.0011 </r>
+        <r>    20.9547     0.0001     0.0001     0.0001     0.0001     0.0007     0.0002     0.0004     0.0008     0.0010 </r>
+        <r>    21.0671     0.0001     0.0001     0.0001     0.0001     0.0006     0.0002     0.0003     0.0007     0.0009 </r>
+        <r>    21.1795     0.0000     0.0001     0.0000     0.0001     0.0005     0.0001     0.0003     0.0007     0.0008 </r>
+        <r>    21.2918     0.0000     0.0000     0.0000     0.0001     0.0004     0.0001     0.0003     0.0006     0.0007 </r>
+        <r>    21.4042     0.0000     0.0000     0.0000     0.0001     0.0003     0.0001     0.0002     0.0005     0.0007 </r>
+        <r>    21.5166     0.0000     0.0000     0.0000     0.0001     0.0003     0.0001     0.0002     0.0005     0.0006 </r>
+        <r>    21.6290     0.0000     0.0000     0.0000     0.0001     0.0002     0.0000     0.0002     0.0005     0.0007 </r>
+        <r>    21.7413     0.0000     0.0000     0.0000     0.0001     0.0004     0.0001     0.0005     0.0006     0.0010 </r>
+        <r>    21.8537     0.0000     0.0000     0.0000     0.0000     0.0002     0.0000     0.0002     0.0003     0.0004 </r>
+        <r>    21.9661     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.0784     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.1908     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.3032     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.4156     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.5279     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.6403     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.7527     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.8650     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.9774     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.0898     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.2021     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.3145     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.4269     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.5393     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+       </set>
+      </set>
+      <set comment="ion 2">
+       <set comment="spin 1">
+        <r>   -10.1718     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>   -10.0594     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.9471     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.8347     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.7223     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.6100     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.4976     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.3852     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.2729     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.1605     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.0481     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.9357     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.8234     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.7110     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.5986     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.4863     0.0296     0.0000     0.0001     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.3739     0.0493     0.0002     0.0002     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.2615     0.0618     0.0003     0.0003     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.1491     0.0766     0.0004     0.0005     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.0368     0.0877     0.0006     0.0006     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.9244     0.0979     0.0008     0.0007     0.0014     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.8120     0.1098     0.0009     0.0008     0.0018     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.6997     0.1229     0.0011     0.0010     0.0022     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.5873     0.1355     0.0012     0.0012     0.0026     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.4749     0.1513     0.0015     0.0014     0.0031     0.0002     0.0001     0.0000     0.0000     0.0000 </r>
+        <r>    -7.3626     0.1743     0.0018     0.0019     0.0036     0.0002     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>    -7.2502     0.1999     0.0021     0.0025     0.0040     0.0003     0.0001     0.0001     0.0001     0.0001 </r>
+        <r>    -7.1378     0.2105     0.0022     0.0025     0.0044     0.0004     0.0001     0.0001     0.0001     0.0001 </r>
+        <r>    -7.0254     0.2278     0.0023     0.0027     0.0048     0.0005     0.0001     0.0001     0.0001     0.0001 </r>
+        <r>    -6.9131     0.2437     0.0025     0.0026     0.0054     0.0006     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -6.8007     0.2876     0.0029     0.0028     0.0064     0.0008     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -6.6883     0.4198     0.0045     0.0039     0.0087     0.0014     0.0003     0.0004     0.0002     0.0002 </r>
+        <r>    -6.5760     0.3339     0.0037     0.0032     0.0068     0.0011     0.0003     0.0003     0.0002     0.0002 </r>
+        <r>    -6.4636     0.2358     0.0034     0.0020     0.0045     0.0008     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -6.3512     0.1991     0.0033     0.0015     0.0033     0.0008     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -6.2389     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.1265     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.0141     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.9017     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.7894     0.0578     0.0020     0.0002     0.0010     0.0002     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>    -5.6770     0.1939     0.0057     0.0006     0.0047     0.0005     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -5.5646     0.2694     0.0060     0.0010     0.0070     0.0009     0.0003     0.0003     0.0001     0.0001 </r>
+        <r>    -5.4523     0.2655     0.0050     0.0013     0.0070     0.0009     0.0004     0.0003     0.0002     0.0001 </r>
+        <r>    -5.3399     0.2664     0.0045     0.0016     0.0066     0.0010     0.0004     0.0003     0.0002     0.0001 </r>
+        <r>    -5.2275     0.2834     0.0041     0.0025     0.0066     0.0010     0.0004     0.0003     0.0002     0.0001 </r>
+        <r>    -5.1152     0.4002     0.0042     0.0076     0.0080     0.0013     0.0004     0.0004     0.0002     0.0002 </r>
+        <r>    -5.0028     0.2581     0.0035     0.0035     0.0056     0.0010     0.0002     0.0003     0.0001     0.0001 </r>
+        <r>    -4.8904     0.2513     0.0033     0.0029     0.0055     0.0011     0.0002     0.0003     0.0001     0.0002 </r>
+        <r>    -4.7780     0.2170     0.0029     0.0024     0.0049     0.0009     0.0002     0.0003     0.0001     0.0001 </r>
+        <r>    -4.6657     0.1824     0.0025     0.0020     0.0044     0.0007     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -4.5533     0.1457     0.0022     0.0014     0.0037     0.0005     0.0001     0.0001     0.0001     0.0001 </r>
+        <r>    -4.4409     0.1253     0.0019     0.0012     0.0033     0.0004     0.0001     0.0001     0.0000     0.0001 </r>
+        <r>    -4.3286     0.1094     0.0015     0.0011     0.0030     0.0003     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>    -4.2162     0.0988     0.0014     0.0009     0.0027     0.0002     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>    -4.1038     0.0892     0.0013     0.0008     0.0024     0.0002     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>    -3.9915     0.0792     0.0013     0.0007     0.0021     0.0001     0.0001     0.0000     0.0000     0.0000 </r>
+        <r>    -3.8791     0.0686     0.0011     0.0006     0.0017     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.7667     0.0610     0.0009     0.0005     0.0015     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.6543     0.0543     0.0007     0.0004     0.0014     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.5420     0.0477     0.0005     0.0004     0.0012     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.4296     0.0418     0.0005     0.0003     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.3172     0.0362     0.0004     0.0003     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.2049     0.0307     0.0003     0.0002     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.0925     0.0255     0.0002     0.0002     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.9801     0.0206     0.0001     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.8677     0.0150     0.0001     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.7554     0.0069     0.0000     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.6430     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.5306     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.4183     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.3059     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.1935     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.0812     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.9688     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.8564     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.7440     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.6317     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.5193     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.4069     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.2946     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.1822     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.0698     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.9575     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.8451     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.7327     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.6203     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.5080     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.3956     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.2832     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.1709     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.0585     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.0539     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.1662     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.2786     0.0009     0.0108     0.0007     0.0219     0.0001     0.0000     0.0001     0.0000     0.0000 </r>
+        <r>     0.3910     0.0013     0.0174     0.0024     0.0350     0.0002     0.0001     0.0002     0.0001     0.0001 </r>
+        <r>     0.5034     0.0016     0.0253     0.0062     0.0485     0.0003     0.0001     0.0003     0.0002     0.0002 </r>
+        <r>     0.6157     0.0018     0.0312     0.0112     0.0566     0.0005     0.0002     0.0004     0.0002     0.0002 </r>
+        <r>     0.7281     0.0023     0.0421     0.0232     0.0700     0.0008     0.0003     0.0006     0.0003     0.0003 </r>
+        <r>     0.8405     0.0023     0.0388     0.0230     0.0629     0.0008     0.0003     0.0006     0.0003     0.0004 </r>
+        <r>     0.9528     0.0026     0.0382     0.0264     0.0598     0.0009     0.0004     0.0006     0.0003     0.0004 </r>
+        <r>     1.0652     0.0028     0.0368     0.0281     0.0564     0.0009     0.0004     0.0006     0.0003     0.0004 </r>
+        <r>     1.1776     0.0031     0.0393     0.0323     0.0569     0.0010     0.0005     0.0007     0.0003     0.0005 </r>
+        <r>     1.2899     0.0035     0.0432     0.0381     0.0589     0.0011     0.0006     0.0008     0.0003     0.0005 </r>
+        <r>     1.4023     0.0039     0.0466     0.0432     0.0601     0.0013     0.0006     0.0009     0.0004     0.0005 </r>
+        <r>     1.5147     0.0044     0.0504     0.0492     0.0611     0.0013     0.0007     0.0010     0.0004     0.0006 </r>
+        <r>     1.6271     0.0048     0.0555     0.0559     0.0633     0.0014     0.0009     0.0011     0.0005     0.0006 </r>
+        <r>     1.7394     0.0053     0.0629     0.0652     0.0671     0.0015     0.0010     0.0013     0.0006     0.0007 </r>
+        <r>     1.8518     0.0066     0.0829     0.1054     0.0774     0.0016     0.0014     0.0018     0.0008     0.0009 </r>
+        <r>     1.9642     0.0069     0.0809     0.0933     0.0759     0.0017     0.0014     0.0017     0.0009     0.0009 </r>
+        <r>     2.0765     0.0073     0.0895     0.0856     0.0786     0.0018     0.0015     0.0017     0.0009     0.0010 </r>
+        <r>     2.1889     0.0077     0.0958     0.0827     0.0796     0.0019     0.0016     0.0017     0.0010     0.0011 </r>
+        <r>     2.3013     0.0083     0.0973     0.0839     0.0788     0.0020     0.0017     0.0018     0.0011     0.0012 </r>
+        <r>     2.4137     0.0088     0.0960     0.0850     0.0778     0.0020     0.0018     0.0019     0.0011     0.0012 </r>
+        <r>     2.5260     0.0093     0.0942     0.0866     0.0754     0.0021     0.0019     0.0019     0.0012     0.0013 </r>
+        <r>     2.6384     0.0097     0.0955     0.0894     0.0727     0.0021     0.0020     0.0019     0.0013     0.0014 </r>
+        <r>     2.7508     0.0102     0.0980     0.0924     0.0709     0.0021     0.0021     0.0020     0.0014     0.0014 </r>
+        <r>     2.8631     0.0107     0.0977     0.0943     0.0681     0.0021     0.0021     0.0021     0.0015     0.0015 </r>
+        <r>     2.9755     0.0111     0.0995     0.0965     0.0671     0.0022     0.0022     0.0021     0.0016     0.0015 </r>
+        <r>     3.0879     0.0115     0.0985     0.0974     0.0678     0.0022     0.0023     0.0022     0.0016     0.0015 </r>
+        <r>     3.2002     0.0119     0.0953     0.0998     0.0659     0.0022     0.0023     0.0022     0.0017     0.0015 </r>
+        <r>     3.3126     0.0123     0.0909     0.1001     0.0603     0.0022     0.0023     0.0022     0.0018     0.0014 </r>
+        <r>     3.4250     0.0127     0.0882     0.0996     0.0540     0.0022     0.0023     0.0022     0.0019     0.0014 </r>
+        <r>     3.5374     0.0142     0.1085     0.1116     0.0583     0.0025     0.0026     0.0025     0.0023     0.0017 </r>
+        <r>     3.6497     0.0157     0.1070     0.1176     0.0624     0.0026     0.0029     0.0027     0.0025     0.0017 </r>
+        <r>     3.7621     0.0172     0.1077     0.1255     0.0670     0.0031     0.0034     0.0031     0.0028     0.0018 </r>
+        <r>     3.8745     0.0162     0.0852     0.1128     0.0615     0.0025     0.0032     0.0028     0.0023     0.0016 </r>
+        <r>     3.9868     0.0176     0.0746     0.1116     0.0650     0.0023     0.0034     0.0027     0.0021     0.0015 </r>
+        <r>     4.0992     0.0218     0.0780     0.1329     0.0732     0.0025     0.0042     0.0032     0.0022     0.0017 </r>
+        <r>     4.2116     0.0238     0.0728     0.1311     0.0787     0.0026     0.0045     0.0030     0.0019     0.0017 </r>
+        <r>     4.3239     0.0229     0.0564     0.1045     0.0803     0.0027     0.0041     0.0023     0.0012     0.0015 </r>
+        <r>     4.4363     0.0193     0.0410     0.0728     0.0737     0.0025     0.0033     0.0016     0.0007     0.0012 </r>
+        <r>     4.5487     0.0139     0.0256     0.0429     0.0550     0.0018     0.0023     0.0010     0.0004     0.0008 </r>
+        <r>     4.6611     0.0067     0.0122     0.0186     0.0269     0.0008     0.0011     0.0004     0.0002     0.0004 </r>
+        <r>     4.7734     0.0007     0.0017     0.0019     0.0038     0.0001     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>     4.8858     0.0000     0.0000     0.0000     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.9982     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.1105     0.0002     0.0002     0.0006     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.2229     0.0008     0.0007     0.0019     0.0024     0.0001     0.0002     0.0001     0.0001     0.0001 </r>
+        <r>     5.3353     0.0017     0.0016     0.0039     0.0050     0.0002     0.0003     0.0002     0.0001     0.0001 </r>
+        <r>     5.4476     0.0029     0.0027     0.0068     0.0086     0.0003     0.0006     0.0003     0.0002     0.0002 </r>
+        <r>     5.5600     0.0055     0.0068     0.0141     0.0148     0.0005     0.0015     0.0007     0.0005     0.0005 </r>
+        <r>     5.6724     0.0129     0.0229     0.0398     0.0315     0.0010     0.0043     0.0019     0.0013     0.0008 </r>
+        <r>     5.7848     0.0192     0.0355     0.0595     0.0504     0.0016     0.0063     0.0026     0.0018     0.0011 </r>
+        <r>     5.8971     0.0316     0.0629     0.0957     0.0932     0.0033     0.0092     0.0045     0.0035     0.0017 </r>
+        <r>     6.0095     0.0258     0.0568     0.0804     0.0764     0.0030     0.0082     0.0036     0.0026     0.0015 </r>
+        <r>     6.1219     0.0262     0.0727     0.0951     0.0733     0.0035     0.0097     0.0047     0.0033     0.0017 </r>
+        <r>     6.2342     0.0221     0.0685     0.0855     0.0622     0.0034     0.0086     0.0045     0.0032     0.0015 </r>
+        <r>     6.3466     0.0201     0.0696     0.0888     0.0566     0.0036     0.0087     0.0049     0.0035     0.0015 </r>
+        <r>     6.4590     0.0177     0.0655     0.0821     0.0514     0.0036     0.0079     0.0048     0.0032     0.0014 </r>
+        <r>     6.5713     0.0159     0.0628     0.0777     0.0478     0.0037     0.0073     0.0048     0.0030     0.0013 </r>
+        <r>     6.6837     0.0146     0.0609     0.0749     0.0456     0.0039     0.0069     0.0049     0.0029     0.0013 </r>
+        <r>     6.7961     0.0135     0.0596     0.0732     0.0445     0.0041     0.0066     0.0051     0.0028     0.0013 </r>
+        <r>     6.9085     0.0127     0.0584     0.0727     0.0440     0.0043     0.0063     0.0053     0.0028     0.0014 </r>
+        <r>     7.0208     0.0120     0.0579     0.0717     0.0432     0.0046     0.0061     0.0056     0.0028     0.0014 </r>
+        <r>     7.1332     0.0115     0.0577     0.0718     0.0444     0.0048     0.0060     0.0060     0.0028     0.0015 </r>
+        <r>     7.2456     0.0112     0.0576     0.0726     0.0463     0.0051     0.0060     0.0065     0.0028     0.0015 </r>
+        <r>     7.3579     0.0109     0.0583     0.0754     0.0477     0.0056     0.0060     0.0073     0.0028     0.0016 </r>
+        <r>     7.4703     0.0106     0.0592     0.0796     0.0484     0.0062     0.0060     0.0084     0.0029     0.0017 </r>
+        <r>     7.5827     0.0103     0.0598     0.0819     0.0486     0.0067     0.0059     0.0096     0.0030     0.0018 </r>
+        <r>     7.6951     0.0103     0.0624     0.0878     0.0519     0.0080     0.0058     0.0117     0.0031     0.0021 </r>
+        <r>     7.8074     0.0109     0.0660     0.1044     0.0560     0.0110     0.0058     0.0195     0.0033     0.0026 </r>
+        <r>     7.9198     0.0085     0.0636     0.0931     0.0508     0.0115     0.0052     0.0202     0.0031     0.0026 </r>
+        <r>     8.0322     0.0060     0.0617     0.0519     0.0498     0.0065     0.0043     0.0081     0.0029     0.0021 </r>
+        <r>     8.1445     0.0058     0.0841     0.0488     0.0634     0.0057     0.0046     0.0055     0.0035     0.0023 </r>
+        <r>     8.2569     0.0058     0.0723     0.0438     0.0609     0.0056     0.0044     0.0057     0.0034     0.0025 </r>
+        <r>     8.3693     0.0059     0.0757     0.0439     0.0648     0.0060     0.0045     0.0064     0.0037     0.0028 </r>
+        <r>     8.4816     0.0059     0.0747     0.0421     0.0650     0.0062     0.0044     0.0068     0.0037     0.0029 </r>
+        <r>     8.5940     0.0059     0.0745     0.0420     0.0646     0.0065     0.0044     0.0073     0.0037     0.0030 </r>
+        <r>     8.7064     0.0058     0.0695     0.0417     0.0592     0.0065     0.0041     0.0073     0.0035     0.0030 </r>
+        <r>     8.8188     0.0061     0.0741     0.0429     0.0634     0.0070     0.0045     0.0086     0.0038     0.0034 </r>
+        <r>     8.9311     0.0064     0.0788     0.0435     0.0664     0.0073     0.0049     0.0097     0.0040     0.0037 </r>
+        <r>     9.0435     0.0064     0.0803     0.0411     0.0661     0.0073     0.0047     0.0108     0.0039     0.0038 </r>
+        <r>     9.1559     0.0061     0.0894     0.0386     0.0730     0.0087     0.0053     0.0137     0.0042     0.0041 </r>
+        <r>     9.2682     0.0047     0.0655     0.0334     0.0582     0.0070     0.0035     0.0097     0.0034     0.0034 </r>
+        <r>     9.3806     0.0042     0.0569     0.0315     0.0528     0.0065     0.0030     0.0083     0.0031     0.0032 </r>
+        <r>     9.4930     0.0037     0.0503     0.0294     0.0490     0.0061     0.0026     0.0072     0.0029     0.0031 </r>
+        <r>     9.6053     0.0033     0.0445     0.0276     0.0456     0.0057     0.0023     0.0063     0.0028     0.0029 </r>
+        <r>     9.7177     0.0030     0.0394     0.0262     0.0421     0.0055     0.0020     0.0057     0.0026     0.0028 </r>
+        <r>     9.8301     0.0028     0.0347     0.0260     0.0384     0.0053     0.0019     0.0054     0.0025     0.0026 </r>
+        <r>     9.9425     0.0029     0.0292     0.0351     0.0356     0.0070     0.0024     0.0111     0.0045     0.0049 </r>
+        <r>    10.0548     0.0037     0.0358     0.0578     0.0427     0.0105     0.0045     0.0238     0.0066     0.0080 </r>
+        <r>    10.1672     0.0045     0.0425     0.0596     0.0514     0.0139     0.0054     0.0295     0.0077     0.0109 </r>
+        <r>    10.2796     0.0047     0.0414     0.0650     0.0485     0.0149     0.0067     0.0307     0.0099     0.0198 </r>
+        <r>    10.3919     0.0048     0.0399     0.0698     0.0476     0.0146     0.0074     0.0327     0.0101     0.0188 </r>
+        <r>    10.5043     0.0041     0.0337     0.0481     0.0438     0.0124     0.0070     0.0291     0.0097     0.0169 </r>
+        <r>    10.6167     0.0029     0.0237     0.0222     0.0365     0.0092     0.0057     0.0230     0.0081     0.0141 </r>
+        <r>    10.7290     0.0025     0.0219     0.0151     0.0375     0.0078     0.0051     0.0208     0.0076     0.0128 </r>
+        <r>    10.8414     0.0026     0.0255     0.0156     0.0447     0.0079     0.0053     0.0219     0.0083     0.0129 </r>
+        <r>    10.9538     0.0029     0.0321     0.0191     0.0566     0.0088     0.0063     0.0253     0.0105     0.0145 </r>
+        <r>    11.0662     0.0036     0.0541     0.0275     0.0904     0.0112     0.0087     0.0287     0.0148     0.0206 </r>
+        <r>    11.1785     0.0018     0.0269     0.0104     0.0454     0.0071     0.0042     0.0176     0.0068     0.0104 </r>
+        <r>    11.2909     0.0016     0.0223     0.0081     0.0374     0.0083     0.0062     0.0206     0.0104     0.0114 </r>
+        <r>    11.4033     0.0015     0.0189     0.0060     0.0313     0.0075     0.0064     0.0176     0.0112     0.0126 </r>
+        <r>    11.5156     0.0015     0.0156     0.0046     0.0251     0.0075     0.0074     0.0174     0.0132     0.0150 </r>
+        <r>    11.6280     0.0013     0.0124     0.0035     0.0189     0.0068     0.0072     0.0155     0.0130     0.0127 </r>
+        <r>    11.7404     0.0011     0.0060     0.0026     0.0072     0.0059     0.0074     0.0131     0.0134     0.0117 </r>
+        <r>    11.8527     0.0010     0.0040     0.0022     0.0049     0.0051     0.0076     0.0109     0.0137     0.0107 </r>
+        <r>    11.9651     0.0013     0.0091     0.0042     0.0115     0.0074     0.0096     0.0153     0.0167     0.0154 </r>
+        <r>    12.0775     0.0015     0.0097     0.0035     0.0127     0.0092     0.0110     0.0162     0.0190     0.0187 </r>
+        <r>    12.1899     0.0020     0.0103     0.0033     0.0143     0.0108     0.0120     0.0169     0.0208     0.0224 </r>
+        <r>    12.3022     0.0027     0.0095     0.0040     0.0151     0.0106     0.0126     0.0168     0.0233     0.0246 </r>
+        <r>    12.4146     0.0034     0.0094     0.0051     0.0169     0.0113     0.0135     0.0171     0.0266     0.0276 </r>
+        <r>    12.5270     0.0040     0.0088     0.0056     0.0161     0.0112     0.0141     0.0163     0.0276     0.0280 </r>
+        <r>    12.6393     0.0048     0.0085     0.0055     0.0155     0.0111     0.0147     0.0147     0.0282     0.0279 </r>
+        <r>    12.7517     0.0059     0.0086     0.0054     0.0152     0.0115     0.0151     0.0135     0.0285     0.0273 </r>
+        <r>    12.8641     0.0070     0.0088     0.0055     0.0151     0.0120     0.0151     0.0128     0.0280     0.0265 </r>
+        <r>    12.9765     0.0079     0.0090     0.0056     0.0154     0.0126     0.0152     0.0125     0.0276     0.0258 </r>
+        <r>    13.0888     0.0086     0.0091     0.0058     0.0158     0.0132     0.0154     0.0124     0.0271     0.0253 </r>
+        <r>    13.2012     0.0091     0.0091     0.0061     0.0164     0.0137     0.0156     0.0126     0.0265     0.0249 </r>
+        <r>    13.3136     0.0094     0.0092     0.0062     0.0168     0.0143     0.0159     0.0128     0.0261     0.0250 </r>
+        <r>    13.4259     0.0099     0.0096     0.0065     0.0170     0.0152     0.0162     0.0136     0.0257     0.0249 </r>
+        <r>    13.5383     0.0103     0.0102     0.0067     0.0173     0.0163     0.0166     0.0144     0.0255     0.0254 </r>
+        <r>    13.6507     0.0109     0.0126     0.0071     0.0188     0.0235     0.0200     0.0172     0.0295     0.0277 </r>
+        <r>    13.7630     0.0117     0.0160     0.0077     0.0209     0.0265     0.0227     0.0203     0.0315     0.0307 </r>
+        <r>    13.8754     0.0162     0.0295     0.0094     0.0290     0.0501     0.0289     0.0345     0.0366     0.0395 </r>
+        <r>    13.9878     0.0132     0.0233     0.0091     0.0229     0.0340     0.0299     0.0260     0.0350     0.0373 </r>
+        <r>    14.1002     0.0124     0.0189     0.0090     0.0201     0.0268     0.0314     0.0211     0.0348     0.0366 </r>
+        <r>    14.2125     0.0123     0.0169     0.0091     0.0195     0.0239     0.0328     0.0192     0.0348     0.0353 </r>
+        <r>    14.3249     0.0105     0.0148     0.0084     0.0180     0.0216     0.0337     0.0181     0.0340     0.0330 </r>
+        <r>    14.4373     0.0094     0.0130     0.0080     0.0169     0.0202     0.0350     0.0172     0.0339     0.0313 </r>
+        <r>    14.5496     0.0094     0.0115     0.0082     0.0170     0.0198     0.0381     0.0164     0.0352     0.0313 </r>
+        <r>    14.6620     0.0098     0.0107     0.0088     0.0178     0.0196     0.0423     0.0158     0.0375     0.0322 </r>
+        <r>    14.7744     0.0108     0.0118     0.0098     0.0200     0.0212     0.0481     0.0166     0.0419     0.0360 </r>
+        <r>    14.8867     0.0127     0.0127     0.0118     0.0233     0.0240     0.0612     0.0194     0.0496     0.0432 </r>
+        <r>    14.9991     0.0139     0.0138     0.0141     0.0262     0.0263     0.0621     0.0234     0.0533     0.0440 </r>
+        <r>    15.1115     0.0145     0.0149     0.0155     0.0291     0.0278     0.0611     0.0268     0.0501     0.0438 </r>
+        <r>    15.2239     0.0151     0.0154     0.0163     0.0298     0.0289     0.0625     0.0282     0.0470     0.0420 </r>
+        <r>    15.3362     0.0157     0.0166     0.0175     0.0310     0.0325     0.0603     0.0308     0.0445     0.0423 </r>
+        <r>    15.4486     0.0135     0.0154     0.0143     0.0266     0.0306     0.0463     0.0287     0.0399     0.0338 </r>
+        <r>    15.5610     0.0128     0.0153     0.0134     0.0216     0.0309     0.0399     0.0283     0.0380     0.0294 </r>
+        <r>    15.6733     0.0129     0.0149     0.0132     0.0189     0.0320     0.0384     0.0289     0.0389     0.0278 </r>
+        <r>    15.7857     0.0174     0.0173     0.0151     0.0201     0.0390     0.0402     0.0342     0.0455     0.0302 </r>
+        <r>    15.8981     0.0185     0.0209     0.0152     0.0208     0.0440     0.0412     0.0414     0.0494     0.0326 </r>
+        <r>    16.0104     0.0137     0.0273     0.0129     0.0213     0.0402     0.0373     0.0524     0.0427     0.0311 </r>
+        <r>    16.1228     0.0085     0.0125     0.0084     0.0109     0.0231     0.0314     0.0250     0.0343     0.0278 </r>
+        <r>    16.2352     0.0089     0.0111     0.0081     0.0102     0.0224     0.0378     0.0207     0.0346     0.0281 </r>
+        <r>    16.3476     0.0105     0.0107     0.0085     0.0099     0.0238     0.0434     0.0186     0.0379     0.0297 </r>
+        <r>    16.4599     0.0113     0.0105     0.0091     0.0099     0.0251     0.0452     0.0168     0.0400     0.0297 </r>
+        <r>    16.5723     0.0211     0.0139     0.0142     0.0159     0.0517     0.0670     0.0217     0.0576     0.0429 </r>
+        <r>    16.6847     0.0198     0.0137     0.0132     0.0160     0.0520     0.0585     0.0224     0.0515     0.0396 </r>
+        <r>    16.7970     0.0153     0.0127     0.0118     0.0131     0.0397     0.0484     0.0201     0.0481     0.0332 </r>
+        <r>    16.9094     0.0171     0.0147     0.0129     0.0146     0.0429     0.0538     0.0230     0.0531     0.0401 </r>
+        <r>    17.0218     0.0177     0.0169     0.0130     0.0153     0.0445     0.0596     0.0247     0.0553     0.0462 </r>
+        <r>    17.1341     0.0139     0.0176     0.0118     0.0140     0.0379     0.0544     0.0239     0.0537     0.0415 </r>
+        <r>    17.2465     0.0129     0.0186     0.0138     0.0136     0.0411     0.0536     0.0244     0.0615     0.0629 </r>
+        <r>    17.3589     0.0131     0.0177     0.0112     0.0139     0.0358     0.0486     0.0228     0.0577     0.0396 </r>
+        <r>    17.4713     0.0141     0.0178     0.0116     0.0145     0.0372     0.0514     0.0230     0.0626     0.0404 </r>
+        <r>    17.5836     0.0165     0.0190     0.0131     0.0164     0.0414     0.0583     0.0254     0.0698     0.0450 </r>
+        <r>    17.6960     0.0157     0.0169     0.0128     0.0149     0.0431     0.0540     0.0244     0.0655     0.0464 </r>
+        <r>    17.8084     0.0154     0.0141     0.0110     0.0119     0.0440     0.0548     0.0219     0.0639     0.0534 </r>
+        <r>    17.9207     0.0162     0.0135     0.0117     0.0115     0.0480     0.0566     0.0236     0.0652     0.0607 </r>
+        <r>    18.0331     0.0189     0.0131     0.0129     0.0118     0.0549     0.0592     0.0269     0.0715     0.0702 </r>
+        <r>    18.1455     0.0190     0.0121     0.0129     0.0117     0.0561     0.0562     0.0266     0.0733     0.0726 </r>
+        <r>    18.2579     0.0184     0.0111     0.0129     0.0115     0.0561     0.0528     0.0253     0.0698     0.0717 </r>
+        <r>    18.3702     0.0190     0.0115     0.0138     0.0120     0.0657     0.0535     0.0260     0.0679     0.0738 </r>
+        <r>    18.4826     0.0200     0.0122     0.0147     0.0125     0.0758     0.0556     0.0277     0.0689     0.0793 </r>
+        <r>    18.5950     0.0207     0.0127     0.0155     0.0128     0.0762     0.0578     0.0290     0.0706     0.0861 </r>
+        <r>    18.7073     0.0210     0.0130     0.0157     0.0134     0.0752     0.0578     0.0287     0.0709     0.0943 </r>
+        <r>    18.8197     0.0143     0.0086     0.0115     0.0088     0.0556     0.0406     0.0205     0.0492     0.0582 </r>
+        <r>    18.9321     0.0140     0.0080     0.0107     0.0076     0.0541     0.0394     0.0224     0.0525     0.0421 </r>
+        <r>    19.0444     0.0097     0.0066     0.0091     0.0064     0.0435     0.0378     0.0148     0.0443     0.0359 </r>
+        <r>    19.1568     0.0086     0.0061     0.0085     0.0059     0.0405     0.0385     0.0132     0.0357     0.0291 </r>
+        <r>    19.2692     0.0070     0.0048     0.0066     0.0046     0.0330     0.0347     0.0094     0.0256     0.0207 </r>
+        <r>    19.3816     0.0047     0.0032     0.0045     0.0032     0.0208     0.0232     0.0054     0.0178     0.0138 </r>
+        <r>    19.4939     0.0032     0.0021     0.0031     0.0024     0.0143     0.0149     0.0038     0.0126     0.0098 </r>
+        <r>    19.6063     0.0015     0.0008     0.0011     0.0013     0.0055     0.0050     0.0019     0.0058     0.0043 </r>
+        <r>    19.7187     0.0010     0.0006     0.0008     0.0009     0.0039     0.0036     0.0014     0.0041     0.0033 </r>
+        <r>    19.8310     0.0007     0.0004     0.0005     0.0007     0.0028     0.0025     0.0011     0.0030     0.0025 </r>
+        <r>    19.9434     0.0004     0.0002     0.0003     0.0004     0.0021     0.0015     0.0008     0.0021     0.0019 </r>
+        <r>    20.0558     0.0002     0.0001     0.0001     0.0002     0.0016     0.0005     0.0006     0.0015     0.0014 </r>
+        <r>    20.1681     0.0001     0.0001     0.0001     0.0002     0.0015     0.0005     0.0006     0.0014     0.0014 </r>
+        <r>    20.2805     0.0001     0.0001     0.0001     0.0002     0.0014     0.0004     0.0005     0.0013     0.0013 </r>
+        <r>    20.3929     0.0001     0.0001     0.0001     0.0002     0.0013     0.0004     0.0005     0.0013     0.0012 </r>
+        <r>    20.5053     0.0001     0.0001     0.0001     0.0002     0.0011     0.0003     0.0005     0.0012     0.0011 </r>
+        <r>    20.6176     0.0001     0.0001     0.0001     0.0002     0.0010     0.0003     0.0004     0.0011     0.0010 </r>
+        <r>    20.7300     0.0001     0.0001     0.0001     0.0001     0.0009     0.0003     0.0004     0.0010     0.0009 </r>
+        <r>    20.8424     0.0001     0.0001     0.0001     0.0001     0.0008     0.0002     0.0003     0.0009     0.0008 </r>
+        <r>    20.9547     0.0001     0.0001     0.0001     0.0001     0.0007     0.0002     0.0003     0.0009     0.0008 </r>
+        <r>    21.0671     0.0001     0.0001     0.0001     0.0001     0.0006     0.0002     0.0003     0.0008     0.0007 </r>
+        <r>    21.1795     0.0001     0.0000     0.0000     0.0001     0.0006     0.0001     0.0002     0.0007     0.0006 </r>
+        <r>    21.2918     0.0001     0.0000     0.0000     0.0001     0.0005     0.0001     0.0002     0.0006     0.0006 </r>
+        <r>    21.4042     0.0000     0.0000     0.0000     0.0001     0.0004     0.0001     0.0002     0.0006     0.0005 </r>
+        <r>    21.5166     0.0000     0.0000     0.0000     0.0001     0.0003     0.0001     0.0002     0.0005     0.0005 </r>
+        <r>    21.6290     0.0000     0.0000     0.0000     0.0001     0.0003     0.0000     0.0001     0.0005     0.0004 </r>
+        <r>    21.7413     0.0000     0.0000     0.0000     0.0000     0.0002     0.0000     0.0001     0.0004     0.0004 </r>
+        <r>    21.8537     0.0000     0.0000     0.0000     0.0001     0.0004     0.0000     0.0004     0.0006     0.0008 </r>
+        <r>    21.9661     0.0000     0.0000     0.0000     0.0000     0.0003     0.0000     0.0003     0.0004     0.0006 </r>
+        <r>    22.0784     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.1908     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.3032     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.4156     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.5279     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.6403     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.7527     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.8650     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.9774     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.0898     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.2021     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.3145     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.4269     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.5393     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+       </set>
+       <set comment="spin 2">
+        <r>   -10.1718     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>   -10.0594     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.9471     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.8347     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.7223     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.6100     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.4976     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.3852     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.2729     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.1605     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -9.0481     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.9357     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.8234     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.7110     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.5986     0.0148     0.0000     0.0001     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.4863     0.0423     0.0001     0.0002     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.3739     0.0564     0.0003     0.0003     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.2615     0.0710     0.0004     0.0004     0.0008     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.1491     0.0835     0.0005     0.0005     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -8.0368     0.0942     0.0008     0.0006     0.0013     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.9244     0.1048     0.0009     0.0007     0.0017     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.8120     0.1176     0.0011     0.0009     0.0020     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -7.6997     0.1306     0.0012     0.0010     0.0025     0.0001     0.0001     0.0000     0.0001     0.0000 </r>
+        <r>    -7.5873     0.1437     0.0014     0.0012     0.0029     0.0001     0.0001     0.0001     0.0001     0.0000 </r>
+        <r>    -7.4749     0.1624     0.0017     0.0016     0.0034     0.0002     0.0001     0.0001     0.0001     0.0000 </r>
+        <r>    -7.3626     0.1920     0.0021     0.0022     0.0040     0.0002     0.0001     0.0001     0.0001     0.0000 </r>
+        <r>    -7.2502     0.2016     0.0023     0.0022     0.0043     0.0003     0.0001     0.0001     0.0001     0.0001 </r>
+        <r>    -7.1378     0.2215     0.0024     0.0025     0.0048     0.0004     0.0002     0.0001     0.0001     0.0001 </r>
+        <r>    -7.0254     0.2324     0.0025     0.0024     0.0052     0.0005     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -6.9131     0.2619     0.0028     0.0025     0.0060     0.0006     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -6.8007     0.3362     0.0040     0.0030     0.0075     0.0009     0.0003     0.0003     0.0002     0.0002 </r>
+        <r>    -6.6883     0.4160     0.0047     0.0037     0.0090     0.0013     0.0004     0.0004     0.0002     0.0002 </r>
+        <r>    -6.5760     0.2858     0.0038     0.0024     0.0059     0.0009     0.0003     0.0003     0.0002     0.0001 </r>
+        <r>    -6.4636     0.2095     0.0035     0.0016     0.0038     0.0007     0.0002     0.0002     0.0001     0.0001 </r>
+        <r>    -6.3512     0.3574     0.0088     0.0017     0.0051     0.0012     0.0004     0.0004     0.0002     0.0002 </r>
+        <r>    -6.2389     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.1265     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -6.0141     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.9017     0.0135     0.0006     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -5.7894     0.1319     0.0046     0.0004     0.0031     0.0003     0.0001     0.0001     0.0001     0.0001 </r>
+        <r>    -5.6770     0.2354     0.0067     0.0008     0.0065     0.0006     0.0002     0.0003     0.0002     0.0001 </r>
+        <r>    -5.5646     0.2638     0.0059     0.0011     0.0077     0.0007     0.0003     0.0003     0.0002     0.0001 </r>
+        <r>    -5.4523     0.2619     0.0052     0.0014     0.0070     0.0008     0.0003     0.0004     0.0002     0.0001 </r>
+        <r>    -5.3399     0.2619     0.0046     0.0017     0.0068     0.0008     0.0003     0.0004     0.0002     0.0001 </r>
+        <r>    -5.2275     0.3088     0.0044     0.0034     0.0071     0.0009     0.0003     0.0005     0.0002     0.0001 </r>
+        <r>    -5.1152     0.2930     0.0041     0.0042     0.0064     0.0009     0.0003     0.0006     0.0001     0.0001 </r>
+        <r>    -5.0028     0.2508     0.0036     0.0031     0.0057     0.0008     0.0002     0.0005     0.0001     0.0001 </r>
+        <r>    -4.8904     0.2374     0.0033     0.0026     0.0055     0.0008     0.0002     0.0005     0.0001     0.0001 </r>
+        <r>    -4.7780     0.2040     0.0029     0.0022     0.0050     0.0006     0.0002     0.0004     0.0001     0.0001 </r>
+        <r>    -4.6657     0.1713     0.0026     0.0017     0.0044     0.0005     0.0001     0.0003     0.0001     0.0001 </r>
+        <r>    -4.5533     0.1362     0.0022     0.0013     0.0037     0.0003     0.0001     0.0002     0.0001     0.0001 </r>
+        <r>    -4.4409     0.1195     0.0019     0.0011     0.0034     0.0002     0.0001     0.0002     0.0000     0.0000 </r>
+        <r>    -4.3286     0.1054     0.0016     0.0010     0.0030     0.0002     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>    -4.2162     0.0956     0.0015     0.0009     0.0027     0.0002     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>    -4.1038     0.0862     0.0014     0.0008     0.0024     0.0001     0.0001     0.0001     0.0000     0.0000 </r>
+        <r>    -3.9915     0.0756     0.0013     0.0006     0.0020     0.0001     0.0000     0.0001     0.0000     0.0000 </r>
+        <r>    -3.8791     0.0657     0.0011     0.0005     0.0017     0.0001     0.0000     0.0001     0.0000     0.0000 </r>
+        <r>    -3.7667     0.0589     0.0009     0.0004     0.0016     0.0001     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.6543     0.0522     0.0007     0.0004     0.0014     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.5420     0.0458     0.0006     0.0003     0.0011     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.4296     0.0401     0.0005     0.0003     0.0009     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.3172     0.0346     0.0004     0.0002     0.0007     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.2049     0.0292     0.0003     0.0002     0.0005     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -3.0925     0.0241     0.0002     0.0001     0.0004     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.9801     0.0193     0.0001     0.0001     0.0003     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.8677     0.0131     0.0000     0.0001     0.0002     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.7554     0.0047     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.6430     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.5306     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.4183     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.3059     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.1935     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -2.0812     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.9688     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.8564     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.7440     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.6317     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.5193     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.4069     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.2946     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.1822     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -1.0698     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.9575     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.8451     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.7327     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.6203     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.5080     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.3956     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.2832     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.1709     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    -0.0585     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.0539     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.1662     0.0008     0.0102     0.0003     0.0203     0.0002     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     0.2786     0.0013     0.0188     0.0010     0.0370     0.0003     0.0000     0.0001     0.0001     0.0002 </r>
+        <r>     0.3910     0.0016     0.0258     0.0033     0.0483     0.0004     0.0001     0.0002     0.0001     0.0003 </r>
+        <r>     0.5034     0.0019     0.0339     0.0077     0.0590     0.0005     0.0001     0.0004     0.0002     0.0005 </r>
+        <r>     0.6157     0.0023     0.0462     0.0139     0.0756     0.0007     0.0002     0.0007     0.0003     0.0008 </r>
+        <r>     0.7281     0.0024     0.0418     0.0184     0.0645     0.0007     0.0002     0.0007     0.0002     0.0007 </r>
+        <r>     0.8405     0.0027     0.0404     0.0219     0.0598     0.0007     0.0002     0.0008     0.0002     0.0008 </r>
+        <r>     0.9528     0.0029     0.0404     0.0238     0.0587     0.0008     0.0002     0.0008     0.0003     0.0008 </r>
+        <r>     1.0652     0.0031     0.0420     0.0276     0.0589     0.0008     0.0002     0.0009     0.0003     0.0009 </r>
+        <r>     1.1776     0.0035     0.0442     0.0318     0.0592     0.0009     0.0003     0.0010     0.0003     0.0009 </r>
+        <r>     1.2899     0.0039     0.0484     0.0384     0.0609     0.0010     0.0003     0.0011     0.0004     0.0009 </r>
+        <r>     1.4023     0.0044     0.0538     0.0449     0.0639     0.0012     0.0004     0.0012     0.0004     0.0009 </r>
+        <r>     1.5147     0.0049     0.0604     0.0480     0.0676     0.0013     0.0005     0.0013     0.0005     0.0010 </r>
+        <r>     1.6271     0.0053     0.0701     0.0535     0.0723     0.0014     0.0006     0.0014     0.0005     0.0012 </r>
+        <r>     1.7394     0.0063     0.1000     0.0728     0.0878     0.0016     0.0008     0.0018     0.0007     0.0014 </r>
+        <r>     1.8518     0.0071     0.1130     0.0786     0.0936     0.0016     0.0009     0.0020     0.0008     0.0015 </r>
+        <r>     1.9642     0.0071     0.1011     0.0667     0.0857     0.0017     0.0010     0.0018     0.0008     0.0015 </r>
+        <r>     2.0765     0.0076     0.0943     0.0764     0.0802     0.0018     0.0011     0.0019     0.0008     0.0015 </r>
+        <r>     2.1889     0.0082     0.0910     0.0866     0.0769     0.0019     0.0012     0.0019     0.0009     0.0015 </r>
+        <r>     2.3013     0.0088     0.0920     0.0932     0.0764     0.0020     0.0013     0.0020     0.0009     0.0015 </r>
+        <r>     2.4137     0.0093     0.0930     0.0906     0.0750     0.0020     0.0015     0.0021     0.0009     0.0015 </r>
+        <r>     2.5260     0.0096     0.0942     0.0927     0.0728     0.0021     0.0016     0.0021     0.0010     0.0015 </r>
+        <r>     2.6384     0.0099     0.0950     0.0962     0.0705     0.0021     0.0018     0.0022     0.0010     0.0015 </r>
+        <r>     2.7508     0.0103     0.0948     0.1000     0.0687     0.0021     0.0020     0.0023     0.0010     0.0015 </r>
+        <r>     2.8631     0.0107     0.0960     0.1019     0.0685     0.0022     0.0021     0.0024     0.0010     0.0015 </r>
+        <r>     2.9755     0.0110     0.0958     0.1001     0.0694     0.0022     0.0022     0.0024     0.0010     0.0015 </r>
+        <r>     3.0879     0.0111     0.0908     0.0975     0.0672     0.0022     0.0023     0.0024     0.0010     0.0013 </r>
+        <r>     3.2002     0.0114     0.0876     0.0969     0.0639     0.0022     0.0025     0.0024     0.0010     0.0012 </r>
+        <r>     3.3126     0.0117     0.0850     0.0960     0.0573     0.0022     0.0026     0.0023     0.0010     0.0010 </r>
+        <r>     3.4250     0.0134     0.1120     0.1142     0.0644     0.0024     0.0031     0.0027     0.0011     0.0011 </r>
+        <r>     3.5374     0.0148     0.1089     0.1133     0.0625     0.0026     0.0034     0.0029     0.0012     0.0012 </r>
+        <r>     3.6497     0.0171     0.1085     0.1208     0.0678     0.0029     0.0040     0.0034     0.0013     0.0014 </r>
+        <r>     3.7621     0.0165     0.0912     0.1143     0.0606     0.0026     0.0039     0.0030     0.0012     0.0013 </r>
+        <r>     3.8745     0.0154     0.0691     0.1031     0.0537     0.0023     0.0037     0.0022     0.0011     0.0011 </r>
+        <r>     3.9868     0.0184     0.0677     0.1122     0.0630     0.0026     0.0043     0.0022     0.0012     0.0013 </r>
+        <r>     4.0992     0.0256     0.0786     0.1431     0.0817     0.0036     0.0056     0.0027     0.0018     0.0017 </r>
+        <r>     4.2116     0.0289     0.0767     0.1426     0.0929     0.0042     0.0060     0.0027     0.0018     0.0020 </r>
+        <r>     4.3239     0.0253     0.0569     0.1072     0.0848     0.0037     0.0047     0.0020     0.0013     0.0018 </r>
+        <r>     4.4363     0.0179     0.0333     0.0617     0.0656     0.0028     0.0031     0.0013     0.0007     0.0014 </r>
+        <r>     4.5487     0.0092     0.0152     0.0265     0.0349     0.0014     0.0016     0.0006     0.0002     0.0007 </r>
+        <r>     4.6611     0.0017     0.0041     0.0058     0.0076     0.0003     0.0003     0.0002     0.0001     0.0001 </r>
+        <r>     4.7734     0.0002     0.0005     0.0005     0.0013     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.8858     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     4.9982     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.1105     0.0000     0.0000     0.0001     0.0001     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>     5.2229     0.0005     0.0006     0.0014     0.0015     0.0000     0.0001     0.0000     0.0001     0.0000 </r>
+        <r>     5.3353     0.0016     0.0018     0.0044     0.0049     0.0002     0.0004     0.0001     0.0002     0.0001 </r>
+        <r>     5.4476     0.0034     0.0040     0.0094     0.0104     0.0003     0.0008     0.0003     0.0004     0.0003 </r>
+        <r>     5.5600     0.0143     0.0288     0.0481     0.0344     0.0012     0.0050     0.0020     0.0025     0.0016 </r>
+        <r>     5.6724     0.0168     0.0388     0.0551     0.0433     0.0014     0.0061     0.0024     0.0026     0.0021 </r>
+        <r>     5.7848     0.0272     0.0628     0.0817     0.0806     0.0030     0.0091     0.0036     0.0036     0.0030 </r>
+        <r>     5.8971     0.0272     0.0667     0.0796     0.0869     0.0038     0.0089     0.0035     0.0034     0.0035 </r>
+        <r>     6.0095     0.0301     0.0892     0.1047     0.0897     0.0049     0.0116     0.0050     0.0046     0.0045 </r>
+        <r>     6.1219     0.0228     0.0735     0.0837     0.0686     0.0045     0.0088     0.0040     0.0038     0.0036 </r>
+        <r>     6.2342     0.0197     0.0719     0.0842     0.0580     0.0046     0.0086     0.0041     0.0038     0.0034 </r>
+        <r>     6.3466     0.0180     0.0674     0.0814     0.0538     0.0045     0.0081     0.0041     0.0036     0.0033 </r>
+        <r>     6.4590     0.0163     0.0647     0.0774     0.0496     0.0046     0.0075     0.0041     0.0034     0.0031 </r>
+        <r>     6.5713     0.0149     0.0625     0.0745     0.0467     0.0047     0.0070     0.0042     0.0033     0.0031 </r>
+        <r>     6.6837     0.0139     0.0609     0.0726     0.0449     0.0049     0.0067     0.0043     0.0031     0.0030 </r>
+        <r>     6.7961     0.0130     0.0594     0.0717     0.0440     0.0051     0.0063     0.0045     0.0031     0.0030 </r>
+        <r>     6.9085     0.0124     0.0589     0.0716     0.0435     0.0054     0.0062     0.0048     0.0031     0.0030 </r>
+        <r>     7.0208     0.0120     0.0589     0.0724     0.0435     0.0057     0.0060     0.0052     0.0031     0.0031 </r>
+        <r>     7.1332     0.0118     0.0587     0.0752     0.0458     0.0061     0.0061     0.0057     0.0032     0.0032 </r>
+        <r>     7.2456     0.0115     0.0591     0.0777     0.0466     0.0066     0.0060     0.0065     0.0033     0.0033 </r>
+        <r>     7.3579     0.0113     0.0597     0.0811     0.0474     0.0072     0.0060     0.0077     0.0034     0.0035 </r>
+        <r>     7.4703     0.0111     0.0608     0.0844     0.0484     0.0081     0.0060     0.0091     0.0035     0.0036 </r>
+        <r>     7.5827     0.0111     0.0640     0.0903     0.0525     0.0097     0.0061     0.0110     0.0037     0.0039 </r>
+        <r>     7.6951     0.0126     0.0923     0.1212     0.0982     0.0144     0.0088     0.0193     0.0053     0.0084 </r>
+        <r>     7.8074     0.0097     0.0715     0.1073     0.0544     0.0157     0.0058     0.0224     0.0043     0.0048 </r>
+        <r>     7.9198     0.0064     0.0742     0.0585     0.0565     0.0094     0.0050     0.0064     0.0038     0.0037 </r>
+        <r>     8.0322     0.0060     0.0723     0.0466     0.0589     0.0082     0.0049     0.0043     0.0037     0.0034 </r>
+        <r>     8.1445     0.0060     0.0711     0.0446     0.0604     0.0084     0.0050     0.0047     0.0036     0.0033 </r>
+        <r>     8.2569     0.0060     0.0730     0.0433     0.0633     0.0089     0.0052     0.0052     0.0037     0.0034 </r>
+        <r>     8.3693     0.0060     0.0725     0.0410     0.0640     0.0091     0.0052     0.0056     0.0038     0.0032 </r>
+        <r>     8.4816     0.0060     0.0749     0.0413     0.0649     0.0096     0.0052     0.0062     0.0039     0.0032 </r>
+        <r>     8.5940     0.0059     0.0697     0.0404     0.0594     0.0093     0.0049     0.0063     0.0035     0.0030 </r>
+        <r>     8.7064     0.0062     0.0726     0.0407     0.0620     0.0098     0.0052     0.0072     0.0038     0.0030 </r>
+        <r>     8.8188     0.0066     0.0800     0.0418     0.0665     0.0106     0.0058     0.0087     0.0042     0.0031 </r>
+        <r>     8.9311     0.0069     0.0836     0.0396     0.0689     0.0110     0.0058     0.0099     0.0042     0.0031 </r>
+        <r>     9.0435     0.0065     0.0905     0.0371     0.0727     0.0120     0.0064     0.0125     0.0045     0.0031 </r>
+        <r>     9.1559     0.0051     0.0699     0.0321     0.0607     0.0100     0.0047     0.0094     0.0035     0.0027 </r>
+        <r>     9.2682     0.0044     0.0595     0.0303     0.0545     0.0090     0.0041     0.0080     0.0031     0.0026 </r>
+        <r>     9.3806     0.0039     0.0517     0.0281     0.0502     0.0081     0.0036     0.0068     0.0028     0.0025 </r>
+        <r>     9.4930     0.0035     0.0451     0.0262     0.0467     0.0073     0.0032     0.0058     0.0026     0.0025 </r>
+        <r>     9.6053     0.0032     0.0395     0.0249     0.0435     0.0067     0.0029     0.0052     0.0024     0.0025 </r>
+        <r>     9.7177     0.0028     0.0335     0.0233     0.0398     0.0060     0.0026     0.0046     0.0022     0.0024 </r>
+        <r>     9.8301     0.0025     0.0261     0.0222     0.0353     0.0054     0.0022     0.0040     0.0020     0.0024 </r>
+        <r>     9.9425     0.0032     0.0283     0.0370     0.0382     0.0076     0.0032     0.0120     0.0046     0.0066 </r>
+        <r>    10.0548     0.0041     0.0353     0.0615     0.0463     0.0115     0.0053     0.0262     0.0069     0.0112 </r>
+        <r>    10.1672     0.0051     0.0388     0.0618     0.0511     0.0148     0.0063     0.0311     0.0086     0.0221 </r>
+        <r>    10.2796     0.0054     0.0404     0.0686     0.0516     0.0149     0.0071     0.0339     0.0087     0.0214 </r>
+        <r>    10.3919     0.0053     0.0417     0.0697     0.0540     0.0147     0.0071     0.0333     0.0091     0.0210 </r>
+        <r>    10.5043     0.0042     0.0297     0.0446     0.0410     0.0120     0.0063     0.0290     0.0086     0.0187 </r>
+        <r>    10.6167     0.0032     0.0234     0.0206     0.0362     0.0099     0.0052     0.0241     0.0078     0.0167 </r>
+        <r>    10.7290     0.0028     0.0244     0.0159     0.0393     0.0090     0.0045     0.0222     0.0074     0.0159 </r>
+        <r>    10.8414     0.0030     0.0300     0.0177     0.0483     0.0099     0.0049     0.0242     0.0087     0.0176 </r>
+        <r>    10.9538     0.0037     0.0434     0.0237     0.0666     0.0123     0.0064     0.0297     0.0120     0.0228 </r>
+        <r>    11.0662     0.0027     0.0338     0.0144     0.0527     0.0105     0.0042     0.0245     0.0083     0.0171 </r>
+        <r>    11.1785     0.0019     0.0256     0.0091     0.0392     0.0083     0.0029     0.0181     0.0059     0.0131 </r>
+        <r>    11.2909     0.0019     0.0210     0.0068     0.0321     0.0087     0.0052     0.0194     0.0103     0.0151 </r>
+        <r>    11.4033     0.0019     0.0171     0.0054     0.0259     0.0083     0.0065     0.0193     0.0127     0.0181 </r>
+        <r>    11.5156     0.0017     0.0115     0.0043     0.0182     0.0073     0.0065     0.0163     0.0126     0.0149 </r>
+        <r>    11.6280     0.0015     0.0077     0.0035     0.0118     0.0062     0.0066     0.0139     0.0128     0.0135 </r>
+        <r>    11.7404     0.0014     0.0045     0.0029     0.0052     0.0056     0.0071     0.0126     0.0139     0.0134 </r>
+        <r>    11.8527     0.0015     0.0044     0.0026     0.0048     0.0056     0.0076     0.0121     0.0147     0.0139 </r>
+        <r>    11.9651     0.0016     0.0051     0.0030     0.0082     0.0064     0.0086     0.0130     0.0163     0.0164 </r>
+        <r>    12.0775     0.0020     0.0075     0.0036     0.0145     0.0094     0.0107     0.0170     0.0189     0.0219 </r>
+        <r>    12.1899     0.0028     0.0083     0.0049     0.0152     0.0109     0.0123     0.0179     0.0211     0.0255 </r>
+        <r>    12.3022     0.0039     0.0084     0.0053     0.0165     0.0118     0.0136     0.0186     0.0235     0.0285 </r>
+        <r>    12.4146     0.0051     0.0083     0.0059     0.0181     0.0124     0.0153     0.0197     0.0265     0.0312 </r>
+        <r>    12.5270     0.0058     0.0080     0.0058     0.0173     0.0121     0.0157     0.0179     0.0274     0.0312 </r>
+        <r>    12.6393     0.0068     0.0081     0.0057     0.0165     0.0122     0.0161     0.0166     0.0281     0.0308 </r>
+        <r>    12.7517     0.0078     0.0083     0.0058     0.0162     0.0126     0.0168     0.0156     0.0291     0.0305 </r>
+        <r>    12.8641     0.0088     0.0086     0.0060     0.0158     0.0132     0.0169     0.0151     0.0287     0.0300 </r>
+        <r>    12.9765     0.0096     0.0087     0.0063     0.0157     0.0137     0.0171     0.0149     0.0284     0.0296 </r>
+        <r>    13.0888     0.0102     0.0088     0.0066     0.0160     0.0142     0.0173     0.0150     0.0279     0.0293 </r>
+        <r>    13.2012     0.0106     0.0088     0.0068     0.0163     0.0147     0.0172     0.0151     0.0272     0.0292 </r>
+        <r>    13.3136     0.0112     0.0089     0.0070     0.0164     0.0155     0.0173     0.0153     0.0266     0.0290 </r>
+        <r>    13.4259     0.0118     0.0093     0.0072     0.0166     0.0165     0.0177     0.0160     0.0264     0.0292 </r>
+        <r>    13.5383     0.0124     0.0104     0.0076     0.0171     0.0202     0.0216     0.0183     0.0280     0.0304 </r>
+        <r>    13.6507     0.0135     0.0138     0.0082     0.0188     0.0253     0.0243     0.0226     0.0324     0.0342 </r>
+        <r>    13.7630     0.0161     0.0217     0.0093     0.0228     0.0405     0.0290     0.0321     0.0366     0.0392 </r>
+        <r>    13.8754     0.0156     0.0244     0.0094     0.0233     0.0430     0.0314     0.0293     0.0370     0.0408 </r>
+        <r>    13.9878     0.0144     0.0199     0.0097     0.0203     0.0331     0.0331     0.0235     0.0373     0.0397 </r>
+        <r>    14.1002     0.0144     0.0171     0.0098     0.0189     0.0290     0.0341     0.0197     0.0372     0.0384 </r>
+        <r>    14.2125     0.0135     0.0158     0.0095     0.0180     0.0275     0.0351     0.0183     0.0371     0.0361 </r>
+        <r>    14.3249     0.0116     0.0141     0.0089     0.0165     0.0253     0.0356     0.0172     0.0366     0.0337 </r>
+        <r>    14.4373     0.0118     0.0129     0.0093     0.0168     0.0253     0.0390     0.0166     0.0381     0.0339 </r>
+        <r>    14.5496     0.0119     0.0117     0.0099     0.0173     0.0250     0.0425     0.0156     0.0400     0.0345 </r>
+        <r>    14.6620     0.0125     0.0111     0.0103     0.0178     0.0245     0.0482     0.0149     0.0428     0.0355 </r>
+        <r>    14.7744     0.0148     0.0132     0.0118     0.0231     0.0285     0.0608     0.0180     0.0515     0.0423 </r>
+        <r>    14.8867     0.0151     0.0134     0.0120     0.0254     0.0294     0.0622     0.0206     0.0517     0.0451 </r>
+        <r>    14.9991     0.0172     0.0158     0.0149     0.0299     0.0340     0.0694     0.0251     0.0579     0.0540 </r>
+        <r>    15.1115     0.0168     0.0152     0.0146     0.0284     0.0325     0.0628     0.0267     0.0472     0.0464 </r>
+        <r>    15.2239     0.0182     0.0168     0.0162     0.0306     0.0359     0.0645     0.0301     0.0467     0.0486 </r>
+        <r>    15.3362     0.0166     0.0165     0.0154     0.0284     0.0361     0.0489     0.0292     0.0394     0.0450 </r>
+        <r>    15.4486     0.0163     0.0158     0.0130     0.0235     0.0351     0.0441     0.0277     0.0398     0.0396 </r>
+        <r>    15.5610     0.0156     0.0148     0.0126     0.0210     0.0353     0.0396     0.0283     0.0395     0.0361 </r>
+        <r>    15.6733     0.0191     0.0161     0.0141     0.0206     0.0401     0.0401     0.0319     0.0451     0.0377 </r>
+        <r>    15.7857     0.0232     0.0196     0.0161     0.0220     0.0479     0.0427     0.0397     0.0563     0.0431 </r>
+        <r>    15.8981     0.0180     0.0248     0.0138     0.0216     0.0467     0.0386     0.0501     0.0494     0.0422 </r>
+        <r>    16.0104     0.0081     0.0137     0.0090     0.0131     0.0261     0.0288     0.0267     0.0305     0.0344 </r>
+        <r>    16.1228     0.0092     0.0115     0.0088     0.0116     0.0263     0.0386     0.0224     0.0375     0.0375 </r>
+        <r>    16.2352     0.0103     0.0112     0.0090     0.0114     0.0280     0.0425     0.0203     0.0375     0.0364 </r>
+        <r>    16.3476     0.0114     0.0108     0.0095     0.0113     0.0298     0.0465     0.0186     0.0402     0.0359 </r>
+        <r>    16.4599     0.0219     0.0147     0.0157     0.0181     0.0540     0.0845     0.0222     0.0667     0.0549 </r>
+        <r>    16.5723     0.0216     0.0135     0.0136     0.0180     0.0627     0.0631     0.0242     0.0561     0.0445 </r>
+        <r>    16.6847     0.0175     0.0126     0.0121     0.0148     0.0514     0.0551     0.0220     0.0519     0.0372 </r>
+        <r>    16.7970     0.0170     0.0129     0.0119     0.0140     0.0464     0.0533     0.0222     0.0525     0.0387 </r>
+        <r>    16.9094     0.0201     0.0154     0.0132     0.0159     0.0522     0.0612     0.0257     0.0599     0.0508 </r>
+        <r>    17.0218     0.0187     0.0168     0.0132     0.0157     0.0513     0.0613     0.0257     0.0601     0.0547 </r>
+        <r>    17.1341     0.0169     0.0210     0.0142     0.0153     0.0455     0.0596     0.0273     0.0705     0.0771 </r>
+        <r>    17.2465     0.0174     0.0194     0.0125     0.0162     0.0462     0.0532     0.0255     0.0666     0.0583 </r>
+        <r>    17.3589     0.0214     0.0202     0.0132     0.0180     0.0495     0.0576     0.0269     0.0724     0.0643 </r>
+        <r>    17.4713     0.0216     0.0197     0.0130     0.0174     0.0455     0.0535     0.0265     0.0687     0.0612 </r>
+        <r>    17.5836     0.0201     0.0180     0.0130     0.0159     0.0428     0.0491     0.0266     0.0650     0.0571 </r>
+        <r>    17.6960     0.0169     0.0127     0.0105     0.0109     0.0378     0.0432     0.0205     0.0489     0.0468 </r>
+        <r>    17.8084     0.0194     0.0131     0.0118     0.0123     0.0462     0.0546     0.0234     0.0633     0.0630 </r>
+        <r>    17.9207     0.0215     0.0135     0.0132     0.0132     0.0534     0.0596     0.0275     0.0707     0.0768 </r>
+        <r>    18.0331     0.0242     0.0142     0.0151     0.0134     0.0624     0.0631     0.0321     0.0775     0.0891 </r>
+        <r>    18.1455     0.0243     0.0139     0.0154     0.0133     0.0691     0.0612     0.0307     0.0701     0.0837 </r>
+        <r>    18.2579     0.0244     0.0139     0.0156     0.0136     0.0728     0.0604     0.0306     0.0676     0.0848 </r>
+        <r>    18.3702     0.0258     0.0148     0.0167     0.0143     0.0753     0.0643     0.0322     0.0713     0.0937 </r>
+        <r>    18.4826     0.0254     0.0156     0.0167     0.0144     0.0746     0.0636     0.0318     0.0679     0.1013 </r>
+        <r>    18.5950     0.0220     0.0139     0.0151     0.0126     0.0677     0.0552     0.0309     0.0607     0.0869 </r>
+        <r>    18.7073     0.0177     0.0117     0.0123     0.0097     0.0585     0.0450     0.0268     0.0506     0.0585 </r>
+        <r>    18.8197     0.0134     0.0096     0.0099     0.0076     0.0478     0.0372     0.0197     0.0425     0.0412 </r>
+        <r>    18.9321     0.0143     0.0092     0.0100     0.0081     0.0528     0.0484     0.0187     0.0459     0.0396 </r>
+        <r>    19.0444     0.0098     0.0068     0.0074     0.0060     0.0369     0.0358     0.0122     0.0319     0.0259 </r>
+        <r>    19.1568     0.0073     0.0051     0.0055     0.0045     0.0272     0.0280     0.0083     0.0223     0.0183 </r>
+        <r>    19.2692     0.0056     0.0038     0.0043     0.0036     0.0200     0.0220     0.0059     0.0173     0.0143 </r>
+        <r>    19.3816     0.0032     0.0021     0.0024     0.0022     0.0099     0.0115     0.0034     0.0106     0.0087 </r>
+        <r>    19.4939     0.0017     0.0010     0.0010     0.0013     0.0051     0.0047     0.0022     0.0049     0.0049 </r>
+        <r>    19.6063     0.0012     0.0007     0.0007     0.0010     0.0038     0.0036     0.0017     0.0037     0.0039 </r>
+        <r>    19.7187     0.0008     0.0005     0.0005     0.0007     0.0027     0.0024     0.0013     0.0027     0.0030 </r>
+        <r>    19.8310     0.0004     0.0003     0.0003     0.0004     0.0021     0.0013     0.0010     0.0019     0.0023 </r>
+        <r>    19.9434     0.0002     0.0002     0.0001     0.0002     0.0017     0.0006     0.0008     0.0015     0.0019 </r>
+        <r>    20.0558     0.0002     0.0002     0.0001     0.0002     0.0016     0.0005     0.0007     0.0014     0.0018 </r>
+        <r>    20.1681     0.0001     0.0002     0.0001     0.0002     0.0014     0.0005     0.0007     0.0013     0.0017 </r>
+        <r>    20.2805     0.0001     0.0001     0.0001     0.0002     0.0013     0.0004     0.0006     0.0012     0.0015 </r>
+        <r>    20.3929     0.0001     0.0001     0.0001     0.0002     0.0012     0.0004     0.0006     0.0011     0.0014 </r>
+        <r>    20.5053     0.0001     0.0001     0.0001     0.0002     0.0011     0.0003     0.0005     0.0011     0.0013 </r>
+        <r>    20.6176     0.0001     0.0001     0.0001     0.0001     0.0010     0.0003     0.0005     0.0010     0.0012 </r>
+        <r>    20.7300     0.0001     0.0001     0.0001     0.0001     0.0009     0.0003     0.0005     0.0009     0.0011 </r>
+        <r>    20.8424     0.0001     0.0001     0.0001     0.0001     0.0008     0.0002     0.0004     0.0009     0.0010 </r>
+        <r>    20.9547     0.0001     0.0001     0.0001     0.0001     0.0007     0.0002     0.0004     0.0008     0.0010 </r>
+        <r>    21.0671     0.0001     0.0001     0.0001     0.0001     0.0006     0.0002     0.0003     0.0007     0.0009 </r>
+        <r>    21.1795     0.0000     0.0001     0.0000     0.0001     0.0005     0.0001     0.0003     0.0007     0.0008 </r>
+        <r>    21.2918     0.0000     0.0000     0.0000     0.0001     0.0004     0.0001     0.0003     0.0006     0.0007 </r>
+        <r>    21.4042     0.0000     0.0000     0.0000     0.0001     0.0003     0.0001     0.0002     0.0005     0.0007 </r>
+        <r>    21.5166     0.0000     0.0000     0.0000     0.0001     0.0003     0.0000     0.0002     0.0005     0.0006 </r>
+        <r>    21.6290     0.0000     0.0000     0.0000     0.0001     0.0003     0.0000     0.0002     0.0005     0.0006 </r>
+        <r>    21.7413     0.0000     0.0000     0.0000     0.0001     0.0005     0.0000     0.0005     0.0007     0.0010 </r>
+        <r>    21.8537     0.0000     0.0000     0.0000     0.0000     0.0002     0.0000     0.0002     0.0003     0.0004 </r>
+        <r>    21.9661     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.0784     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.1908     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.3032     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.4156     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.5279     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.6403     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.7527     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.8650     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    22.9774     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.0898     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.2021     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.3145     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.4269     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+        <r>    23.5393     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000     0.0000 </r>
+       </set>
+      </set>
+     </set>
+    </array>
+   </partial>
+  </dos>
+  <projected>
+   <eigenvalues>
+    <array>
+     <dimension dim="1">band</dimension>
+     <dimension dim="2">kpoint</dimension>
+     <dimension dim="3">spin</dimension>
+     <field>eigene</field>
+     <field>occ</field>
+     <set>
+      <set comment="spin 1">
+       <set comment="kpoint 1">
+        <r>   -8.5725    1.0000 </r>
+        <r>   -2.6756    1.0000 </r>
+        <r>    3.5500    1.0000 </r>
+        <r>    3.6723    1.0000 </r>
+        <r>    3.6745    1.0000 </r>
+        <r>    7.3160    0.0000 </r>
+        <r>    8.0570    0.0000 </r>
+        <r>    8.0573    0.0000 </r>
+        <r>   10.9331    0.0000 </r>
+        <r>   11.2489    0.0000 </r>
+        <r>   11.2496    0.0000 </r>
+        <r>   12.1082    0.0000 </r>
+        <r>   12.4249    0.0000 </r>
+        <r>   13.5924    0.0000 </r>
+        <r>   13.5930    0.0000 </r>
+        <r>   22.0069    0.0000 </r>
+       </set>
+       <set comment="kpoint 2">
+        <r>   -8.3777    1.0000 </r>
+        <r>   -3.1364    1.0000 </r>
+        <r>    3.1714    1.0000 </r>
+        <r>    3.8824    1.0000 </r>
+        <r>    4.0432    1.0000 </r>
+        <r>    6.7573    0.0000 </r>
+        <r>    7.2741    0.0000 </r>
+        <r>    8.0228    0.0000 </r>
+        <r>   10.5804    0.0000 </r>
+        <r>   11.3727    0.0000 </r>
+        <r>   11.4919    0.0000 </r>
+        <r>   13.0657    0.0000 </r>
+        <r>   13.6978    0.0000 </r>
+        <r>   14.5844    0.0000 </r>
+        <r>   14.7754    0.0000 </r>
+        <r>   19.7200    0.0000 </r>
+       </set>
+       <set comment="kpoint 3">
+        <r>   -7.8882    1.0000 </r>
+        <r>   -4.0814    1.0000 </r>
+        <r>    2.9260    1.0000 </r>
+        <r>    4.0294    1.0000 </r>
+        <r>    4.5147    1.0000 </r>
+        <r>    5.7667    0.0000 </r>
+        <r>    6.4337    0.0000 </r>
+        <r>    7.5100    0.0000 </r>
+        <r>   10.8262    0.0000 </r>
+        <r>   12.0875    0.0000 </r>
+        <r>   12.2424    0.0000 </r>
+        <r>   14.8387    0.0000 </r>
+        <r>   15.9418    0.0000 </r>
+        <r>   16.4852    0.0000 </r>
+        <r>   16.5840    0.0000 </r>
+        <r>   17.5588    0.0000 </r>
+       </set>
+       <set comment="kpoint 4">
+        <r>   -7.1441    1.0000 </r>
+        <r>   -5.1951    1.0000 </r>
+        <r>    2.9874    1.0000 </r>
+        <r>    3.9909    1.0000 </r>
+        <r>    4.8710    1.0000 </r>
+        <r>    4.9742    0.0000 </r>
+        <r>    6.0062    0.0000 </r>
+        <r>    6.7381    0.0000 </r>
+        <r>   12.1101    0.0000 </r>
+        <r>   13.3447    0.0000 </r>
+        <r>   13.3983    0.0000 </r>
+        <r>   14.6982    0.0000 </r>
+        <r>   16.2749    0.0000 </r>
+        <r>   17.3061    0.0000 </r>
+        <r>   18.0877    0.0000 </r>
+        <r>   18.8005    0.0000 </r>
+       </set>
+       <set comment="kpoint 5">
+        <r>   -6.6051    1.0000 </r>
+        <r>   -5.8412    1.0000 </r>
+        <r>    3.3519    1.0000 </r>
+        <r>    3.7311    1.0000 </r>
+        <r>    4.2292    1.0000 </r>
+        <r>    5.4561    0.0000 </r>
+        <r>    6.1184    0.0000 </r>
+        <r>    6.1864    0.0000 </r>
+        <r>   12.5439    0.0000 </r>
+        <r>   14.0396    0.0000 </r>
+        <r>   14.5718    0.0000 </r>
+        <r>   14.9387    0.0000 </r>
+        <r>   15.3724    0.0000 </r>
+        <r>   15.4532    0.0000 </r>
+        <r>   19.3908    0.0000 </r>
+        <r>   20.0505    0.0000 </r>
+       </set>
+       <set comment="kpoint 6">
+        <r>   -7.3718    1.0000 </r>
+        <r>   -4.8705    1.0000 </r>
+        <r>    3.4872    1.0000 </r>
+        <r>    3.7834    1.0000 </r>
+        <r>    3.8997    1.0000 </r>
+        <r>    5.6398    0.0000 </r>
+        <r>    6.2872    0.0000 </r>
+        <r>    6.7889    0.0000 </r>
+        <r>   11.1373    0.0000 </r>
+        <r>   12.8292    0.0000 </r>
+        <r>   13.6551    0.0000 </r>
+        <r>   15.7297    0.0000 </r>
+        <r>   16.6175    0.0000 </r>
+        <r>   17.2627    0.0000 </r>
+        <r>   17.7359    0.0000 </r>
+        <r>   17.8929    0.0000 </r>
+       </set>
+       <set comment="kpoint 7">
+        <r>   -8.0523    1.0000 </r>
+        <r>   -3.7586    1.0000 </r>
+        <r>    3.4043    1.0000 </r>
+        <r>    3.4974    1.0000 </r>
+        <r>    4.2259    1.0000 </r>
+        <r>    5.9780    0.0000 </r>
+        <r>    7.0174    0.0000 </r>
+        <r>    7.5765    0.0000 </r>
+        <r>   10.3806    0.0000 </r>
+        <r>   11.6263    0.0000 </r>
+        <r>   12.3560    0.0000 </r>
+        <r>   14.4510    0.0000 </r>
+        <r>   15.1167    0.0000 </r>
+        <r>   15.3468    0.0000 </r>
+        <r>   16.6675    0.0000 </r>
+        <r>   19.5443    0.0000 </r>
+       </set>
+       <set comment="kpoint 8">
+        <r>   -8.4620    1.0000 </r>
+        <r>   -2.9174    1.0000 </r>
+        <r>    3.3953    1.0000 </r>
+        <r>    3.4862    1.0000 </r>
+        <r>    4.0654    1.0000 </r>
+        <r>    6.8639    0.0000 </r>
+        <r>    7.6278    0.0000 </r>
+        <r>    8.1851    0.0000 </r>
+        <r>   10.4782    0.0000 </r>
+        <r>   11.2669    0.0000 </r>
+        <r>   11.5582    0.0000 </r>
+        <r>   12.5837    0.0000 </r>
+        <r>   13.2415    0.0000 </r>
+        <r>   13.7367    0.0000 </r>
+        <r>   14.7160    0.0000 </r>
+        <r>   21.8135    0.0000 </r>
+       </set>
+       <set comment="kpoint 9">
+        <r>   -8.2975    1.0000 </r>
+        <r>   -3.2680    1.0000 </r>
+        <r>    2.9902    1.0000 </r>
+        <r>    3.2325    1.0000 </r>
+        <r>    4.9084    1.0000 </r>
+        <r>    5.7711    0.0000 </r>
+        <r>    7.8847    0.0000 </r>
+        <r>    8.4055    0.0000 </r>
+        <r>   10.2340    0.0000 </r>
+        <r>   11.7921    0.0000 </r>
+        <r>   12.2004    0.0000 </r>
+        <r>   12.8343    0.0000 </r>
+        <r>   13.8016    0.0000 </r>
+        <r>   13.8844    0.0000 </r>
+        <r>   16.2092    0.0000 </r>
+        <r>   20.0209    0.0000 </r>
+       </set>
+       <set comment="kpoint 10">
+        <r>   -7.9258    1.0000 </r>
+        <r>   -3.8857    1.0000 </r>
+        <r>    2.4506    1.0000 </r>
+        <r>    3.1784    1.0000 </r>
+        <r>    4.3334    1.0000 </r>
+        <r>    6.1697    0.0000 </r>
+        <r>    7.6102    0.0000 </r>
+        <r>    8.4697    0.0000 </r>
+        <r>   10.0720    0.0000 </r>
+        <r>   12.5848    0.0000 </r>
+        <r>   12.8675    0.0000 </r>
+        <r>   13.7236    0.0000 </r>
+        <r>   14.8127    0.0000 </r>
+        <r>   15.7239    0.0000 </r>
+        <r>   17.2652    0.0000 </r>
+        <r>   18.2701    0.0000 </r>
+       </set>
+       <set comment="kpoint 11">
+        <r>   -7.2919    1.0000 </r>
+        <r>   -4.8134    1.0000 </r>
+        <r>    2.2282    1.0000 </r>
+        <r>    2.8339    1.0000 </r>
+        <r>    3.9978    1.0000 </r>
+        <r>    6.3656    0.0000 </r>
+        <r>    7.4003    0.0000 </r>
+        <r>    8.1013    0.0000 </r>
+        <r>   10.5682    0.0000 </r>
+        <r>   13.6739    0.0000 </r>
+        <r>   13.8955    0.0000 </r>
+        <r>   14.7043    0.0000 </r>
+        <r>   15.5192    0.0000 </r>
+        <r>   17.1838    0.0000 </r>
+        <r>   17.6155    0.0000 </r>
+        <r>   18.3978    0.0000 </r>
+       </set>
+       <set comment="kpoint 12">
+        <r>   -6.5352    1.0000 </r>
+        <r>   -5.7372    1.0000 </r>
+        <r>    2.2550    1.0000 </r>
+        <r>    2.5097    1.0000 </r>
+        <r>    4.2417    1.0000 </r>
+        <r>    5.7957    0.0000 </r>
+        <r>    7.3485    0.0000 </r>
+        <r>    7.9488    0.0000 </r>
+        <r>   12.0290    0.0000 </r>
+        <r>   12.5883    0.0000 </r>
+        <r>   14.7248    0.0000 </r>
+        <r>   15.1826    0.0000 </r>
+        <r>   15.7963    0.0000 </r>
+        <r>   17.5779    0.0000 </r>
+        <r>   18.7909    0.0000 </r>
+        <r>   18.9194    0.0000 </r>
+       </set>
+       <set comment="kpoint 13">
+        <r>   -6.9286    1.0000 </r>
+        <r>   -5.2903    1.0000 </r>
+        <r>    2.0905    1.0000 </r>
+        <r>    3.0762    1.0000 </r>
+        <r>    4.4105    1.0000 </r>
+        <r>    5.5646    0.0000 </r>
+        <r>    6.6662    0.0000 </r>
+        <r>    8.4662    0.0000 </r>
+        <r>   11.1557    0.0000 </r>
+        <r>   13.0892    0.0000 </r>
+        <r>   14.0096    0.0000 </r>
+        <r>   15.6320    0.0000 </r>
+        <r>   15.8411    0.0000 </r>
+        <r>   17.6956    0.0000 </r>
+        <r>   18.0820    0.0000 </r>
+        <r>   19.3695    0.0000 </r>
+       </set>
+       <set comment="kpoint 14">
+        <r>   -7.6611    1.0000 </r>
+        <r>   -4.3160    1.0000 </r>
+        <r>    2.3132    1.0000 </r>
+        <r>    3.9439    1.0000 </r>
+        <r>    4.0469    1.0000 </r>
+        <r>    5.9757    0.0000 </r>
+        <r>    6.2552    0.0000 </r>
+        <r>    8.6975    0.0000 </r>
+        <r>   10.3556    0.0000 </r>
+        <r>   12.0779    0.0000 </r>
+        <r>   13.8950    0.0000 </r>
+        <r>   14.0078    0.0000 </r>
+        <r>   15.9819    0.0000 </r>
+        <r>   16.8413    0.0000 </r>
+        <r>   17.6635    0.0000 </r>
+        <r>   18.8193    0.0000 </r>
+       </set>
+       <set comment="kpoint 15">
+        <r>   -8.1610    1.0000 </r>
+        <r>   -3.5246    1.0000 </r>
+        <r>    2.9620    1.0000 </r>
+        <r>    3.5194    1.0000 </r>
+        <r>    4.5866    1.0000 </r>
+        <r>    5.8758    0.0000 </r>
+        <r>    7.1687    0.0000 </r>
+        <r>    8.2463    0.0000 </r>
+        <r>   10.1961    0.0000 </r>
+        <r>   11.6096    0.0000 </r>
+        <r>   12.3953    0.0000 </r>
+        <r>   13.3011    0.0000 </r>
+        <r>   14.5882    0.0000 </r>
+        <r>   15.1216    0.0000 </r>
+        <r>   16.4253    0.0000 </r>
+        <r>   19.5616    0.0000 </r>
+       </set>
+       <set comment="kpoint 16">
+        <r>   -7.6932    1.0000 </r>
+        <r>   -4.0347    1.0000 </r>
+        <r>    1.9654    1.0000 </r>
+        <r>    2.5819    1.0000 </r>
+        <r>    3.1436    1.0000 </r>
+        <r>    7.6593    0.0000 </r>
+        <r>    8.1692    0.0000 </r>
+        <r>    9.0890    0.0000 </r>
+        <r>   10.0318    0.0000 </r>
+        <r>   13.4180    0.0000 </r>
+        <r>   13.6900    0.0000 </r>
+        <r>   13.8216    0.0000 </r>
+        <r>   14.5603    0.0000 </r>
+        <r>   16.1008    0.0000 </r>
+        <r>   17.7109    0.0000 </r>
+        <r>   17.7929    0.0000 </r>
+       </set>
+       <set comment="kpoint 17">
+        <r>   -7.2203    1.0000 </r>
+        <r>   -4.5620    1.0000 </r>
+        <r>    1.3753    1.0000 </r>
+        <r>    2.0880    1.0000 </r>
+        <r>    2.9191    1.0000 </r>
+        <r>    7.9298    0.0000 </r>
+        <r>    8.8162    0.0000 </r>
+        <r>    9.2139    0.0000 </r>
+        <r>   10.1047    0.0000 </r>
+        <r>   14.1573    0.0000 </r>
+        <r>   14.5845    0.0000 </r>
+        <r>   15.1348    0.0000 </r>
+        <r>   15.2987    0.0000 </r>
+        <r>   16.1256    0.0000 </r>
+        <r>   17.6867    0.0000 </r>
+        <r>   17.9872    0.0000 </r>
+       </set>
+       <set comment="kpoint 18">
+        <r>   -6.5783    1.0000 </r>
+        <r>   -5.3417    1.0000 </r>
+        <r>    0.9922    1.0000 </r>
+        <r>    1.9131    1.0000 </r>
+        <r>    3.2643    1.0000 </r>
+        <r>    7.3210    0.0000 </r>
+        <r>    8.7241    0.0000 </r>
+        <r>    9.8961    0.0000 </r>
+        <r>   10.3564    0.0000 </r>
+        <r>   13.1155    0.0000 </r>
+        <r>   14.8700    0.0000 </r>
+        <r>   15.8773    0.0000 </r>
+        <r>   16.5039    0.0000 </r>
+        <r>   17.3467    0.0000 </r>
+        <r>   18.0098    0.0000 </r>
+        <r>   18.2871    0.0000 </r>
+       </set>
+       <set comment="kpoint 19">
+        <r>   -6.3027    1.0000 </r>
+        <r>   -5.7423    1.0000 </r>
+        <r>    1.0075    1.0000 </r>
+        <r>    2.3180    1.0000 </r>
+        <r>    3.7861    1.0000 </r>
+        <r>    6.3763    0.0000 </r>
+        <r>    7.9596    0.0000 </r>
+        <r>   10.1392    0.0000 </r>
+        <r>   11.6929    0.0000 </r>
+        <r>   11.8858    0.0000 </r>
+        <r>   13.5882    0.0000 </r>
+        <r>   15.3216    0.0000 </r>
+        <r>   18.0003    0.0000 </r>
+        <r>   18.2416    0.0000 </r>
+        <r>   18.7983    0.0000 </r>
+        <r>   18.9762    0.0000 </r>
+       </set>
+       <set comment="kpoint 20">
+        <r>   -7.0173    1.0000 </r>
+        <r>   -5.0912    1.0000 </r>
+        <r>    1.5880    1.0000 </r>
+        <r>    3.1637    1.0000 </r>
+        <r>    4.1749    1.0000 </r>
+        <r>    5.7335    0.0000 </r>
+        <r>    6.9251    0.0000 </r>
+        <r>    9.4197    0.0000 </r>
+        <r>   10.9126    0.0000 </r>
+        <r>   12.7379    0.0000 </r>
+        <r>   13.8172    0.0000 </r>
+        <r>   14.6639    0.0000 </r>
+        <r>   16.0893    0.0000 </r>
+        <r>   17.9496    0.0000 </r>
+        <r>   18.9140    0.0000 </r>
+        <r>   19.6174    0.0000 </r>
+       </set>
+       <set comment="kpoint 21">
+        <r>   -7.5772    1.0000 </r>
+        <r>   -4.5098    1.0000 </r>
+        <r>    2.7201    1.0000 </r>
+        <r>    3.6482    1.0000 </r>
+        <r>    4.3054    1.0000 </r>
+        <r>    5.7963    0.0000 </r>
+        <r>    6.3301    0.0000 </r>
+        <r>    7.8899    0.0000 </r>
+        <r>   10.7289    0.0000 </r>
+        <r>   12.1778    0.0000 </r>
+        <r>   13.7605    0.0000 </r>
+        <r>   14.9563    0.0000 </r>
+        <r>   16.1059    0.0000 </r>
+        <r>   17.1928    0.0000 </r>
+        <r>   17.4326    0.0000 </r>
+        <r>   17.8979    0.0000 </r>
+       </set>
+       <set comment="kpoint 22">
+        <r>   -6.9707    1.0000 </r>
+        <r>   -4.6000    1.0000 </r>
+        <r>    0.5924    1.0000 </r>
+        <r>    2.1144    1.0000 </r>
+        <r>    2.1166    1.0000 </r>
+        <r>    7.8449    0.0000 </r>
+        <r>    9.7693    0.0000 </r>
+        <r>   10.2838    0.0000 </r>
+        <r>   10.9131    0.0000 </r>
+        <r>   14.4007    0.0000 </r>
+        <r>   14.9337    0.0000 </r>
+        <r>   15.8762    0.0000 </r>
+        <r>   16.1823    0.0000 </r>
+        <r>   16.2978    0.0000 </r>
+        <r>   16.6206    0.0000 </r>
+        <r>   18.3823    0.0000 </r>
+       </set>
+       <set comment="kpoint 23">
+        <r>   -6.6240    1.0000 </r>
+        <r>   -4.9712    1.0000 </r>
+        <r>    0.2970    1.0000 </r>
+        <r>    1.7357    1.0000 </r>
+        <r>    2.4692    1.0000 </r>
+        <r>    8.0566    0.0000 </r>
+        <r>    9.2099    0.0000 </r>
+        <r>   10.4130    0.0000 </r>
+        <r>   11.5614    0.0000 </r>
+        <r>   14.0731    0.0000 </r>
+        <r>   15.2303    0.0000 </r>
+        <r>   16.0310    0.0000 </r>
+        <r>   16.5942    0.0000 </r>
+        <r>   17.0680    0.0000 </r>
+        <r>   17.2337    0.0000 </r>
+        <r>   17.8302    0.0000 </r>
+       </set>
+       <set comment="kpoint 24">
+        <r>   -6.2786    1.0000 </r>
+        <r>   -5.5525    1.0000 </r>
+        <r>    0.5487    1.0000 </r>
+        <r>    1.9094    1.0000 </r>
+        <r>    3.0179    1.0000 </r>
+        <r>    7.4757    0.0000 </r>
+        <r>    8.9491    0.0000 </r>
+        <r>   10.2356    0.0000 </r>
+        <r>   10.9729    0.0000 </r>
+        <r>   12.8661    0.0000 </r>
+        <r>   14.5464    0.0000 </r>
+        <r>   16.1276    0.0000 </r>
+        <r>   16.9941    0.0000 </r>
+        <r>   17.0388    0.0000 </r>
+        <r>   18.6229    0.0000 </r>
+        <r>   18.9618    0.0000 </r>
+       </set>
+       <set comment="kpoint 25">
+        <r>   -6.2588    1.0000 </r>
+        <r>   -5.8837    1.0000 </r>
+        <r>    1.3768    1.0000 </r>
+        <r>    2.6178    1.0000 </r>
+        <r>    3.6768    1.0000 </r>
+        <r>    6.1648    0.0000 </r>
+        <r>    7.7951    0.0000 </r>
+        <r>    9.2943    0.0000 </r>
+        <r>   11.8478    0.0000 </r>
+        <r>   12.2588    0.0000 </r>
+        <r>   13.7047    0.0000 </r>
+        <r>   15.5780    0.0000 </r>
+        <r>   16.7393    0.0000 </r>
+        <r>   17.7556    0.0000 </r>
+        <r>   18.6215    0.0000 </r>
+        <r>   19.1164    0.0000 </r>
+       </set>
+       <set comment="kpoint 26">
+        <r>   -6.7782    1.0000 </r>
+        <r>   -5.5739    1.0000 </r>
+        <r>    2.6895    1.0000 </r>
+        <r>    3.7514    1.0000 </r>
+        <r>    3.8279    1.0000 </r>
+        <r>    5.7136    0.0000 </r>
+        <r>    6.2123    0.0000 </r>
+        <r>    7.3686    0.0000 </r>
+        <r>   12.1429    0.0000 </r>
+        <r>   13.3021    0.0000 </r>
+        <r>   14.1232    0.0000 </r>
+        <r>   15.1390    0.0000 </r>
+        <r>   15.4518    0.0000 </r>
+        <r>   17.0566    0.0000 </r>
+        <r>   18.3299    0.0000 </r>
+        <r>   19.5614    0.0000 </r>
+       </set>
+       <set comment="kpoint 27">
+        <r>   -6.7011    1.0000 </r>
+        <r>   -4.7991    1.0000 </r>
+        <r>    0.2369    1.0000 </r>
+        <r>    1.9213    1.0000 </r>
+        <r>    2.0089    1.0000 </r>
+        <r>    7.7624    0.0000 </r>
+        <r>    9.9191    0.0000 </r>
+        <r>   10.5277    0.0000 </r>
+        <r>   11.7458    0.0000 </r>
+        <r>   14.7751    0.0000 </r>
+        <r>   15.4246    0.0000 </r>
+        <r>   15.6935    0.0000 </r>
+        <r>   16.1144    0.0000 </r>
+        <r>   16.8697    0.0000 </r>
+        <r>   17.2546    0.0000 </r>
+        <r>   17.7651    0.0000 </r>
+       </set>
+       <set comment="kpoint 28">
+        <r>   -6.8042    1.0000 </r>
+        <r>   -4.8825    1.0000 </r>
+        <r>    0.7322    1.0000 </r>
+        <r>    1.9048    1.0000 </r>
+        <r>    2.4882    1.0000 </r>
+        <r>    7.9960    0.0000 </r>
+        <r>    9.0041    0.0000 </r>
+        <r>   10.2413    0.0000 </r>
+        <r>   10.5623    0.0000 </r>
+        <r>   14.2977    0.0000 </r>
+        <r>   15.0473    0.0000 </r>
+        <r>   15.7820    0.0000 </r>
+        <r>   16.1443    0.0000 </r>
+        <r>   16.3496    0.0000 </r>
+        <r>   17.3554    0.0000 </r>
+        <r>   18.5335    0.0000 </r>
+       </set>
+       <set comment="kpoint 29">
+        <r>   -6.8531    1.0000 </r>
+        <r>   -5.1877    1.0000 </r>
+        <r>    1.6153    1.0000 </r>
+        <r>    2.4893    1.0000 </r>
+        <r>    3.1864    1.0000 </r>
+        <r>    6.9226    0.0000 </r>
+        <r>    8.2774    0.0000 </r>
+        <r>    8.8057    0.0000 </r>
+        <r>   10.3804    0.0000 </r>
+        <r>   14.0450    0.0000 </r>
+        <r>   14.3211    0.0000 </r>
+        <r>   15.1526    0.0000 </r>
+        <r>   15.9887    0.0000 </r>
+        <r>   16.3759    0.0000 </r>
+        <r>   18.2494    0.0000 </r>
+        <r>   19.3601    0.0000 </r>
+       </set>
+       <set comment="kpoint 30">
+        <r>   -7.2547    1.0000 </r>
+        <r>   -4.4311    1.0000 </r>
+        <r>    1.4142    1.0000 </r>
+        <r>    2.2857    1.0000 </r>
+        <r>    2.2863    1.0000 </r>
+        <r>    7.8551    0.0000 </r>
+        <r>    9.2474    0.0000 </r>
+        <r>    9.4024    0.0000 </r>
+        <r>   10.0828    0.0000 </r>
+        <r>   13.8637    0.0000 </r>
+        <r>   14.4441    0.0000 </r>
+        <r>   14.8901    0.0000 </r>
+        <r>   15.6151    0.0000 </r>
+        <r>   17.6621    0.0000 </r>
+        <r>   17.6864    0.0000 </r>
+        <r>   17.7868    0.0000 </r>
+       </set>
+       <set comment="kpoint 31">
+        <r>   -7.5316    1.0000 </r>
+        <r>   -4.3171    1.0000 </r>
+        <r>    2.1047    1.0000 </r>
+        <r>    2.8016    1.0000 </r>
+        <r>    3.0242    1.0000 </r>
+        <r>    7.5766    0.0000 </r>
+        <r>    7.6689    0.0000 </r>
+        <r>    8.6838    0.0000 </r>
+        <r>    9.9409    0.0000 </r>
+        <r>   13.3534    0.0000 </r>
+        <r>   13.8821    0.0000 </r>
+        <r>   14.2476    0.0000 </r>
+        <r>   15.3775    0.0000 </r>
+        <r>   17.0574    0.0000 </r>
+        <r>   17.5106    0.0000 </r>
+        <r>   17.6993    0.0000 </r>
+       </set>
+       <set comment="kpoint 32">
+        <r>   -7.9824    1.0000 </r>
+        <r>   -3.7115    1.0000 </r>
+        <r>    2.6522    1.0000 </r>
+        <r>    2.8670    1.0000 </r>
+        <r>    3.9502    1.0000 </r>
+        <r>    6.4552    0.0000 </r>
+        <r>    7.8702    0.0000 </r>
+        <r>    8.6983    0.0000 </r>
+        <r>    9.8834    0.0000 </r>
+        <r>   12.4760    0.0000 </r>
+        <r>   12.9378    0.0000 </r>
+        <r>   13.3509    0.0000 </r>
+        <r>   14.2754    0.0000 </r>
+        <r>   15.3042    0.0000 </r>
+        <r>   18.1662    0.0000 </r>
+        <r>   19.6141    0.0000 </r>
+       </set>
+       <set comment="kpoint 33">
+        <r>   -8.3232    1.0000 </r>
+        <r>   -3.3354    1.0000 </r>
+        <r>    3.7235    1.0000 </r>
+        <r>    3.7859    1.0000 </r>
+        <r>    3.7882    1.0000 </r>
+        <r>    6.8933    0.0000 </r>
+        <r>    7.3493    0.0000 </r>
+        <r>    7.3496    0.0000 </r>
+        <r>   10.5113    0.0000 </r>
+        <r>   11.7171    0.0000 </r>
+        <r>   11.7178    0.0000 </r>
+        <r>   13.4652    0.0000 </r>
+        <r>   14.2610    0.0000 </r>
+        <r>   14.7378    0.0000 </r>
+        <r>   14.7383    0.0000 </r>
+        <r>   19.8473    0.0000 </r>
+       </set>
+       <set comment="kpoint 34">
+        <r>   -8.0562    1.0000 </r>
+        <r>   -3.8077    1.0000 </r>
+        <r>    2.5614    1.0000 </r>
+        <r>    4.2913    1.0000 </r>
+        <r>    4.6688    1.0000 </r>
+        <r>    5.8572    0.0000 </r>
+        <r>    6.3058    0.0000 </r>
+        <r>    8.5322    0.0000 </r>
+        <r>   10.6529    0.0000 </r>
+        <r>   11.6769    0.0000 </r>
+        <r>   12.7236    0.0000 </r>
+        <r>   13.5897    0.0000 </r>
+        <r>   15.0041    0.0000 </r>
+        <r>   16.0265    0.0000 </r>
+        <r>   16.3871    0.0000 </r>
+        <r>   17.5880    0.0000 </r>
+       </set>
+       <set comment="kpoint 35">
+        <r>   -7.5163    1.0000 </r>
+        <r>   -4.5649    1.0000 </r>
+        <r>    1.7938    1.0000 </r>
+        <r>    4.1339    1.0000 </r>
+        <r>    4.6460    1.0000 </r>
+        <r>    5.6274    0.0000 </r>
+        <r>    6.1106    0.0000 </r>
+        <r>    9.0804    0.0000 </r>
+        <r>   11.0378    0.0000 </r>
+        <r>   12.2211    0.0000 </r>
+        <r>   13.7801    0.0000 </r>
+        <r>   14.3805    0.0000 </r>
+        <r>   14.8419    0.0000 </r>
+        <r>   17.3722    0.0000 </r>
+        <r>   18.3431    0.0000 </r>
+        <r>   18.7919    0.0000 </r>
+       </set>
+       <set comment="kpoint 36">
+        <r>   -6.7849    1.0000 </r>
+        <r>   -5.4373    1.0000 </r>
+        <r>    1.5997    1.0000 </r>
+        <r>    3.4889    1.0000 </r>
+        <r>    3.7986    1.0000 </r>
+        <r>    6.2764    0.0000 </r>
+        <r>    6.6650    0.0000 </r>
+        <r>    8.7289    0.0000 </r>
+        <r>   12.1859    0.0000 </r>
+        <r>   12.3091    0.0000 </r>
+        <r>   13.3574    0.0000 </r>
+        <r>   15.8718    0.0000 </r>
+        <r>   16.0392    0.0000 </r>
+        <r>   17.7894    0.0000 </r>
+        <r>   18.3245    0.0000 </r>
+        <r>   19.8463    0.0000 </r>
+       </set>
+       <set comment="kpoint 37">
+        <r>   -6.6838    1.0000 </r>
+        <r>   -5.5078    1.0000 </r>
+        <r>    1.9447    1.0000 </r>
+        <r>    2.9858    1.0000 </r>
+        <r>    3.1759    1.0000 </r>
+        <r>    6.8856    0.0000 </r>
+        <r>    7.3968    0.0000 </r>
+        <r>    8.0640    0.0000 </r>
+        <r>   10.7305    0.0000 </r>
+        <r>   14.0508    0.0000 </r>
+        <r>   14.9020    0.0000 </r>
+        <r>   15.0726    0.0000 </r>
+        <r>   15.9297    0.0000 </r>
+        <r>   17.7291    0.0000 </r>
+        <r>   18.1232    0.0000 </r>
+        <r>   18.9482    0.0000 </r>
+       </set>
+       <set comment="kpoint 38">
+        <r>   -7.4064    1.0000 </r>
+        <r>   -4.5665    1.0000 </r>
+        <r>    2.6294    1.0000 </r>
+        <r>    2.7735    1.0000 </r>
+        <r>    2.9073    1.0000 </r>
+        <r>    7.2813    0.0000 </r>
+        <r>    7.5224    0.0000 </r>
+        <r>    8.1633    0.0000 </r>
+        <r>    9.8897    0.0000 </r>
+        <r>   13.4772    0.0000 </r>
+        <r>   14.1697    0.0000 </r>
+        <r>   14.9556    0.0000 </r>
+        <r>   15.6722    0.0000 </r>
+        <r>   17.5226    0.0000 </r>
+        <r>   17.5315    0.0000 </r>
+        <r>   17.7760    0.0000 </r>
+       </set>
+       <set comment="kpoint 39">
+        <r>   -7.9092    1.0000 </r>
+        <r>   -4.0356    1.0000 </r>
+        <r>    2.7843    1.0000 </r>
+        <r>    3.1988    1.0000 </r>
+        <r>    4.6020    1.0000 </r>
+        <r>    5.8856    0.0000 </r>
+        <r>    7.7292    0.0000 </r>
+        <r>    7.8644    0.0000 </r>
+        <r>   10.2182    0.0000 </r>
+        <r>   12.5976    0.0000 </r>
+        <r>   13.2067    0.0000 </r>
+        <r>   14.4164    0.0000 </r>
+        <r>   14.9889    0.0000 </r>
+        <r>   15.6298    0.0000 </r>
+        <r>   17.3270    0.0000 </r>
+        <r>   17.6329    0.0000 </r>
+       </set>
+       <set comment="kpoint 40">
+        <r>   -7.4992    1.0000 </r>
+        <r>   -4.4991    1.0000 </r>
+        <r>    1.7779    1.0000 </r>
+        <r>    2.9154    1.0000 </r>
+        <r>    4.2452    1.0000 </r>
+        <r>    6.3050    0.0000 </r>
+        <r>    7.6046    0.0000 </r>
+        <r>    9.0648    0.0000 </r>
+        <r>   10.4599    0.0000 </r>
+        <r>   13.1775    0.0000 </r>
+        <r>   13.8201    0.0000 </r>
+        <r>   14.6087    0.0000 </r>
+        <r>   15.0164    0.0000 </r>
+        <r>   16.9100    0.0000 </r>
+        <r>   17.3215    0.0000 </r>
+        <r>   18.1592    0.0000 </r>
+       </set>
+       <set comment="kpoint 41">
+        <r>   -6.8827    1.0000 </r>
+        <r>   -5.1442    1.0000 </r>
+        <r>    1.1893    1.0000 </r>
+        <r>    2.1273    1.0000 </r>
+        <r>    4.7570    1.0000 </r>
+        <r>    5.6081    0.0000 </r>
+        <r>    8.4775    0.0000 </r>
+        <r>    9.7044    0.0000 </r>
+        <r>   10.9938    0.0000 </r>
+        <r>   12.4789    0.0000 </r>
+        <r>   13.9902    0.0000 </r>
+        <r>   15.0212    0.0000 </r>
+        <r>   16.4988    0.0000 </r>
+        <r>   17.9562    0.0000 </r>
+        <r>   18.8570    0.0000 </r>
+        <r>   19.1369    0.0000 </r>
+       </set>
+       <set comment="kpoint 42">
+        <r>   -6.4048    1.0000 </r>
+        <r>   -5.6138    1.0000 </r>
+        <r>    1.2195    1.0000 </r>
+        <r>    1.6672    1.0000 </r>
+        <r>    4.2982    1.0000 </r>
+        <r>    5.9619    0.0000 </r>
+        <r>    9.0587    0.0000 </r>
+        <r>    9.4566    0.0000 </r>
+        <r>   11.0009    0.0000 </r>
+        <r>   12.2182    0.0000 </r>
+        <r>   15.1984    0.0000 </r>
+        <r>   15.3758    0.0000 </r>
+        <r>   17.2468    0.0000 </r>
+        <r>   17.4349    0.0000 </r>
+        <r>   18.6970    0.0000 </r>
+        <r>   18.9476    0.0000 </r>
+       </set>
+       <set comment="kpoint 43">
+        <r>   -6.9291    1.0000 </r>
+        <r>   -5.0170    1.0000 </r>
+        <r>    1.5904    1.0000 </r>
+        <r>    1.8923    1.0000 </r>
+        <r>    3.5286    1.0000 </r>
+        <r>    6.7836    0.0000 </r>
+        <r>    8.6592    0.0000 </r>
+        <r>    9.0191    0.0000 </r>
+        <r>   10.4095    0.0000 </r>
+        <r>   13.9162    0.0000 </r>
+        <r>   14.0991    0.0000 </r>
+        <r>   15.0117    0.0000 </r>
+        <r>   16.1824    0.0000 </r>
+        <r>   17.7980    0.0000 </r>
+        <r>   18.3970    0.0000 </r>
+        <r>   18.5253    0.0000 </r>
+       </set>
+       <set comment="kpoint 44">
+        <r>   -7.2528    1.0000 </r>
+        <r>   -4.6394    1.0000 </r>
+        <r>    1.3651    1.0000 </r>
+        <r>    2.5975    1.0000 </r>
+        <r>    2.9429    1.0000 </r>
+        <r>    7.7970    0.0000 </r>
+        <r>    8.6094    0.0000 </r>
+        <r>    9.1213    0.0000 </r>
+        <r>   10.0068    0.0000 </r>
+        <r>   14.3085    0.0000 </r>
+        <r>   14.9712    0.0000 </r>
+        <r>   15.0932    0.0000 </r>
+        <r>   15.5471    0.0000 </r>
+        <r>   16.0877    0.0000 </r>
+        <r>   16.3119    0.0000 </r>
+        <r>   17.9227    0.0000 </r>
+       </set>
+       <set comment="kpoint 45">
+        <r>   -6.8260    1.0000 </r>
+        <r>   -4.9838    1.0000 </r>
+        <r>    0.7745    1.0000 </r>
+        <r>    1.6488    1.0000 </r>
+        <r>    3.5529    1.0000 </r>
+        <r>    7.1800    0.0000 </r>
+        <r>    9.1602    0.0000 </r>
+        <r>   10.1587    0.0000 </r>
+        <r>   10.7711    0.0000 </r>
+        <r>   13.1546    0.0000 </r>
+        <r>   14.8583    0.0000 </r>
+        <r>   15.7666    0.0000 </r>
+        <r>   16.4883    0.0000 </r>
+        <r>   16.8413    0.0000 </r>
+        <r>   17.7940    0.0000 </r>
+        <r>   18.1584    0.0000 </r>
+       </set>
+       <set comment="kpoint 46">
+        <r>   -6.3246    1.0000 </r>
+        <r>   -5.4911    1.0000 </r>
+        <r>    0.7251    1.0000 </r>
+        <r>    1.0569    1.0000 </r>
+        <r>    4.3772    1.0000 </r>
+        <r>    6.1180    0.0000 </r>
+        <r>    9.9212    0.0000 </r>
+        <r>   10.4995    0.0000 </r>
+        <r>   11.0946    0.0000 </r>
+        <r>   11.9405    0.0000 </r>
+        <r>   15.5578    0.0000 </r>
+        <r>   15.9114    0.0000 </r>
+        <r>   16.6654    0.0000 </r>
+        <r>   16.8195    0.0000 </r>
+        <r>   18.1698    0.0000 </r>
+        <r>   18.4514    0.0000 </r>
+       </set>
+       <set comment="kpoint 47">
+        <r>   -6.3025    1.0000 </r>
+        <r>   -5.6138    1.0000 </r>
+        <r>    0.9841    1.0000 </r>
+        <r>    1.3852    1.0000 </r>
+        <r>    4.2359    1.0000 </r>
+        <r>    5.9732    0.0000 </r>
+        <r>    9.7396    0.0000 </r>
+        <r>    9.8472    0.0000 </r>
+        <r>   11.0321    0.0000 </r>
+        <r>   12.1222    0.0000 </r>
+        <r>   14.9336    0.0000 </r>
+        <r>   15.4688    0.0000 </r>
+        <r>   16.4642    0.0000 </r>
+        <r>   17.2523    0.0000 </r>
+        <r>   18.8284    0.0000 </r>
+        <r>   19.3227    0.0000 </r>
+       </set>
+       <set comment="kpoint 48">
+        <r>   -6.6632    1.0000 </r>
+        <r>   -5.0293    1.0000 </r>
+        <r>    0.3146    1.0000 </r>
+        <r>    2.2798    1.0000 </r>
+        <r>    2.3658    1.0000 </r>
+        <r>    8.0626    0.0000 </r>
+        <r>    9.0923    0.0000 </r>
+        <r>   10.0078    0.0000 </r>
+        <r>   11.4148    0.0000 </r>
+        <r>   13.9666    0.0000 </r>
+        <r>   14.6669    0.0000 </r>
+        <r>   16.2326    0.0000 </r>
+        <r>   16.5818    0.0000 </r>
+        <r>   16.7181    0.0000 </r>
+        <r>   17.7905    0.0000 </r>
+        <r>   18.0261    0.0000 </r>
+       </set>
+       <set comment="kpoint 49">
+        <r>   -6.4693    1.0000 </r>
+        <r>   -5.2645    1.0000 </r>
+        <r>    0.4597    1.0000 </r>
+        <r>    1.4500    1.0000 </r>
+        <r>    3.3352    1.0000 </r>
+        <r>    7.3083    0.0000 </r>
+        <r>    9.1028    0.0000 </r>
+        <r>   10.7435    0.0000 </r>
+        <r>   11.1393    0.0000 </r>
+        <r>   12.9188    0.0000 </r>
+        <r>   15.4427    0.0000 </r>
+        <r>   15.9553    0.0000 </r>
+        <r>   16.4709    0.0000 </r>
+        <r>   17.1390    0.0000 </r>
+        <r>   18.0240    0.0000 </r>
+        <r>   18.5546    0.0000 </r>
+       </set>
+       <set comment="kpoint 50">
+        <r>   -6.7119    1.0000 </r>
+        <r>   -5.0896    1.0000 </r>
+        <r>    0.8315    1.0000 </r>
+        <r>    2.3469    1.0000 </r>
+        <r>    2.3752    1.0000 </r>
+        <r>    7.8876    0.0000 </r>
+        <r>    8.8362    0.0000 </r>
+        <r>    9.8807    0.0000 </r>
+        <r>   10.2016    0.0000 </r>
+        <r>   14.2569    0.0000 </r>
+        <r>   15.0795    0.0000 </r>
+        <r>   15.6685    0.0000 </r>
+        <r>   16.4039    0.0000 </r>
+        <r>   17.2579    0.0000 </r>
+        <r>   17.3610    0.0000 </r>
+        <r>   18.9920    0.0000 </r>
+       </set>
+       <set comment="kpoint 51">
+        <r>   -7.8658    1.0000 </r>
+        <r>   -4.2905    1.0000 </r>
+        <r>    3.8565    1.0000 </r>
+        <r>    4.0148    1.0000 </r>
+        <r>    4.0163    1.0000 </r>
+        <r>    6.3874    0.0000 </r>
+        <r>    6.4754    0.0000 </r>
+        <r>    6.4758    0.0000 </r>
+        <r>   11.0312    0.0000 </r>
+        <r>   12.6414    0.0000 </r>
+        <r>   12.6420    0.0000 </r>
+        <r>   15.4998    0.0000 </r>
+        <r>   16.3269    0.0000 </r>
+        <r>   16.3838    0.0000 </r>
+        <r>   16.3848    0.0000 </r>
+        <r>   17.7758    0.0000 </r>
+       </set>
+       <set comment="kpoint 52">
+        <r>   -7.5646    1.0000 </r>
+        <r>   -4.6467    1.0000 </r>
+        <r>    2.3074    1.0000 </r>
+        <r>    4.3167    1.0000 </r>
+        <r>    4.7226    1.0000 </r>
+        <r>    5.5720    0.0000 </r>
+        <r>    5.9289    0.0000 </r>
+        <r>    8.3607    0.0000 </r>
+        <r>   11.1859    0.0000 </r>
+        <r>   12.4783    0.0000 </r>
+        <r>   14.1435    0.0000 </r>
+        <r>   14.9356    0.0000 </r>
+        <r>   15.1152    0.0000 </r>
+        <r>   17.1561    0.0000 </r>
+        <r>   17.9243    0.0000 </r>
+        <r>   18.1128    0.0000 </r>
+       </set>
+       <set comment="kpoint 53">
+        <r>   -7.0511    1.0000 </r>
+        <r>   -5.0641    1.0000 </r>
+        <r>    1.1490    1.0000 </r>
+        <r>    3.5058    1.0000 </r>
+        <r>    3.7977    1.0000 </r>
+        <r>    6.6089    0.0000 </r>
+        <r>    6.8288    0.0000 </r>
+        <r>    9.9257    0.0000 </r>
+        <r>   11.6760    0.0000 </r>
+        <r>   12.5100    0.0000 </r>
+        <r>   12.8313    0.0000 </r>
+        <r>   14.5883    0.0000 </r>
+        <r>   16.6452    0.0000 </r>
+        <r>   18.6259    0.0000 </r>
+        <r>   18.7377    0.0000 </r>
+        <r>   19.3222    0.0000 </r>
+       </set>
+       <set comment="kpoint 54">
+        <r>   -6.5342    1.0000 </r>
+        <r>   -5.4257    1.0000 </r>
+        <r>    0.6578    1.0000 </r>
+        <r>    2.7666    1.0000 </r>
+        <r>    2.9480    1.0000 </r>
+        <r>    7.5199    0.0000 </r>
+        <r>    7.9088    0.0000 </r>
+        <r>   10.5208    0.0000 </r>
+        <r>   10.6803    0.0000 </r>
+        <r>   12.7810    0.0000 </r>
+        <r>   13.7754    0.0000 </r>
+        <r>   15.6361    0.0000 </r>
+        <r>   17.9958    0.0000 </r>
+        <r>   18.2630    0.0000 </r>
+        <r>   18.6260    0.0000 </r>
+        <r>   18.8663    0.0000 </r>
+       </set>
+       <set comment="kpoint 55">
+        <r>   -7.4031    1.0000 </r>
+        <r>   -4.8681    1.0000 </r>
+        <r>    2.5903    1.0000 </r>
+        <r>    3.4075    1.0000 </r>
+        <r>    4.1998    1.0000 </r>
+        <r>    6.1291    0.0000 </r>
+        <r>    7.0794    0.0000 </r>
+        <r>    7.6085    0.0000 </r>
+        <r>   10.9822    0.0000 </r>
+        <r>   13.6273    0.0000 </r>
+        <r>   14.5279    0.0000 </r>
+        <r>   15.0444    0.0000 </r>
+        <r>   15.3039    0.0000 </r>
+        <r>   16.9818    0.0000 </r>
+        <r>   17.1817    0.0000 </r>
+        <r>   17.9872    0.0000 </r>
+       </set>
+       <set comment="kpoint 56">
+        <r>   -7.0484    1.0000 </r>
+        <r>   -5.0880    1.0000 </r>
+        <r>    1.4893    1.0000 </r>
+        <r>    2.4822    1.0000 </r>
+        <r>    4.7860    1.0000 </r>
+        <r>    5.5905    0.0000 </r>
+        <r>    8.2231    0.0000 </r>
+        <r>    9.1713    0.0000 </r>
+        <r>   11.0637    0.0000 </r>
+        <r>   12.6883    0.0000 </r>
+        <r>   14.3331    0.0000 </r>
+        <r>   15.2623    0.0000 </r>
+        <r>   16.5397    0.0000 </r>
+        <r>   16.7034    0.0000 </r>
+        <r>   18.5331    0.0000 </r>
+        <r>   18.8038    0.0000 </r>
+       </set>
+       <set comment="kpoint 57">
+        <r>   -6.6165    1.0000 </r>
+        <r>   -5.2908    1.0000 </r>
+        <r>    0.6903    1.0000 </r>
+        <r>    1.6728    1.0000 </r>
+        <r>    4.3587    1.0000 </r>
+        <r>    6.1660    0.0000 </r>
+        <r>    9.3143    0.0000 </r>
+        <r>   10.4514    0.0000 </r>
+        <r>   11.0653    0.0000 </r>
+        <r>   11.9736    0.0000 </r>
+        <r>   14.8336    0.0000 </r>
+        <r>   15.5267    0.0000 </r>
+        <r>   16.8003    0.0000 </r>
+        <r>   17.1837    0.0000 </r>
+        <r>   18.5184    0.0000 </r>
+        <r>   19.2851    0.0000 </r>
+       </set>
+       <set comment="kpoint 58">
+        <r>   -6.8884    1.0000 </r>
+        <r>   -5.1627    1.0000 </r>
+        <r>    1.0337    1.0000 </r>
+        <r>    2.9192    1.0000 </r>
+        <r>    3.2114    1.0000 </r>
+        <r>    7.3808    0.0000 </r>
+        <r>    7.7614    0.0000 </r>
+        <r>    9.8753    0.0000 </r>
+        <r>   10.6668    0.0000 </r>
+        <r>   13.1488    0.0000 </r>
+        <r>   13.9359    0.0000 </r>
+        <r>   15.8345    0.0000 </r>
+        <r>   16.8943    0.0000 </r>
+        <r>   17.4835    0.0000 </r>
+        <r>   17.8389    0.0000 </r>
+        <r>   17.8686    0.0000 </r>
+       </set>
+       <set comment="kpoint 59">
+        <r>   -7.3728    1.0000 </r>
+        <r>   -5.0942    1.0000 </r>
+        <r>    3.9037    1.0000 </r>
+        <r>    4.2879    1.0000 </r>
+        <r>    4.2880    1.0000 </r>
+        <r>    5.8256    0.0000 </r>
+        <r>    5.8260    0.0000 </r>
+        <r>    6.0622    0.0000 </r>
+        <r>   12.1395    0.0000 </r>
+        <r>   13.9648    0.0000 </r>
+        <r>   13.9653    0.0000 </r>
+        <r>   15.1155    0.0000 </r>
+        <r>   15.6091    0.0000 </r>
+        <r>   15.6096    0.0000 </r>
+        <r>   18.5435    0.0000 </r>
+        <r>   18.5435    0.0000 </r>
+       </set>
+       <set comment="kpoint 60">
+        <r>   -7.1770    1.0000 </r>
+        <r>   -5.1970    1.0000 </r>
+        <r>    2.3658    1.0000 </r>
+        <r>    3.8406    1.0000 </r>
+        <r>    4.3078    1.0000 </r>
+        <r>    5.9064    0.0000 </r>
+        <r>    6.3546    0.0000 </r>
+        <r>    7.9012    0.0000 </r>
+        <r>   11.9541    0.0000 </r>
+        <r>   13.3092    0.0000 </r>
+        <r>   13.7377    0.0000 </r>
+        <r>   15.4266    0.0000 </r>
+        <r>   16.1530    0.0000 </r>
+        <r>   16.4314    0.0000 </r>
+        <r>   17.8097    0.0000 </r>
+        <r>   19.0241    0.0000 </r>
+       </set>
+      </set>
+      <set comment="spin 2">
+       <set comment="kpoint 1">
+        <r>   -8.6395    1.0000 </r>
+        <r>   -2.7008    1.0000 </r>
+        <r>    3.5522    1.0000 </r>
+        <r>    3.5816    1.0000 </r>
+        <r>    3.5829    1.0000 </r>
+        <r>    7.6389    0.0000 </r>
+        <r>    7.6907    0.0000 </r>
+        <r>    7.6913    0.0000 </r>
+        <r>   10.8573    0.0000 </r>
+        <r>   11.2076    0.0000 </r>
+        <r>   11.2081    0.0000 </r>
+        <r>   12.1176    0.0000 </r>
+        <r>   12.3568    0.0000 </r>
+        <r>   13.4333    0.0000 </r>
+        <r>   13.4346    0.0000 </r>
+        <r>   21.8950    0.0000 </r>
+       </set>
+       <set comment="kpoint 2">
+        <r>   -8.4440    1.0000 </r>
+        <r>   -3.1676    1.0000 </r>
+        <r>    3.1351    1.0000 </r>
+        <r>    3.7888    1.0000 </r>
+        <r>    3.9922    1.0000 </r>
+        <r>    6.7927    0.0000 </r>
+        <r>    6.9909    0.0000 </r>
+        <r>    7.9378    0.0000 </r>
+        <r>   10.5828    0.0000 </r>
+        <r>   11.2141    0.0000 </r>
+        <r>   11.3947    0.0000 </r>
+        <r>   12.9710    0.0000 </r>
+        <r>   13.7448    0.0000 </r>
+        <r>   14.4007    0.0000 </r>
+        <r>   14.6553    0.0000 </r>
+        <r>   19.6841    0.0000 </r>
+       </set>
+       <set comment="kpoint 3">
+        <r>   -7.9524    1.0000 </r>
+        <r>   -4.1244    1.0000 </r>
+        <r>    2.9052    1.0000 </r>
+        <r>    3.8923    1.0000 </r>
+        <r>    4.4405    1.0000 </r>
+        <r>    5.7474    0.0000 </r>
+        <r>    6.2633    0.0000 </r>
+        <r>    7.4760    0.0000 </r>
+        <r>   10.8001    0.0000 </r>
+        <r>   11.8486    0.0000 </r>
+        <r>   12.2311    0.0000 </r>
+        <r>   14.7401    0.0000 </r>
+        <r>   15.9531    0.0000 </r>
+        <r>   16.3253    0.0000 </r>
+        <r>   16.4884    0.0000 </r>
+        <r>   17.5668    0.0000 </r>
+       </set>
+       <set comment="kpoint 4">
+        <r>   -7.2035    1.0000 </r>
+        <r>   -5.2508    1.0000 </r>
+        <r>    2.9708    1.0000 </r>
+        <r>    3.7906    1.0000 </r>
+        <r>    4.6760    1.0000 </r>
+        <r>    5.0836    0.0000 </r>
+        <r>    5.9274    0.0000 </r>
+        <r>    6.6809    0.0000 </r>
+        <r>   12.0393    0.0000 </r>
+        <r>   13.0690    0.0000 </r>
+        <r>   13.4427    0.0000 </r>
+        <r>   14.6901    0.0000 </r>
+        <r>   16.3713    0.0000 </r>
+        <r>   17.1277    0.0000 </r>
+        <r>   17.9440    0.0000 </r>
+        <r>   18.6324    0.0000 </r>
+       </set>
+       <set comment="kpoint 5">
+        <r>   -6.6556    1.0000 </r>
+        <r>   -5.9081    1.0000 </r>
+        <r>    3.3167    1.0000 </r>
+        <r>    3.5207    1.0000 </r>
+        <r>    4.1807    1.0000 </r>
+        <r>    5.5014    0.0000 </r>
+        <r>    5.9981    0.0000 </r>
+        <r>    6.1262    0.0000 </r>
+        <r>   12.4027    0.0000 </r>
+        <r>   14.0816    0.0000 </r>
+        <r>   14.5179    0.0000 </r>
+        <r>   14.7200    0.0000 </r>
+        <r>   15.3783    0.0000 </r>
+        <r>   15.3860    0.0000 </r>
+        <r>   19.2554    0.0000 </r>
+        <r>   19.9026    0.0000 </r>
+       </set>
+       <set comment="kpoint 6">
+        <r>   -7.4335    1.0000 </r>
+        <r>   -4.9225    1.0000 </r>
+        <r>    3.3020    1.0000 </r>
+        <r>    3.6399    1.0000 </r>
+        <r>    3.9810    1.0000 </r>
+        <r>    5.6104    0.0000 </r>
+        <r>    6.2306    0.0000 </r>
+        <r>    6.6949    0.0000 </r>
+        <r>   11.0238    0.0000 </r>
+        <r>   12.9198    0.0000 </r>
+        <r>   13.3633    0.0000 </r>
+        <r>   15.8011    0.0000 </r>
+        <r>   16.6067    0.0000 </r>
+        <r>   17.2268    0.0000 </r>
+        <r>   17.3826    0.0000 </r>
+        <r>   17.8147    0.0000 </r>
+       </set>
+       <set comment="kpoint 7">
+        <r>   -8.1176    1.0000 </r>
+        <r>   -3.7985    1.0000 </r>
+        <r>    3.2531    1.0000 </r>
+        <r>    3.4490    1.0000 </r>
+        <r>    4.2135    1.0000 </r>
+        <r>    5.8789    0.0000 </r>
+        <r>    7.0541    0.0000 </r>
+        <r>    7.4084    0.0000 </r>
+        <r>   10.2734    0.0000 </r>
+        <r>   11.6818    0.0000 </r>
+        <r>   12.1245    0.0000 </r>
+        <r>   14.3977    0.0000 </r>
+        <r>   15.0217    0.0000 </r>
+        <r>   15.2230    0.0000 </r>
+        <r>   16.5916    0.0000 </r>
+        <r>   19.2504    0.0000 </r>
+       </set>
+       <set comment="kpoint 8">
+        <r>   -8.5287    1.0000 </r>
+        <r>   -2.9469    1.0000 </r>
+        <r>    3.3680    1.0000 </r>
+        <r>    3.3706    1.0000 </r>
+        <r>    4.0141    1.0000 </r>
+        <r>    6.7790    0.0000 </r>
+        <r>    7.7017    0.0000 </r>
+        <r>    7.8854    0.0000 </r>
+        <r>   10.4188    0.0000 </r>
+        <r>   11.1896    0.0000 </r>
+        <r>   11.4650    0.0000 </r>
+        <r>   12.5088    0.0000 </r>
+        <r>   13.2085    0.0000 </r>
+        <r>   13.5903    0.0000 </r>
+        <r>   14.5858    0.0000 </r>
+        <r>   21.6163    0.0000 </r>
+       </set>
+       <set comment="kpoint 9">
+        <r>   -8.3633    1.0000 </r>
+        <r>   -3.2986    1.0000 </r>
+        <r>    2.9990    1.0000 </r>
+        <r>    3.1074    1.0000 </r>
+        <r>    4.8766    1.0000 </r>
+        <r>    5.6355    0.0000 </r>
+        <r>    7.8818    0.0000 </r>
+        <r>    8.1103    0.0000 </r>
+        <r>   10.2441    0.0000 </r>
+        <r>   11.6867    0.0000 </r>
+        <r>   12.1435    0.0000 </r>
+        <r>   12.7471    0.0000 </r>
+        <r>   13.6298    0.0000 </r>
+        <r>   13.8766    0.0000 </r>
+        <r>   16.0876    0.0000 </r>
+        <r>   20.0589    0.0000 </r>
+       </set>
+       <set comment="kpoint 10">
+        <r>   -7.9899    1.0000 </r>
+        <r>   -3.9232    1.0000 </r>
+        <r>    2.4440    1.0000 </r>
+        <r>    3.0378    1.0000 </r>
+        <r>    4.2666    1.0000 </r>
+        <r>    6.0804    0.0000 </r>
+        <r>    7.4839    0.0000 </r>
+        <r>    8.3740    0.0000 </r>
+        <r>   10.0659    0.0000 </r>
+        <r>   12.4447    0.0000 </r>
+        <r>   12.7656    0.0000 </r>
+        <r>   13.6684    0.0000 </r>
+        <r>   14.7025    0.0000 </r>
+        <r>   15.6718    0.0000 </r>
+        <r>   17.2018    0.0000 </r>
+        <r>   18.2109    0.0000 </r>
+       </set>
+       <set comment="kpoint 11">
+        <r>   -7.3522    1.0000 </r>
+        <r>   -4.8619    1.0000 </r>
+        <r>    2.2406    1.0000 </r>
+        <r>    2.6134    1.0000 </r>
+        <r>    4.0017    1.0000 </r>
+        <r>    6.1873    0.0000 </r>
+        <r>    7.3720    0.0000 </r>
+        <r>    8.0449    0.0000 </r>
+        <r>   10.5095    0.0000 </r>
+        <r>   13.4542    0.0000 </r>
+        <r>   13.8829    0.0000 </r>
+        <r>   14.7230    0.0000 </r>
+        <r>   15.4512    0.0000 </r>
+        <r>   17.1236    0.0000 </r>
+        <r>   17.4375    0.0000 </r>
+        <r>   18.3078    0.0000 </r>
+       </set>
+       <set comment="kpoint 12">
+        <r>   -6.5867    1.0000 </r>
+        <r>   -5.7985    1.0000 </r>
+        <r>    2.1016    1.0000 </r>
+        <r>    2.4632    1.0000 </r>
+        <r>    4.2560    1.0000 </r>
+        <r>    5.6289    0.0000 </r>
+        <r>    7.3204    0.0000 </r>
+        <r>    7.8871    0.0000 </r>
+        <r>   11.8556    0.0000 </r>
+        <r>   12.6015    0.0000 </r>
+        <r>   14.7066    0.0000 </r>
+        <r>   15.0451    0.0000 </r>
+        <r>   15.7991    0.0000 </r>
+        <r>   17.5282    0.0000 </r>
+        <r>   18.6097    0.0000 </r>
+        <r>   18.7128    0.0000 </r>
+       </set>
+       <set comment="kpoint 13">
+        <r>   -6.9870    1.0000 </r>
+        <r>   -5.3437    1.0000 </r>
+        <r>    1.9164    1.0000 </r>
+        <r>    3.0639    1.0000 </r>
+        <r>    4.3981    1.0000 </r>
+        <r>    5.4586    0.0000 </r>
+        <r>    6.6005    0.0000 </r>
+        <r>    8.4042    0.0000 </r>
+        <r>   11.0318    0.0000 </r>
+        <r>   13.0458    0.0000 </r>
+        <r>   14.0064    0.0000 </r>
+        <r>   15.4365    0.0000 </r>
+        <r>   15.8386    0.0000 </r>
+        <r>   17.5956    0.0000 </r>
+        <r>   17.9062    0.0000 </r>
+        <r>   19.2851    0.0000 </r>
+       </set>
+       <set comment="kpoint 14">
+        <r>   -7.7246    1.0000 </r>
+        <r>   -4.3598    1.0000 </r>
+        <r>    2.1622    1.0000 </r>
+        <r>    3.9050    1.0000 </r>
+        <r>    4.0273    1.0000 </r>
+        <r>    5.9101    0.0000 </r>
+        <r>    6.1739    0.0000 </r>
+        <r>    8.6090    0.0000 </r>
+        <r>   10.2432    0.0000 </r>
+        <r>   12.0912    0.0000 </r>
+        <r>   13.7723    0.0000 </r>
+        <r>   13.8855    0.0000 </r>
+        <r>   15.9387    0.0000 </r>
+        <r>   16.7965    0.0000 </r>
+        <r>   17.4023    0.0000 </r>
+        <r>   18.6396    0.0000 </r>
+       </set>
+       <set comment="kpoint 15">
+        <r>   -8.2266    1.0000 </r>
+        <r>   -3.5610    1.0000 </r>
+        <r>    2.8548    1.0000 </r>
+        <r>    3.4676    1.0000 </r>
+        <r>    4.5608    1.0000 </r>
+        <r>    5.7531    0.0000 </r>
+        <r>    7.1356    0.0000 </r>
+        <r>    8.1200    0.0000 </r>
+        <r>   10.1169    0.0000 </r>
+        <r>   11.5910    0.0000 </r>
+        <r>   12.2408    0.0000 </r>
+        <r>   13.2323    0.0000 </r>
+        <r>   14.4003    0.0000 </r>
+        <r>   15.1150    0.0000 </r>
+        <r>   16.3126    0.0000 </r>
+        <r>   19.3825    0.0000 </r>
+       </set>
+       <set comment="kpoint 16">
+        <r>   -7.7556    1.0000 </r>
+        <r>   -4.0707    1.0000 </r>
+        <r>    1.9817    1.0000 </r>
+        <r>    2.4195    1.0000 </r>
+        <r>    3.0380    1.0000 </r>
+        <r>    7.6324    0.0000 </r>
+        <r>    8.0522    0.0000 </r>
+        <r>    8.8915    0.0000 </r>
+        <r>   10.0687    0.0000 </r>
+        <r>   13.3465    0.0000 </r>
+        <r>   13.5970    0.0000 </r>
+        <r>   13.7698    0.0000 </r>
+        <r>   14.3527    0.0000 </r>
+        <r>   16.0935    0.0000 </r>
+        <r>   17.6393    0.0000 </r>
+        <r>   17.7902    0.0000 </r>
+       </set>
+       <set comment="kpoint 17">
+        <r>   -7.2794    1.0000 </r>
+        <r>   -4.6033    1.0000 </r>
+        <r>    1.3351    1.0000 </r>
+        <r>    1.9334    1.0000 </r>
+        <r>    2.8631    1.0000 </r>
+        <r>    7.7963    0.0000 </r>
+        <r>    8.6921    0.0000 </r>
+        <r>    9.2045    0.0000 </r>
+        <r>   10.0829    0.0000 </r>
+        <r>   14.0115    0.0000 </r>
+        <r>   14.5895    0.0000 </r>
+        <r>   15.0477    0.0000 </r>
+        <r>   15.1739    0.0000 </r>
+        <r>   16.0795    0.0000 </r>
+        <r>   17.5409    0.0000 </r>
+        <r>   17.9572    0.0000 </r>
+       </set>
+       <set comment="kpoint 18">
+        <r>   -6.6324    1.0000 </r>
+        <r>   -5.3909    1.0000 </r>
+        <r>    0.8563    1.0000 </r>
+        <r>    1.8482    1.0000 </r>
+        <r>    3.2323    1.0000 </r>
+        <r>    7.1849    0.0000 </r>
+        <r>    8.6534    0.0000 </r>
+        <r>    9.8783    0.0000 </r>
+        <r>   10.2578    0.0000 </r>
+        <r>   13.0612    0.0000 </r>
+        <r>   14.8824    0.0000 </r>
+        <r>   15.7765    0.0000 </r>
+        <r>   16.4522    0.0000 </r>
+        <r>   17.1381    0.0000 </r>
+        <r>   17.8761    0.0000 </r>
+        <r>   18.1990    0.0000 </r>
+       </set>
+       <set comment="kpoint 19">
+        <r>   -6.3561    1.0000 </r>
+        <r>   -5.7946    1.0000 </r>
+        <r>    0.8297    1.0000 </r>
+        <r>    2.2986    1.0000 </r>
+        <r>    3.7756    1.0000 </r>
+        <r>    6.2638    0.0000 </r>
+        <r>    7.8891    0.0000 </r>
+        <r>   10.0627    0.0000 </r>
+        <r>   11.3788    0.0000 </r>
+        <r>   12.0321    0.0000 </r>
+        <r>   13.6060    0.0000 </r>
+        <r>   15.2430    0.0000 </r>
+        <r>   17.8489    0.0000 </r>
+        <r>   18.1885    0.0000 </r>
+        <r>   18.6408    0.0000 </r>
+        <r>   19.0885    0.0000 </r>
+       </set>
+       <set comment="kpoint 20">
+        <r>   -7.0771    1.0000 </r>
+        <r>   -5.1395    1.0000 </r>
+        <r>    1.4050    1.0000 </r>
+        <r>    3.1634    1.0000 </r>
+        <r>    4.1791    1.0000 </r>
+        <r>    5.6333    0.0000 </r>
+        <r>    6.8277    0.0000 </r>
+        <r>    9.3299    0.0000 </r>
+        <r>   10.7951    0.0000 </r>
+        <r>   12.7439    0.0000 </r>
+        <r>   13.8011    0.0000 </r>
+        <r>   14.5480    0.0000 </r>
+        <r>   15.9428    0.0000 </r>
+        <r>   17.9443    0.0000 </r>
+        <r>   18.7709    0.0000 </r>
+        <r>   19.4394    0.0000 </r>
+       </set>
+       <set comment="kpoint 21">
+        <r>   -7.6401    1.0000 </r>
+        <r>   -4.5566    1.0000 </r>
+        <r>    2.5589    1.0000 </r>
+        <r>    3.6322    1.0000 </r>
+        <r>    4.3109    1.0000 </r>
+        <r>    5.6417    0.0000 </r>
+        <r>    6.2852    0.0000 </r>
+        <r>    7.8160    0.0000 </r>
+        <r>   10.6241    0.0000 </r>
+        <r>   12.1639    0.0000 </r>
+        <r>   13.5969    0.0000 </r>
+        <r>   14.9228    0.0000 </r>
+        <r>   16.0330    0.0000 </r>
+        <r>   17.1219    0.0000 </r>
+        <r>   17.4127    0.0000 </r>
+        <r>   17.7078    0.0000 </r>
+       </set>
+       <set comment="kpoint 22">
+        <r>   -7.0268    1.0000 </r>
+        <r>   -4.6399    1.0000 </r>
+        <r>    0.5223    1.0000 </r>
+        <r>    1.9330    1.0000 </r>
+        <r>    2.0953    1.0000 </r>
+        <r>    7.7321    0.0000 </r>
+        <r>    9.6517    0.0000 </r>
+        <r>   10.3452    0.0000 </r>
+        <r>   10.8160    0.0000 </r>
+        <r>   14.3026    0.0000 </r>
+        <r>   14.8185    0.0000 </r>
+        <r>   15.9099    0.0000 </r>
+        <r>   16.1461    0.0000 </r>
+        <r>   16.2154    0.0000 </r>
+        <r>   16.5031    0.0000 </r>
+        <r>   17.9890    0.0000 </r>
+       </set>
+       <set comment="kpoint 23">
+        <r>   -6.6772    1.0000 </r>
+        <r>   -5.0143    1.0000 </r>
+        <r>    0.1867    1.0000 </r>
+        <r>    1.6502    1.0000 </r>
+        <r>    2.3992    1.0000 </r>
+        <r>    7.9257    0.0000 </r>
+        <r>    9.1377    0.0000 </r>
+        <r>   10.4120    0.0000 </r>
+        <r>   11.4897    0.0000 </r>
+        <r>   14.0269    0.0000 </r>
+        <r>   15.2249    0.0000 </r>
+        <r>   15.8886    0.0000 </r>
+        <r>   16.5018    0.0000 </r>
+        <r>   16.9856    0.0000 </r>
+        <r>   17.1374    0.0000 </r>
+        <r>   17.7313    0.0000 </r>
+       </set>
+       <set comment="kpoint 24">
+        <r>   -6.3310    1.0000 </r>
+        <r>   -5.6005    1.0000 </r>
+        <r>    0.3837    1.0000 </r>
+        <r>    1.8761    1.0000 </r>
+        <r>    2.9770    1.0000 </r>
+        <r>    7.3892    0.0000 </r>
+        <r>    8.8211    0.0000 </r>
+        <r>   10.1765    0.0000 </r>
+        <r>   10.9112    0.0000 </r>
+        <r>   12.8169    0.0000 </r>
+        <r>   14.5610    0.0000 </r>
+        <r>   16.0373    0.0000 </r>
+        <r>   16.8959    0.0000 </r>
+        <r>   17.0728    0.0000 </r>
+        <r>   18.3722    0.0000 </r>
+        <r>   18.8311    0.0000 </r>
+       </set>
+       <set comment="kpoint 25">
+        <r>   -6.3093    1.0000 </r>
+        <r>   -5.9414    1.0000 </r>
+        <r>    1.1722    1.0000 </r>
+        <r>    2.6334    1.0000 </r>
+        <r>    3.6672    1.0000 </r>
+        <r>    6.0845    0.0000 </r>
+        <r>    7.6536    0.0000 </r>
+        <r>    9.2546    0.0000 </r>
+        <r>   11.5913    0.0000 </r>
+        <r>   12.3318    0.0000 </r>
+        <r>   13.7105    0.0000 </r>
+        <r>   15.5242    0.0000 </r>
+        <r>   16.7811    0.0000 </r>
+        <r>   17.6953    0.0000 </r>
+        <r>   18.3960    0.0000 </r>
+        <r>   18.8279    0.0000 </r>
+       </set>
+       <set comment="kpoint 26">
+        <r>   -6.8343    1.0000 </r>
+        <r>   -5.6325    1.0000 </r>
+        <r>    2.4682    1.0000 </r>
+        <r>    3.8097    1.0000 </r>
+        <r>    3.8305    1.0000 </r>
+        <r>    5.6220    0.0000 </r>
+        <r>    6.0447    0.0000 </r>
+        <r>    7.3512    0.0000 </r>
+        <r>   11.9744    0.0000 </r>
+        <r>   13.2856    0.0000 </r>
+        <r>   14.1212    0.0000 </r>
+        <r>   15.0725    0.0000 </r>
+        <r>   15.3480    0.0000 </r>
+        <r>   17.1157    0.0000 </r>
+        <r>   18.0478    0.0000 </r>
+        <r>   19.3970    0.0000 </r>
+       </set>
+       <set comment="kpoint 27">
+        <r>   -6.7544    1.0000 </r>
+        <r>   -4.8415    1.0000 </r>
+        <r>    0.1408    1.0000 </r>
+        <r>    1.8185    1.0000 </r>
+        <r>    1.9298    1.0000 </r>
+        <r>    7.6517    0.0000 </r>
+        <r>    9.8406    0.0000 </r>
+        <r>   10.5275    0.0000 </r>
+        <r>   11.6934    0.0000 </r>
+        <r>   14.8636    0.0000 </r>
+        <r>   15.2516    0.0000 </r>
+        <r>   15.5651    0.0000 </r>
+        <r>   15.9634    0.0000 </r>
+        <r>   16.8836    0.0000 </r>
+        <r>   17.1075    0.0000 </r>
+        <r>   17.7750    0.0000 </r>
+       </set>
+       <set comment="kpoint 28">
+        <r>   -6.8598    1.0000 </r>
+        <r>   -4.9258    1.0000 </r>
+        <r>    0.6002    1.0000 </r>
+        <r>    1.8476    1.0000 </r>
+        <r>    2.4173    1.0000 </r>
+        <r>    7.8918    0.0000 </r>
+        <r>    8.9103    0.0000 </r>
+        <r>   10.1707    0.0000 </r>
+        <r>   10.5623    0.0000 </r>
+        <r>   14.2838    0.0000 </r>
+        <r>   14.9014    0.0000 </r>
+        <r>   15.8045    0.0000 </r>
+        <r>   16.1344    0.0000 </r>
+        <r>   16.2082    0.0000 </r>
+        <r>   17.1671    0.0000 </r>
+        <r>   18.2880    0.0000 </r>
+       </set>
+       <set comment="kpoint 29">
+        <r>   -6.9106    1.0000 </r>
+        <r>   -5.2368    1.0000 </r>
+        <r>    1.4082    1.0000 </r>
+        <r>    2.5152    1.0000 </r>
+        <r>    3.1461    1.0000 </r>
+        <r>    6.8589    0.0000 </r>
+        <r>    8.0773    0.0000 </r>
+        <r>    8.8061    0.0000 </r>
+        <r>   10.3188    0.0000 </r>
+        <r>   13.8925    0.0000 </r>
+        <r>   14.3983    0.0000 </r>
+        <r>   15.0997    0.0000 </r>
+        <r>   15.8808    0.0000 </r>
+        <r>   16.3349    0.0000 </r>
+        <r>   18.0251    0.0000 </r>
+        <r>   19.2760    0.0000 </r>
+       </set>
+       <set comment="kpoint 30">
+        <r>   -7.3141    1.0000 </r>
+        <r>   -4.4715    1.0000 </r>
+        <r>    1.3175    1.0000 </r>
+        <r>    2.1048    1.0000 </r>
+        <r>    2.3021    1.0000 </r>
+        <r>    7.7566    0.0000 </r>
+        <r>    9.1933    0.0000 </r>
+        <r>    9.2951    0.0000 </r>
+        <r>   10.0906    0.0000 </r>
+        <r>   13.8856    0.0000 </r>
+        <r>   14.2302    0.0000 </r>
+        <r>   14.8368    0.0000 </r>
+        <r>   15.5410    0.0000 </r>
+        <r>   17.4264    0.0000 </r>
+        <r>   17.5636    0.0000 </r>
+        <r>   17.7476    0.0000 </r>
+       </set>
+       <set comment="kpoint 31">
+        <r>   -7.5936    1.0000 </r>
+        <r>   -4.3585    1.0000 </r>
+        <r>    1.9569    1.0000 </r>
+        <r>    2.7451    1.0000 </r>
+        <r>    2.9921    1.0000 </r>
+        <r>    7.4828    0.0000 </r>
+        <r>    7.6134    0.0000 </r>
+        <r>    8.5640    0.0000 </r>
+        <r>    9.9216    0.0000 </r>
+        <r>   13.3243    0.0000 </r>
+        <r>   13.7871    0.0000 </r>
+        <r>   14.1168    0.0000 </r>
+        <r>   15.2972    0.0000 </r>
+        <r>   17.0285    0.0000 </r>
+        <r>   17.2225    0.0000 </r>
+        <r>   17.6712    0.0000 </r>
+       </set>
+       <set comment="kpoint 32">
+        <r>   -8.0470    1.0000 </r>
+        <r>   -3.7480    1.0000 </r>
+        <r>    2.6251    1.0000 </r>
+        <r>    2.7086    1.0000 </r>
+        <r>    3.9065    1.0000 </r>
+        <r>    6.3760    0.0000 </r>
+        <r>    7.8494    0.0000 </r>
+        <r>    8.5147    0.0000 </r>
+        <r>    9.8746    0.0000 </r>
+        <r>   12.4683    0.0000 </r>
+        <r>   12.7572    0.0000 </r>
+        <r>   13.2593    0.0000 </r>
+        <r>   14.1582    0.0000 </r>
+        <r>   15.2283    0.0000 </r>
+        <r>   18.0854    0.0000 </r>
+        <r>   19.3751    0.0000 </r>
+       </set>
+       <set comment="kpoint 33">
+        <r>   -8.3889    1.0000 </r>
+        <r>   -3.3646    1.0000 </r>
+        <r>    3.7030    1.0000 </r>
+        <r>    3.7045    1.0000 </r>
+        <r>    3.7814    1.0000 </r>
+        <r>    7.0234    0.0000 </r>
+        <r>    7.0237    0.0000 </r>
+        <r>    7.0267    0.0000 </r>
+        <r>   10.5600    0.0000 </r>
+        <r>   11.6004    0.0000 </r>
+        <r>   11.6007    0.0000 </r>
+        <r>   13.5444    0.0000 </r>
+        <r>   14.1209    0.0000 </r>
+        <r>   14.6117    0.0000 </r>
+        <r>   14.6129    0.0000 </r>
+        <r>   19.6943    0.0000 </r>
+       </set>
+       <set comment="kpoint 34">
+        <r>   -8.1208    1.0000 </r>
+        <r>   -3.8416    1.0000 </r>
+        <r>    2.5397    1.0000 </r>
+        <r>    4.2419    1.0000 </r>
+        <r>    4.6306    1.0000 </r>
+        <r>    5.8251    0.0000 </r>
+        <r>    5.9977    0.0000 </r>
+        <r>    8.3939    0.0000 </r>
+        <r>   10.7156    0.0000 </r>
+        <r>   11.4947    0.0000 </r>
+        <r>   12.6707    0.0000 </r>
+        <r>   13.4373    0.0000 </r>
+        <r>   15.0672    0.0000 </r>
+        <r>   15.8595    0.0000 </r>
+        <r>   16.2760    0.0000 </r>
+        <r>   17.5548    0.0000 </r>
+       </set>
+       <set comment="kpoint 35">
+        <r>   -7.5780    1.0000 </r>
+        <r>   -4.6090    1.0000 </r>
+        <r>    1.7752    1.0000 </r>
+        <r>    3.9966    1.0000 </r>
+        <r>    4.5381    1.0000 </r>
+        <r>    5.6305    0.0000 </r>
+        <r>    5.9383    0.0000 </r>
+        <r>    9.0112    0.0000 </r>
+        <r>   11.0820    0.0000 </r>
+        <r>   11.9934    0.0000 </r>
+        <r>   13.6654    0.0000 </r>
+        <r>   14.3154    0.0000 </r>
+        <r>   14.8102    0.0000 </r>
+        <r>   17.3913    0.0000 </r>
+        <r>   18.2445    0.0000 </r>
+        <r>   18.6952    0.0000 </r>
+       </set>
+       <set comment="kpoint 36">
+        <r>   -6.8401    1.0000 </r>
+        <r>   -5.4938    1.0000 </r>
+        <r>    1.5731    1.0000 </r>
+        <r>    3.3014    1.0000 </r>
+        <r>    3.7242    1.0000 </r>
+        <r>    6.2559    0.0000 </r>
+        <r>    6.5713    0.0000 </r>
+        <r>    8.6764    0.0000 </r>
+        <r>   12.0546    0.0000 </r>
+        <r>   12.4056    0.0000 </r>
+        <r>   13.1036    0.0000 </r>
+        <r>   15.8702    0.0000 </r>
+        <r>   16.0544    0.0000 </r>
+        <r>   17.5795    0.0000 </r>
+        <r>   18.1630    0.0000 </r>
+        <r>   19.7484    0.0000 </r>
+       </set>
+       <set comment="kpoint 37">
+        <r>   -6.7378    1.0000 </r>
+        <r>   -5.5658    1.0000 </r>
+        <r>    1.8897    1.0000 </r>
+        <r>    2.7941    1.0000 </r>
+        <r>    3.1459    1.0000 </r>
+        <r>    6.8729    0.0000 </r>
+        <r>    7.3192    0.0000 </r>
+        <r>    7.9992    0.0000 </r>
+        <r>   10.6442    0.0000 </r>
+        <r>   14.1003    0.0000 </r>
+        <r>   14.5861    0.0000 </r>
+        <r>   15.1766    0.0000 </r>
+        <r>   15.7864    0.0000 </r>
+        <r>   17.6400    0.0000 </r>
+        <r>   17.9372    0.0000 </r>
+        <r>   18.8315    0.0000 </r>
+       </set>
+       <set comment="kpoint 38">
+        <r>   -7.4680    1.0000 </r>
+        <r>   -4.6124    1.0000 </r>
+        <r>    2.4830    1.0000 </r>
+        <r>    2.5927    1.0000 </r>
+        <r>    2.9791    1.0000 </r>
+        <r>    7.2580    0.0000 </r>
+        <r>    7.4618    0.0000 </r>
+        <r>    8.0631    0.0000 </r>
+        <r>    9.8110    0.0000 </r>
+        <r>   13.5535    0.0000 </r>
+        <r>   13.8668    0.0000 </r>
+        <r>   14.9605    0.0000 </r>
+        <r>   15.6794    0.0000 </r>
+        <r>   17.1781    0.0000 </r>
+        <r>   17.3291    0.0000 </r>
+        <r>   17.7003    0.0000 </r>
+       </set>
+       <set comment="kpoint 39">
+        <r>   -7.9731    1.0000 </r>
+        <r>   -4.0693    1.0000 </r>
+        <r>    2.8627    1.0000 </r>
+        <r>    3.0702    1.0000 </r>
+        <r>    4.4209    1.0000 </r>
+        <r>    5.8795    0.0000 </r>
+        <r>    7.5917    0.0000 </r>
+        <r>    7.6002    0.0000 </r>
+        <r>   10.2488    0.0000 </r>
+        <r>   12.5249    0.0000 </r>
+        <r>   13.0994    0.0000 </r>
+        <r>   14.3083    0.0000 </r>
+        <r>   14.8604    0.0000 </r>
+        <r>   15.6476    0.0000 </r>
+        <r>   17.3041    0.0000 </r>
+        <r>   17.4670    0.0000 </r>
+       </set>
+       <set comment="kpoint 40">
+        <r>   -7.5608    1.0000 </r>
+        <r>   -4.5382    1.0000 </r>
+        <r>    1.7984    1.0000 </r>
+        <r>    2.7533    1.0000 </r>
+        <r>    4.1500    1.0000 </r>
+        <r>    6.2120    0.0000 </r>
+        <r>    7.4901    0.0000 </r>
+        <r>    8.9289    0.0000 </r>
+        <r>   10.4629    0.0000 </r>
+        <r>   13.0828    0.0000 </r>
+        <r>   13.7164    0.0000 </r>
+        <r>   14.4573    0.0000 </r>
+        <r>   14.9840    0.0000 </r>
+        <r>   16.9110    0.0000 </r>
+        <r>   17.2535    0.0000 </r>
+        <r>   18.1145    0.0000 </r>
+       </set>
+       <set comment="kpoint 41">
+        <r>   -6.9396    1.0000 </r>
+        <r>   -5.1925    1.0000 </r>
+        <r>    1.1907    1.0000 </r>
+        <r>    1.9455    1.0000 </r>
+        <r>    4.7448    1.0000 </r>
+        <r>    5.4347    0.0000 </r>
+        <r>    8.4162    0.0000 </r>
+        <r>    9.6306    0.0000 </r>
+        <r>   10.9607    0.0000 </r>
+        <r>   12.4263    0.0000 </r>
+        <r>   13.8424    0.0000 </r>
+        <r>   14.9331    0.0000 </r>
+        <r>   16.4643    0.0000 </r>
+        <r>   17.7876    0.0000 </r>
+        <r>   18.8618    0.0000 </r>
+        <r>   19.1087    0.0000 </r>
+       </set>
+       <set comment="kpoint 42">
+        <r>   -6.4553    1.0000 </r>
+        <r>   -5.6702    1.0000 </r>
+        <r>    1.1491    1.0000 </r>
+        <r>    1.5492    1.0000 </r>
+        <r>    4.2361    1.0000 </r>
+        <r>    5.8715    0.0000 </r>
+        <r>    9.0028    0.0000 </r>
+        <r>    9.3995    0.0000 </r>
+        <r>   10.8995    0.0000 </r>
+        <r>   12.1903    0.0000 </r>
+        <r>   15.1023    0.0000 </r>
+        <r>   15.3782    0.0000 </r>
+        <r>   17.0449    0.0000 </r>
+        <r>   17.3169    0.0000 </r>
+        <r>   18.5994    0.0000 </r>
+        <r>   18.7523    0.0000 </r>
+       </set>
+       <set comment="kpoint 43">
+        <r>   -6.9871    1.0000 </r>
+        <r>   -5.0644    1.0000 </r>
+        <r>    1.3742    1.0000 </r>
+        <r>    1.9207    1.0000 </r>
+        <r>    3.4650    1.0000 </r>
+        <r>    6.7222    0.0000 </r>
+        <r>    8.5736    0.0000 </r>
+        <r>    8.9464    0.0000 </r>
+        <r>   10.3481    0.0000 </r>
+        <r>   13.9134    0.0000 </r>
+        <r>   14.0133    0.0000 </r>
+        <r>   14.9668    0.0000 </r>
+        <r>   16.0420    0.0000 </r>
+        <r>   17.5965    0.0000 </r>
+        <r>   18.2176    0.0000 </r>
+        <r>   18.4050    0.0000 </r>
+       </set>
+       <set comment="kpoint 44">
+        <r>   -7.3125    1.0000 </r>
+        <r>   -4.6781    1.0000 </r>
+        <r>    1.3873    1.0000 </r>
+        <r>    2.4340    1.0000 </r>
+        <r>    2.8185    1.0000 </r>
+        <r>    7.7841    0.0000 </r>
+        <r>    8.4205    0.0000 </r>
+        <r>    8.9926    0.0000 </r>
+        <r>    9.9976    0.0000 </r>
+        <r>   14.2828    0.0000 </r>
+        <r>   14.9083    0.0000 </r>
+        <r>   14.9941    0.0000 </r>
+        <r>   15.3042    0.0000 </r>
+        <r>   16.1108    0.0000 </r>
+        <r>   16.2238    0.0000 </r>
+        <r>   17.9443    0.0000 </r>
+       </set>
+       <set comment="kpoint 45">
+        <r>   -6.8818    1.0000 </r>
+        <r>   -5.0272    1.0000 </r>
+        <r>    0.7664    1.0000 </r>
+        <r>    1.4759    1.0000 </r>
+        <r>    3.4733    1.0000 </r>
+        <r>    7.0621    0.0000 </r>
+        <r>    9.0704    0.0000 </r>
+        <r>   10.1689    0.0000 </r>
+        <r>   10.6591    0.0000 </r>
+        <r>   13.1072    0.0000 </r>
+        <r>   14.7498    0.0000 </r>
+        <r>   15.6522    0.0000 </r>
+        <r>   16.4463    0.0000 </r>
+        <r>   16.7307    0.0000 </r>
+        <r>   17.7170    0.0000 </r>
+        <r>   18.1681    0.0000 </r>
+       </set>
+       <set comment="kpoint 46">
+        <r>   -6.3762    1.0000 </r>
+        <r>   -5.5400    1.0000 </r>
+        <r>    0.6068    1.0000 </r>
+        <r>    0.9797    1.0000 </r>
+        <r>    4.3483    1.0000 </r>
+        <r>    5.9880    0.0000 </r>
+        <r>    9.8133    0.0000 </r>
+        <r>   10.4304    0.0000 </r>
+        <r>   11.0404    0.0000 </r>
+        <r>   11.9335    0.0000 </r>
+        <r>   15.5383    0.0000 </r>
+        <r>   15.8206    0.0000 </r>
+        <r>   16.5191    0.0000 </r>
+        <r>   16.7601    0.0000 </r>
+        <r>   18.0172    0.0000 </r>
+        <r>   18.2572    0.0000 </r>
+       </set>
+       <set comment="kpoint 47">
+        <r>   -6.3560    1.0000 </r>
+        <r>   -5.6627    1.0000 </r>
+        <r>    0.7375    1.0000 </r>
+        <r>    1.4355    1.0000 </r>
+        <r>    4.2180    1.0000 </r>
+        <r>    5.8721    0.0000 </r>
+        <r>    9.5513    0.0000 </r>
+        <r>    9.8053    0.0000 </r>
+        <r>   10.9929    0.0000 </r>
+        <r>   12.0984    0.0000 </r>
+        <r>   14.9201    0.0000 </r>
+        <r>   15.3762    0.0000 </r>
+        <r>   16.4736    0.0000 </r>
+        <r>   17.2242    0.0000 </r>
+        <r>   18.5784    0.0000 </r>
+        <r>   18.9705    0.0000 </r>
+       </set>
+       <set comment="kpoint 48">
+        <r>   -6.7165    1.0000 </r>
+        <r>   -5.0747    1.0000 </r>
+        <r>    0.2621    1.0000 </r>
+        <r>    2.0980    1.0000 </r>
+        <r>    2.3219    1.0000 </r>
+        <r>    7.9678    0.0000 </r>
+        <r>    8.9784    0.0000 </r>
+        <r>   10.0369    0.0000 </r>
+        <r>   11.3154    0.0000 </r>
+        <r>   13.9982    0.0000 </r>
+        <r>   14.4980    0.0000 </r>
+        <r>   16.0990    0.0000 </r>
+        <r>   16.4348    0.0000 </r>
+        <r>   16.7095    0.0000 </r>
+        <r>   17.7740    0.0000 </r>
+        <r>   18.0909    0.0000 </r>
+       </set>
+       <set comment="kpoint 49">
+        <r>   -6.5211    1.0000 </r>
+        <r>   -5.3127    1.0000 </r>
+        <r>    0.3689    1.0000 </r>
+        <r>    1.3485    1.0000 </r>
+        <r>    3.2609    1.0000 </r>
+        <r>    7.2203    0.0000 </r>
+        <r>    9.0118    0.0000 </r>
+        <r>   10.7139    0.0000 </r>
+        <r>   11.0708    0.0000 </r>
+        <r>   12.8898    0.0000 </r>
+        <r>   15.3596    0.0000 </r>
+        <r>   15.8549    0.0000 </r>
+        <r>   16.4570    0.0000 </r>
+        <r>   17.0663    0.0000 </r>
+        <r>   17.8556    0.0000 </r>
+        <r>   18.3571    0.0000 </r>
+       </set>
+       <set comment="kpoint 50">
+        <r>   -6.7660    1.0000 </r>
+        <r>   -5.1388    1.0000 </r>
+        <r>    0.7521    1.0000 </r>
+        <r>    2.1585    1.0000 </r>
+        <r>    2.3684    1.0000 </r>
+        <r>    7.8173    0.0000 </r>
+        <r>    8.7566    0.0000 </r>
+        <r>    9.8445    0.0000 </r>
+        <r>   10.1440    0.0000 </r>
+        <r>   14.3495    0.0000 </r>
+        <r>   14.8528    0.0000 </r>
+        <r>   15.7057    0.0000 </r>
+        <r>   16.1930    0.0000 </r>
+        <r>   17.1251    0.0000 </r>
+        <r>   17.1740    0.0000 </r>
+        <r>   18.7896    0.0000 </r>
+       </set>
+       <set comment="kpoint 51">
+        <r>   -7.9300    1.0000 </r>
+        <r>   -4.3234    1.0000 </r>
+        <r>    3.9593    1.0000 </r>
+        <r>    3.9606    1.0000 </r>
+        <r>    4.0041    1.0000 </r>
+        <r>    6.1482    0.0000 </r>
+        <r>    6.1487    0.0000 </r>
+        <r>    6.3449    0.0000 </r>
+        <r>   11.1557    0.0000 </r>
+        <r>   12.4895    0.0000 </r>
+        <r>   12.4899    0.0000 </r>
+        <r>   15.4794    0.0000 </r>
+        <r>   16.2284    0.0000 </r>
+        <r>   16.2928    0.0000 </r>
+        <r>   16.2936    0.0000 </r>
+        <r>   17.6058    0.0000 </r>
+       </set>
+       <set comment="kpoint 52">
+        <r>   -7.6275    1.0000 </r>
+        <r>   -4.6827    1.0000 </r>
+        <r>    2.3172    1.0000 </r>
+        <r>    4.2853    1.0000 </r>
+        <r>    4.6405    1.0000 </r>
+        <r>    5.5508    0.0000 </r>
+        <r>    5.6037    0.0000 </r>
+        <r>    8.1642    0.0000 </r>
+        <r>   11.3062    0.0000 </r>
+        <r>   12.2996    0.0000 </r>
+        <r>   14.0246    0.0000 </r>
+        <r>   14.8484    0.0000 </r>
+        <r>   15.0173    0.0000 </r>
+        <r>   17.2273    0.0000 </r>
+        <r>   17.8233    0.0000 </r>
+        <r>   17.9514    0.0000 </r>
+       </set>
+       <set comment="kpoint 53">
+        <r>   -7.1103    1.0000 </r>
+        <r>   -5.1076    1.0000 </r>
+        <r>    1.1377    1.0000 </r>
+        <r>    3.3540    1.0000 </r>
+        <r>    3.6967    1.0000 </r>
+        <r>    6.5938    0.0000 </r>
+        <r>    6.6603    0.0000 </r>
+        <r>    9.8031    0.0000 </r>
+        <r>   11.8726    0.0000 </r>
+        <r>   12.3190    0.0000 </r>
+        <r>   12.6288    0.0000 </r>
+        <r>   14.4850    0.0000 </r>
+        <r>   16.5780    0.0000 </r>
+        <r>   18.5775    0.0000 </r>
+        <r>   18.7987    0.0000 </r>
+        <r>   19.2636    0.0000 </r>
+       </set>
+       <set comment="kpoint 54">
+        <r>   -6.5865    1.0000 </r>
+        <r>   -5.4786    1.0000 </r>
+        <r>    0.6187    1.0000 </r>
+        <r>    2.5844    1.0000 </r>
+        <r>    2.8874    1.0000 </r>
+        <r>    7.4763    0.0000 </r>
+        <r>    7.8047    0.0000 </r>
+        <r>   10.4915    0.0000 </r>
+        <r>   10.6068    0.0000 </r>
+        <r>   12.8140    0.0000 </r>
+        <r>   13.5543    0.0000 </r>
+        <r>   15.5913    0.0000 </r>
+        <r>   17.8267    0.0000 </r>
+        <r>   18.1868    0.0000 </r>
+        <r>   18.5841    0.0000 </r>
+        <r>   18.6416    0.0000 </r>
+       </set>
+       <set comment="kpoint 55">
+        <r>   -7.4658    1.0000 </r>
+        <r>   -4.9039    1.0000 </r>
+        <r>    2.7073    1.0000 </r>
+        <r>    3.2868    1.0000 </r>
+        <r>    3.9680    1.0000 </r>
+        <r>    6.2244    0.0000 </r>
+        <r>    6.8263    0.0000 </r>
+        <r>    7.3406    0.0000 </r>
+        <r>   11.0396    0.0000 </r>
+        <r>   13.5732    0.0000 </r>
+        <r>   14.3873    0.0000 </r>
+        <r>   14.9341    0.0000 </r>
+        <r>   15.1855    0.0000 </r>
+        <r>   16.9531    0.0000 </r>
+        <r>   17.0268    0.0000 </r>
+        <r>   18.0265    0.0000 </r>
+       </set>
+       <set comment="kpoint 56">
+        <r>   -7.1083    1.0000 </r>
+        <r>   -5.1280    1.0000 </r>
+        <r>    1.5564    1.0000 </r>
+        <r>    2.2675    1.0000 </r>
+        <r>    4.7058    1.0000 </r>
+        <r>    5.4604    0.0000 </r>
+        <r>    8.1894    0.0000 </r>
+        <r>    8.9303    0.0000 </r>
+        <r>   11.1282    0.0000 </r>
+        <r>   12.6005    0.0000 </r>
+        <r>   14.1969    0.0000 </r>
+        <r>   15.1821    0.0000 </r>
+        <r>   16.4108    0.0000 </r>
+        <r>   16.6358    0.0000 </r>
+        <r>   18.4542    0.0000 </r>
+        <r>   18.6680    0.0000 </r>
+       </set>
+       <set comment="kpoint 57">
+        <r>   -6.6712    1.0000 </r>
+        <r>   -5.3374    1.0000 </r>
+        <r>    0.6886    1.0000 </r>
+        <r>    1.4945    1.0000 </r>
+        <r>    4.2805    1.0000 </r>
+        <r>    6.0534    0.0000 </r>
+        <r>    9.2394    0.0000 </r>
+        <r>   10.3866    0.0000 </r>
+        <r>   11.0107    0.0000 </r>
+        <r>   11.9274    0.0000 </r>
+        <r>   14.7167    0.0000 </r>
+        <r>   15.4093    0.0000 </r>
+        <r>   16.7130    0.0000 </r>
+        <r>   17.1337    0.0000 </r>
+        <r>   18.4646    0.0000 </r>
+        <r>   19.0735    0.0000 </r>
+       </set>
+       <set comment="kpoint 58">
+        <r>   -6.9466    1.0000 </r>
+        <r>   -5.2045    1.0000 </r>
+        <r>    1.0370    1.0000 </r>
+        <r>    2.7589    1.0000 </r>
+        <r>    3.0981    1.0000 </r>
+        <r>    7.3729    0.0000 </r>
+        <r>    7.5850    0.0000 </r>
+        <r>    9.7119    0.0000 </r>
+        <r>   10.6912    0.0000 </r>
+        <r>   13.1443    0.0000 </r>
+        <r>   13.7722    0.0000 </r>
+        <r>   15.7061    0.0000 </r>
+        <r>   16.7996    0.0000 </r>
+        <r>   17.4949    0.0000 </r>
+        <r>   17.6733    0.0000 </r>
+        <r>   17.7714    0.0000 </r>
+       </set>
+       <set comment="kpoint 59">
+        <r>   -7.4369    1.0000 </r>
+        <r>   -5.1280    1.0000 </r>
+        <r>    4.1259    1.0000 </r>
+        <r>    4.3091    1.0000 </r>
+        <r>    4.3094    1.0000 </r>
+        <r>    5.4295    0.0000 </r>
+        <r>    5.4299    0.0000 </r>
+        <r>    5.9189    0.0000 </r>
+        <r>   12.3256    0.0000 </r>
+        <r>   13.8016    0.0000 </r>
+        <r>   13.8020    0.0000 </r>
+        <r>   15.0300    0.0000 </r>
+        <r>   15.4817    0.0000 </r>
+        <r>   15.4821    0.0000 </r>
+        <r>   18.4380    0.0000 </r>
+        <r>   18.4391    0.0000 </r>
+       </set>
+       <set comment="kpoint 60">
+        <r>   -7.2399    1.0000 </r>
+        <r>   -5.2329    1.0000 </r>
+        <r>    2.4284    1.0000 </r>
+        <r>    3.7468    1.0000 </r>
+        <r>    4.1400    1.0000 </r>
+        <r>    5.9563    0.0000 </r>
+        <r>    6.0860    0.0000 </r>
+        <r>    7.6572    0.0000 </r>
+        <r>   12.1521    0.0000 </r>
+        <r>   13.1257    0.0000 </r>
+        <r>   13.5749    0.0000 </r>
+        <r>   15.4183    0.0000 </r>
+        <r>   16.0190    0.0000 </r>
+        <r>   16.2167    0.0000 </r>
+        <r>   17.7879    0.0000 </r>
+        <r>   18.9386    0.0000 </r>
+       </set>
+      </set>
+     </set>
+    </array>
+   </eigenvalues>
+   <array>
+    <dimension dim="1">ion</dimension>
+    <dimension dim="2">band</dimension>
+    <dimension dim="3">kpoint</dimension>
+    <dimension dim="4">spin</dimension>
+    <field>    s</field>
+    <field>   py</field>
+    <field>   pz</field>
+    <field>   px</field>
+    <field>  dxy</field>
+    <field>  dyz</field>
+    <field>  dz2</field>
+    <field>  dxz</field>
+    <field>x2-y2</field>
+    <set>
+     <set comment="spin1">
+      <set comment="kpoint 1">
+       <set comment="band 1">
+        <r>  0.3891  0.0003  0.0019  0.0006  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.3890  0.0003  0.0019  0.0006  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4656  0.0005  0.0034  0.0010  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.4656  0.0005  0.0034  0.0010  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0065  0.0343  0.2412  0.0715  0.0001  0.0003  0.0004  0.0005  0.0000 </r>
+        <r>  0.0065  0.0343  0.2411  0.0715  0.0001  0.0003  0.0004  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2692  0.0543  0.0452  0.0017  0.0007  0.0000  0.0015  0.0026 </r>
+        <r>  0.0000  0.2691  0.0543  0.0452  0.0015  0.0009  0.0000  0.0013  0.0028 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0632  0.0584  0.2484  0.0035  0.0018  0.0000  0.0002  0.0008 </r>
+        <r>  0.0000  0.0632  0.0584  0.2483  0.0036  0.0017  0.0000  0.0004  0.0006 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0068  0.0290  0.2025  0.0603  0.0029  0.0097  0.0138  0.0202  0.0004 </r>
+        <r>  0.0068  0.0290  0.2024  0.0603  0.0029  0.0097  0.0138  0.0202  0.0004 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.1280  0.0937  0.1002  0.0083  0.0001  0.0008  0.0007  0.0017 </r>
+        <r>  0.0000  0.1281  0.0936  0.1001  0.0081  0.0002  0.0008  0.0006  0.0019 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1619  0.0048  0.1552  0.0010  0.0068  0.0000  0.0027  0.0010 </r>
+        <r>  0.0000  0.1618  0.0049  0.1554  0.0012  0.0067  0.0000  0.0029  0.0008 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0228  0.0021  0.0145  0.0043  0.0068  0.0229  0.0327  0.0477  0.0010 </r>
+        <r>  0.0228  0.0021  0.0145  0.0043  0.0068  0.0229  0.0326  0.0478  0.0010 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0006  0.0011  0.0019  0.0346  0.0226  0.0963  0.0504  0.0018 </r>
+        <r>  0.0000  0.0006  0.0011  0.0019  0.0334  0.0235  0.0963  0.0495  0.0028 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0026  0.0000  0.0009  0.0197  0.0023  0.0018  0.0001  0.1817 </r>
+        <r>  0.0000  0.0026  0.0000  0.0009  0.0209  0.0013  0.0018  0.0012  0.1807 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0803  0.0019  0.0133  0.0040  0.0003  0.0009  0.0013  0.0019  0.0000 </r>
+        <r>  0.0802  0.0019  0.0133  0.0040  0.0003  0.0009  0.0013  0.0019  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0359  0.0021  0.0145  0.0043  0.0026  0.0087  0.0123  0.0181  0.0004 </r>
+        <r>  0.0359  0.0021  0.0145  0.0043  0.0026  0.0087  0.0123  0.0181  0.0004 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0013  0.0019  0.0029  0.2117  0.0002  0.0792  0.0007  0.0296 </r>
+        <r>  0.0000  0.0013  0.0019  0.0029  0.2117  0.0001  0.0791  0.0007  0.0295 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0042  0.0000  0.0019  0.0000  0.2170  0.0000  0.1038  0.0006 </r>
+        <r>  0.0000  0.0042  0.0000  0.0019  0.0000  0.2168  0.0000  0.1037  0.0006 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0020  0.0018  0.0078  0.0065  0.0094  0.0535  0.0313  0.0564 </r>
+        <r>  0.0000  0.0020  0.0018  0.0078  0.0133  0.0026  0.0536  0.0381  0.0498 </r>
+       </set>
+      </set>
+      <set comment="kpoint 2">
+       <set comment="band 1">
+        <r>  0.3887  0.0003  0.0018  0.0035  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.3886  0.0003  0.0018  0.0035  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4451  0.0006  0.0023  0.0124  0.0001  0.0002  0.0000  0.0000  0.0000 </r>
+        <r>  0.4451  0.0006  0.0023  0.0124  0.0001  0.0002  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0003  0.1088  0.1987  0.0380  0.0016  0.0025  0.0022  0.0007  0.0007 </r>
+        <r>  0.0003  0.1087  0.1987  0.0379  0.0016  0.0025  0.0022  0.0007  0.0007 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2482  0.0843  0.0348  0.0044  0.0011  0.0012  0.0015  0.0024 </r>
+        <r>  0.0000  0.2481  0.0843  0.0348  0.0044  0.0011  0.0012  0.0015  0.0024 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0264  0.0020  0.0658  0.2651  0.0023  0.0020  0.0000  0.0001  0.0016 </r>
+        <r>  0.0265  0.0020  0.0657  0.2650  0.0023  0.0020  0.0000  0.0001  0.0016 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0255  0.0034  0.0989  0.1751  0.0022  0.0101  0.0056  0.0053  0.0005 </r>
+        <r>  0.0255  0.0034  0.0989  0.1752  0.0022  0.0101  0.0056  0.0053  0.0005 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2024  0.0687  0.0285  0.0128  0.0059  0.0065  0.0013  0.0014 </r>
+        <r>  0.0000  0.2024  0.0688  0.0284  0.0128  0.0059  0.0065  0.0013  0.0015 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0078  0.0975  0.1365  0.0672  0.0044  0.0011  0.0042  0.0106  0.0008 </r>
+        <r>  0.0078  0.0975  0.1365  0.0672  0.0044  0.0011  0.0042  0.0106  0.0008 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0003  0.0082  0.0133  0.0073  0.0302  0.0178  0.0458  0.0066  0.0237 </r>
+        <r>  0.0003  0.0082  0.0133  0.0073  0.0301  0.0178  0.0458  0.0067  0.0237 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0012  0.0004  0.0002  0.0086  0.0201  0.0706  0.0364  0.0735 </r>
+        <r>  0.0000  0.0012  0.0004  0.0002  0.0085  0.0201  0.0705  0.0364  0.0734 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0110  0.0022  0.0044  0.0052  0.0047  0.0311  0.0044  0.0723  0.0532 </r>
+        <r>  0.0110  0.0022  0.0044  0.0052  0.0047  0.0311  0.0044  0.0723  0.0533 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0756  0.0052  0.0042  0.0384  0.0171  0.0378  0.0041  0.0288  0.0015 </r>
+        <r>  0.0755  0.0052  0.0042  0.0384  0.0171  0.0378  0.0040  0.0288  0.0015 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0081  0.0005  0.0012  0.0120  0.0263  0.0010  0.0206  0.0083  0.0375 </r>
+        <r>  0.0081  0.0005  0.0012  0.0121  0.0262  0.0010  0.0206  0.0083  0.0376 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0137  0.0006  0.0183  0.0232  0.0374  0.1068  0.0199  0.0570  0.0039 </r>
+        <r>  0.0137  0.0006  0.0183  0.0232  0.0373  0.1067  0.0200  0.0569  0.0039 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0215  0.0073  0.0030  0.1439  0.0562  0.0554  0.0191  0.0240 </r>
+        <r>  0.0000  0.0215  0.0073  0.0030  0.1439  0.0561  0.0553  0.0191  0.0240 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0106  0.0005  0.0078  0.0184  0.0009  0.0021  0.0003  0.1315  0.0914 </r>
+        <r>  0.0106  0.0005  0.0078  0.0184  0.0009  0.0021  0.0003  0.1314  0.0915 </r>
+       </set>
+      </set>
+      <set comment="kpoint 3">
+       <set comment="band 1">
+        <r>  0.3877  0.0009  0.0015  0.0099  0.0001  0.0001  0.0000  0.0000  0.0000 </r>
+        <r>  0.3876  0.0009  0.0015  0.0099  0.0001  0.0001  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4166  0.0023  0.0005  0.0240  0.0003  0.0005  0.0000  0.0001  0.0000 </r>
+        <r>  0.4165  0.0023  0.0005  0.0240  0.0003  0.0005  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0064  0.1007  0.1856  0.0365  0.0012  0.0055  0.0044  0.0002  0.0011 </r>
+        <r>  0.0064  0.1005  0.1856  0.0365  0.0012  0.0055  0.0044  0.0002  0.0011 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2429  0.0825  0.0341  0.0074  0.0029  0.0032  0.0014  0.0022 </r>
+        <r>  0.0000  0.2428  0.0825  0.0341  0.0074  0.0029  0.0032  0.0014  0.0021 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0452  0.0005  0.0779  0.2164  0.0049  0.0031  0.0003  0.0001  0.0035 </r>
+        <r>  0.0453  0.0005  0.0779  0.2163  0.0049  0.0031  0.0003  0.0001  0.0035 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0446  0.0035  0.0645  0.1825  0.0042  0.0072  0.0016  0.0014  0.0015 </r>
+        <r>  0.0446  0.0035  0.0645  0.1826  0.0042  0.0072  0.0016  0.0014  0.0015 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.1924  0.0653  0.0271  0.0140  0.0095  0.0128  0.0005  0.0003 </r>
+        <r>  0.0000  0.1924  0.0654  0.0270  0.0140  0.0095  0.0128  0.0005  0.0003 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0126  0.0887  0.1659  0.0274  0.0013  0.0130  0.0060  0.0073  0.0024 </r>
+        <r>  0.0127  0.0887  0.1658  0.0274  0.0013  0.0130  0.0060  0.0073  0.0024 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0025  0.0107  0.0037  0.0340  0.0308  0.0163  0.0405  0.0072  0.0217 </r>
+        <r>  0.0025  0.0107  0.0037  0.0340  0.0307  0.0163  0.0405  0.0072  0.0217 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0079  0.0027  0.0011  0.0114  0.0169  0.0636  0.0378  0.0755 </r>
+        <r>  0.0000  0.0079  0.0027  0.0011  0.0113  0.0169  0.0635  0.0378  0.0754 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0034  0.0014  0.0089  0.0087  0.0021  0.0334  0.0111  0.0876  0.0385 </r>
+        <r>  0.0034  0.0014  0.0089  0.0087  0.0021  0.0334  0.0111  0.0875  0.0386 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0412  0.0223  0.0087  0.0729  0.0183  0.0401  0.0042  0.0355  0.0024 </r>
+        <r>  0.0411  0.0223  0.0087  0.0729  0.0183  0.0401  0.0042  0.0355  0.0024 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0094  0.0003  0.0160  0.0527  0.0327  0.0279  0.0095  0.0175  0.0460 </r>
+        <r>  0.0094  0.0002  0.0160  0.0527  0.0326  0.0279  0.0095  0.0174  0.0461 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0002  0.0019  0.0202  0.0228  0.0330  0.0629  0.0306  0.0064  0.0131 </r>
+        <r>  0.0002  0.0019  0.0202  0.0229  0.0325  0.0628  0.0309  0.0066  0.0132 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0323  0.0111  0.0045  0.1318  0.0543  0.0551  0.0166  0.0206 </r>
+        <r>  0.0000  0.0324  0.0111  0.0045  0.1322  0.0544  0.0548  0.0165  0.0204 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0320  0.0008  0.0026  0.0034  0.0032  0.0036  0.0017  0.1669  0.0783 </r>
+        <r>  0.0320  0.0008  0.0026  0.0034  0.0032  0.0036  0.0017  0.1668  0.0784 </r>
+       </set>
+      </set>
+      <set comment="kpoint 4">
+       <set comment="band 1">
+        <r>  0.3891  0.0017  0.0011  0.0180  0.0002  0.0003  0.0000  0.0001  0.0001 </r>
+        <r>  0.3890  0.0017  0.0011  0.0180  0.0002  0.0003  0.0000  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3956  0.0038  0.0000  0.0265  0.0004  0.0005  0.0001  0.0002  0.0000 </r>
+        <r>  0.3956  0.0038  0.0000  0.0265  0.0004  0.0005  0.0001  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0150  0.0941  0.1785  0.0324  0.0006  0.0082  0.0053  0.0000  0.0013 </r>
+        <r>  0.0150  0.0940  0.1785  0.0324  0.0006  0.0082  0.0053  0.0000  0.0013 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2373  0.0807  0.0333  0.0096  0.0041  0.0043  0.0011  0.0014 </r>
+        <r>  0.0000  0.2373  0.0806  0.0334  0.0096  0.0041  0.0043  0.0011  0.0014 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0581  0.0029  0.0415  0.1741  0.0058  0.0078  0.0003  0.0003  0.0032 </r>
+        <r>  0.0584  0.0029  0.0413  0.1735  0.0058  0.0078  0.0003  0.0003  0.0032 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0462  0.0007  0.1015  0.1848  0.0074  0.0028  0.0011  0.0008  0.0042 </r>
+        <r>  0.0460  0.0007  0.1017  0.1856  0.0074  0.0028  0.0011  0.0008  0.0042 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.1894  0.0643  0.0266  0.0125  0.0116  0.0175  0.0001  0.0000 </r>
+        <r>  0.0000  0.1894  0.0644  0.0266  0.0125  0.0116  0.0175  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0156  0.0813  0.1617  0.0187  0.0009  0.0202  0.0092  0.0046  0.0033 </r>
+        <r>  0.0156  0.0813  0.1616  0.0187  0.0009  0.0202  0.0092  0.0046  0.0033 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0061  0.0166  0.0030  0.0689  0.0287  0.0102  0.0343  0.0072  0.0193 </r>
+        <r>  0.0061  0.0166  0.0030  0.0689  0.0286  0.0102  0.0343  0.0073  0.0193 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0168  0.0057  0.0024  0.0138  0.0136  0.0555  0.0382  0.0752 </r>
+        <r>  0.0000  0.0168  0.0057  0.0023  0.0136  0.0135  0.0555  0.0383  0.0752 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0009  0.0018  0.0168  0.0187  0.0029  0.0285  0.0126  0.0682  0.0239 </r>
+        <r>  0.0009  0.0018  0.0168  0.0188  0.0030  0.0286  0.0125  0.0681  0.0238 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0049  0.0027  0.0083  0.0568  0.0028  0.0099  0.0018  0.1037  0.0736 </r>
+        <r>  0.0049  0.0027  0.0083  0.0568  0.0028  0.0099  0.0018  0.1036  0.0737 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0041  0.0353  0.0251  0.0695  0.0021  0.0393  0.0337  0.0224  0.0006 </r>
+        <r>  0.0041  0.0353  0.0251  0.0695  0.0021  0.0392  0.0337  0.0224  0.0006 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0327  0.0111  0.0046  0.0092  0.0155  0.0576  0.0330  0.0664 </r>
+        <r>  0.0000  0.0327  0.0111  0.0046  0.0091  0.0155  0.0576  0.0331  0.0664 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0078  0.0017  0.0111  0.0106  0.1026  0.0581  0.0030  0.1555  0.0074 </r>
+        <r>  0.0077  0.0017  0.0110  0.0106  0.1025  0.0581  0.0030  0.1554  0.0074 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0185  0.0063  0.0026  0.1640  0.0377  0.0237  0.0388  0.0569 </r>
+        <r>  0.0000  0.0185  0.0063  0.0026  0.1637  0.0377  0.0239  0.0388  0.0573 </r>
+       </set>
+      </set>
+      <set comment="kpoint 5">
+       <set comment="band 1">
+        <r>  0.3936  0.0023  0.0004  0.0228  0.0005  0.0003  0.0000  0.0002  0.0001 </r>
+        <r>  0.3935  0.0023  0.0004  0.0228  0.0005  0.0003  0.0000  0.0002  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3863  0.0046  0.0005  0.0240  0.0001  0.0005  0.0001  0.0001  0.0000 </r>
+        <r>  0.3863  0.0046  0.0005  0.0239  0.0001  0.0005  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0200  0.0921  0.1794  0.0286  0.0004  0.0101  0.0048  0.0003  0.0009 </r>
+        <r>  0.0200  0.0918  0.1796  0.0286  0.0004  0.0101  0.0048  0.0003  0.0009 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2327  0.0792  0.0327  0.0083  0.0042  0.0049  0.0008  0.0009 </r>
+        <r>  0.0000  0.2329  0.0790  0.0327  0.0083  0.0042  0.0048  0.0007  0.0009 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0532  0.0028  0.0654  0.1800  0.0066  0.0044  0.0006  0.0005  0.0037 </r>
+        <r>  0.0532  0.0028  0.0654  0.1800  0.0066  0.0044  0.0006  0.0005  0.0037 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0506  0.0025  0.0720  0.1705  0.0076  0.0077  0.0027  0.0004  0.0049 </r>
+        <r>  0.0506  0.0025  0.0720  0.1706  0.0076  0.0077  0.0027  0.0004  0.0049 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0170  0.0775  0.1648  0.0183  0.0010  0.0188  0.0087  0.0042  0.0033 </r>
+        <r>  0.0170  0.0771  0.1652  0.0184  0.0010  0.0188  0.0087  0.0042  0.0033 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1898  0.0647  0.0268  0.0132  0.0126  0.0193  0.0001  0.0002 </r>
+        <r>  0.0000  0.1902  0.0644  0.0267  0.0132  0.0126  0.0193  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0037  0.0019  0.0060  0.0519  0.0071  0.0098  0.0001  0.0391  0.0457 </r>
+        <r>  0.0037  0.0019  0.0060  0.0519  0.0071  0.0099  0.0001  0.0391  0.0457 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0062  0.0208  0.0040  0.0955  0.0289  0.0103  0.0324  0.0096  0.0208 </r>
+        <r>  0.0062  0.0208  0.0040  0.0956  0.0288  0.0103  0.0324  0.0097  0.0209 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0046  0.0216  0.0158  0.0513  0.0220  0.0273  0.0462  0.0438  0.0025 </r>
+        <r>  0.0046  0.0216  0.0158  0.0513  0.0220  0.0272  0.0460  0.0439  0.0025 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0335  0.0113  0.0047  0.0057  0.0155  0.0566  0.0299  0.0606 </r>
+        <r>  0.0000  0.0335  0.0114  0.0047  0.0056  0.0154  0.0564  0.0296  0.0602 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0030  0.0027  0.0177  0.0086  0.0028  0.0176  0.0128  0.1521  0.0465 </r>
+        <r>  0.0031  0.0028  0.0176  0.0086  0.0027  0.0177  0.0126  0.1527  0.0461 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0149  0.0050  0.0021  0.0281  0.0076  0.0452  0.0496  0.0940 </r>
+        <r>  0.0000  0.0147  0.0050  0.0021  0.0280  0.0076  0.0457  0.0492  0.0947 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0251  0.0085  0.0035  0.1549  0.0386  0.0271  0.0350  0.0511 </r>
+        <r>  0.0000  0.0251  0.0085  0.0035  0.1551  0.0387  0.0273  0.0351  0.0513 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0288  0.0007  0.0273  0.0366  0.0173  0.0803  0.0223  0.0487  0.0191 </r>
+        <r>  0.0287  0.0007  0.0270  0.0369  0.0179  0.0811  0.0227  0.0497  0.0194 </r>
+       </set>
+      </set>
+      <set comment="kpoint 6">
+       <set comment="band 1">
+        <r>  0.3875  0.0025  0.0008  0.0145  0.0002  0.0002  0.0000  0.0001  0.0000 </r>
+        <r>  0.3874  0.0025  0.0008  0.0145  0.0002  0.0002  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4021  0.0044  0.0002  0.0264  0.0003  0.0006  0.0001  0.0001  0.0001 </r>
+        <r>  0.4021  0.0044  0.0002  0.0264  0.0003  0.0006  0.0001  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.2348  0.0797  0.0329  0.0054  0.0032  0.0043  0.0007  0.0010 </r>
+        <r>  0.0000  0.2345  0.0798  0.0330  0.0054  0.0032  0.0043  0.0007  0.0010 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0385  0.0007  0.0927  0.1884  0.0060  0.0034  0.0006  0.0003  0.0034 </r>
+        <r>  0.0386  0.0007  0.0930  0.1882  0.0059  0.0034  0.0006  0.0003  0.0034 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0228  0.0983  0.1845  0.0289  0.0008  0.0101  0.0040  0.0010  0.0001 </r>
+        <r>  0.0227  0.0985  0.1838  0.0290  0.0008  0.0101  0.0040  0.0010  0.0001 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0403  0.0617  0.0719  0.0917  0.0008  0.0135  0.0102  0.0012  0.0052 </r>
+        <r>  0.0403  0.0617  0.0719  0.0917  0.0008  0.0135  0.0102  0.0012  0.0052 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0264  0.0178  0.1393  0.1150  0.0066  0.0102  0.0002  0.0052  0.0028 </r>
+        <r>  0.0264  0.0178  0.1393  0.1150  0.0066  0.0102  0.0002  0.0052  0.0028 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1922  0.0653  0.0270  0.0145  0.0122  0.0179  0.0002  0.0002 </r>
+        <r>  0.0000  0.1923  0.0653  0.0270  0.0145  0.0122  0.0179  0.0002  0.0002 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0042  0.0023  0.0028  0.0351  0.0110  0.0106  0.0007  0.0345  0.0511 </r>
+        <r>  0.0042  0.0023  0.0028  0.0351  0.0110  0.0106  0.0007  0.0345  0.0511 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0055  0.0139  0.0088  0.0328  0.0232  0.0315  0.0503  0.0637  0.0001 </r>
+        <r>  0.0055  0.0139  0.0088  0.0327  0.0231  0.0315  0.0503  0.0638  0.0001 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0217  0.0074  0.0031  0.0163  0.0144  0.0571  0.0393  0.0773 </r>
+        <r>  0.0000  0.0217  0.0074  0.0031  0.0162  0.0144  0.0571  0.0393  0.0772 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0050  0.0221  0.0033  0.1563  0.0212  0.0044  0.0090  0.0139  0.0098 </r>
+        <r>  0.0050  0.0221  0.0033  0.1563  0.0212  0.0044  0.0090  0.0139  0.0099 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0442  0.0150  0.0062  0.0211  0.0402  0.0757  0.0032  0.0095 </r>
+        <r>  0.0000  0.0442  0.0150  0.0062  0.0211  0.0401  0.0757  0.0032  0.0094 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0029  0.0078  0.0350  0.0032  0.0006  0.0470  0.0315  0.0894  0.0239 </r>
+        <r>  0.0029  0.0078  0.0350  0.0032  0.0006  0.0470  0.0315  0.0893  0.0240 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0008  0.0003  0.0001  0.1725  0.0143  0.0028  0.0748  0.1231 </r>
+        <r>  0.0000  0.0008  0.0003  0.0001  0.1715  0.0143  0.0028  0.0749  0.1237 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0068  0.0043  0.0047  0.0170  0.0256  0.0227  0.0130  0.0939  0.0452 </r>
+        <r>  0.0068  0.0043  0.0047  0.0170  0.0259  0.0225  0.0132  0.0939  0.0453 </r>
+       </set>
+      </set>
+      <set comment="kpoint 7">
+       <set comment="band 1">
+        <r>  0.3876  0.0016  0.0014  0.0069  0.0001  0.0001  0.0000  0.0001  0.0000 </r>
+        <r>  0.3874  0.0016  0.0014  0.0069  0.0001  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4267  0.0040  0.0004  0.0196  0.0003  0.0005  0.0001  0.0001  0.0001 </r>
+        <r>  0.4267  0.0040  0.0004  0.0196  0.0003  0.0005  0.0001  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.2405  0.0818  0.0336  0.0031  0.0017  0.0027  0.0009  0.0015 </r>
+        <r>  0.0000  0.2404  0.0819  0.0337  0.0031  0.0017  0.0027  0.0009  0.0015 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0209  0.0014  0.1017  0.2154  0.0040  0.0013  0.0006  0.0005  0.0021 </r>
+        <r>  0.0209  0.0014  0.1018  0.2154  0.0040  0.0013  0.0006  0.0005  0.0021 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0182  0.1072  0.1952  0.0356  0.0016  0.0085  0.0038  0.0006  0.0003 </r>
+        <r>  0.0182  0.1071  0.1950  0.0356  0.0016  0.0085  0.0038  0.0006  0.0003 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0318  0.0764  0.0889  0.0754  0.0004  0.0098  0.0050  0.0048  0.0035 </r>
+        <r>  0.0318  0.0764  0.0889  0.0754  0.0004  0.0098  0.0049  0.0048  0.0035 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0220  0.0047  0.1111  0.1615  0.0044  0.0100  0.0026  0.0079  0.0027 </r>
+        <r>  0.0220  0.0047  0.1111  0.1616  0.0044  0.0100  0.0026  0.0079  0.0027 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2019  0.0686  0.0284  0.0122  0.0090  0.0125  0.0003  0.0001 </r>
+        <r>  0.0000  0.2019  0.0686  0.0284  0.0122  0.0090  0.0125  0.0003  0.0001 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0032  0.0021  0.0029  0.0179  0.0174  0.0088  0.0031  0.0253  0.0572 </r>
+        <r>  0.0032  0.0021  0.0029  0.0179  0.0174  0.0089  0.0031  0.0252  0.0572 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0051  0.0057  0.0024  0.0173  0.0234  0.0408  0.0543  0.0667  0.0001 </r>
+        <r>  0.0051  0.0057  0.0024  0.0173  0.0233  0.0408  0.0542  0.0668  0.0001 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0133  0.0045  0.0019  0.0147  0.0178  0.0641  0.0382  0.0759 </r>
+        <r>  0.0000  0.0133  0.0045  0.0019  0.0146  0.0178  0.0640  0.0382  0.0759 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0674  0.0096  0.0061  0.0965  0.0047  0.0142  0.0022  0.0163  0.0036 </r>
+        <r>  0.0674  0.0096  0.0061  0.0965  0.0047  0.0142  0.0022  0.0163  0.0036 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0236  0.0080  0.0033  0.1328  0.0546  0.0566  0.0170  0.0215 </r>
+        <r>  0.0000  0.0236  0.0080  0.0033  0.1324  0.0545  0.0567  0.0170  0.0216 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0012  0.0030  0.0030  0.0096  0.0316  0.0053  0.0150  0.0133  0.0471 </r>
+        <r>  0.0012  0.0030  0.0030  0.0096  0.0319  0.0052  0.0148  0.0133  0.0471 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0061  0.0189  0.0316  0.0091  0.0381  0.1165  0.0247  0.0520  0.0101 </r>
+        <r>  0.0061  0.0189  0.0317  0.0091  0.0381  0.1164  0.0247  0.0519  0.0101 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0119  0.0040  0.0017  0.0659  0.0010  0.0209  0.0608  0.1097 </r>
+        <r>  0.0000  0.0119  0.0040  0.0017  0.0658  0.0010  0.0209  0.0607  0.1098 </r>
+       </set>
+      </set>
+      <set comment="kpoint 8">
+       <set comment="band 1">
+        <r>  0.3887  0.0008  0.0017  0.0018  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.3885  0.0008  0.0017  0.0018  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4562  0.0024  0.0020  0.0059  0.0001  0.0002  0.0000  0.0001  0.0000 </r>
+        <r>  0.4562  0.0024  0.0020  0.0059  0.0001  0.0002  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0024  0.0009  0.1114  0.2366  0.0017  0.0006  0.0005  0.0004  0.0007 </r>
+        <r>  0.0024  0.0009  0.1114  0.2366  0.0016  0.0006  0.0005  0.0004  0.0007 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2464  0.0835  0.0348  0.0021  0.0005  0.0009  0.0012  0.0021 </r>
+        <r>  0.0000  0.2463  0.0835  0.0348  0.0021  0.0005  0.0009  0.0012  0.0021 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0121  0.1153  0.1713  0.0694  0.0018  0.0039  0.0013  0.0003  0.0007 </r>
+        <r>  0.0121  0.1152  0.1712  0.0694  0.0018  0.0039  0.0013  0.0003  0.0007 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0147  0.0853  0.1686  0.0273  0.0031  0.0062  0.0030  0.0131  0.0012 </r>
+        <r>  0.0147  0.0853  0.1686  0.0273  0.0031  0.0062  0.0030  0.0131  0.0012 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0111  0.0033  0.0474  0.2367  0.0004  0.0129  0.0080  0.0086  0.0018 </r>
+        <r>  0.0111  0.0033  0.0474  0.2367  0.0004  0.0129  0.0080  0.0086  0.0018 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2186  0.0743  0.0307  0.0049  0.0026  0.0033  0.0006  0.0009 </r>
+        <r>  0.0000  0.2187  0.0743  0.0307  0.0049  0.0026  0.0033  0.0006  0.0009 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0020  0.0006  0.0038  0.0063  0.0242  0.0076  0.0072  0.0215  0.0692 </r>
+        <r>  0.0020  0.0006  0.0038  0.0063  0.0242  0.0076  0.0073  0.0215  0.0694 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0008  0.0012  0.0096  0.0156  0.0260  0.0363  0.0565  0.0578  0.0011 </r>
+        <r>  0.0008  0.0012  0.0095  0.0155  0.0259  0.0362  0.0565  0.0579  0.0012 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0053  0.0018  0.0008  0.0096  0.0208  0.0714  0.0362  0.0732 </r>
+        <r>  0.0000  0.0053  0.0018  0.0007  0.0095  0.0209  0.0713  0.0362  0.0731 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.1093  0.0074  0.0045  0.0344  0.0035  0.0125  0.0024  0.0073  0.0008 </r>
+        <r>  0.1093  0.0074  0.0045  0.0344  0.0035  0.0125  0.0024  0.0073  0.0008 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0002  0.0001  0.0012  0.0022  0.0189  0.0026  0.0069  0.0142  0.0409 </r>
+        <r>  0.0002  0.0001  0.0011  0.0022  0.0188  0.0026  0.0070  0.0142  0.0410 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0052  0.0017  0.0007  0.1519  0.0594  0.0589  0.0200  0.0254 </r>
+        <r>  0.0000  0.0052  0.0018  0.0007  0.1520  0.0593  0.0588  0.0201  0.0254 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0070  0.0121  0.0227  0.0036  0.0465  0.1292  0.0198  0.0679  0.0056 </r>
+        <r>  0.0070  0.0121  0.0227  0.0036  0.0464  0.1291  0.0198  0.0678  0.0056 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0040  0.0014  0.0006  0.0492  0.0017  0.0085  0.0356  0.0623 </r>
+        <r>  0.0000  0.0040  0.0014  0.0006  0.0491  0.0017  0.0084  0.0355  0.0624 </r>
+       </set>
+      </set>
+      <set comment="kpoint 9">
+       <set comment="band 1">
+        <r>  0.3891  0.0015  0.0022  0.0030  0.0001  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.3889  0.0014  0.0022  0.0030  0.0001  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4421  0.0038  0.0035  0.0079  0.0005  0.0000  0.0002  0.0000  0.0001 </r>
+        <r>  0.4421  0.0038  0.0035  0.0079  0.0005  0.0000  0.0002  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0044  0.0061  0.3165  0.0124  0.0027  0.0014  0.0006  0.0029  0.0004 </r>
+        <r>  0.0044  0.0059  0.3164  0.0125  0.0027  0.0014  0.0006  0.0029  0.0004 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2388  0.0000  0.1150  0.0006  0.0019  0.0000  0.0009  0.0041 </r>
+        <r>  0.0000  0.2390  0.0000  0.1146  0.0006  0.0019  0.0000  0.0009  0.0041 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0241  0.1106  0.0087  0.2303  0.0098  0.0001  0.0008  0.0002  0.0014 </r>
+        <r>  0.0241  0.1105  0.0087  0.2302  0.0098  0.0001  0.0008  0.0002  0.0014 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0257  0.0799  0.0206  0.1664  0.0070  0.0005  0.0102  0.0010  0.0010 </r>
+        <r>  0.0256  0.0799  0.0206  0.1666  0.0070  0.0005  0.0102  0.0010  0.0010 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0012  0.0027  0.2797  0.0057  0.0151  0.0036  0.0154  0.0075  0.0021 </r>
+        <r>  0.0012  0.0027  0.2797  0.0057  0.0151  0.0036  0.0154  0.0075  0.0021 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2220  0.0000  0.1067  0.0005  0.0069  0.0000  0.0033  0.0033 </r>
+        <r>  0.0000  0.2221  0.0000  0.1067  0.0005  0.0069  0.0000  0.0033  0.0033 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0031  0.0002  0.0414  0.0005  0.0200  0.0018  0.0838  0.0037  0.0029 </r>
+        <r>  0.0031  0.0002  0.0414  0.0005  0.0200  0.0018  0.0838  0.0037  0.0027 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0131  0.0015  0.0118  0.0031  0.0025  0.0534  0.0011  0.1116  0.0003 </r>
+        <r>  0.0131  0.0015  0.0118  0.0031  0.0025  0.0536  0.0011  0.1114  0.0004 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0116  0.0000  0.0055  0.0251  0.0032  0.0000  0.0015  0.1786 </r>
+        <r>  0.0000  0.0116  0.0000  0.0056  0.0251  0.0032  0.0000  0.0015  0.1789 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0838  0.0046  0.0217  0.0095  0.0471  0.0036  0.0218  0.0075  0.0066 </r>
+        <r>  0.0837  0.0045  0.0218  0.0095  0.0469  0.0036  0.0218  0.0075  0.0066 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0030  0.0000  0.0014  0.0002  0.2110  0.0000  0.1013  0.0013 </r>
+        <r>  0.0000  0.0030  0.0000  0.0014  0.0002  0.2109  0.0000  0.1012  0.0013 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0003  0.0001  0.0017  0.0002  0.0161  0.0015  0.0508  0.0031  0.0023 </r>
+        <r>  0.0003  0.0001  0.0017  0.0002  0.0161  0.0015  0.0507  0.0031  0.0023 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0141  0.0212  0.0009  0.0440  0.1495  0.0021  0.0546  0.0043  0.0211 </r>
+        <r>  0.0142  0.0211  0.0009  0.0440  0.1495  0.0021  0.0546  0.0043  0.0210 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0215  0.0048  0.0147  0.0199  0.0031  0.0517  0.0013  0.1596  0.0154 </r>
+        <r>  0.0214  0.0066  0.0147  0.0180  0.0011  0.0560  0.0013  0.1553  0.0174 </r>
+       </set>
+      </set>
+      <set comment="kpoint 10">
+       <set comment="band 1">
+        <r>  0.3894  0.0003  0.0023  0.0085  0.0002  0.0001  0.0001  0.0000  0.0000 </r>
+        <r>  0.3892  0.0003  0.0023  0.0085  0.0002  0.0001  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4272  0.0000  0.0022  0.0176  0.0012  0.0002  0.0002  0.0000  0.0000 </r>
+        <r>  0.4272  0.0000  0.0022  0.0176  0.0011  0.0002  0.0002  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0010  0.0649  0.2111  0.0492  0.0028  0.0033  0.0022  0.0010  0.0004 </r>
+        <r>  0.0010  0.0648  0.2111  0.0492  0.0028  0.0033  0.0022  0.0010  0.0004 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0099  0.2031  0.0610  0.0658  0.0020  0.0025  0.0009  0.0012  0.0040 </r>
+        <r>  0.0099  0.2030  0.0610  0.0658  0.0020  0.0025  0.0009  0.0012  0.0040 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0251  0.0621  0.0636  0.1617  0.0102  0.0004  0.0048  0.0001  0.0003 </r>
+        <r>  0.0251  0.0621  0.0636  0.1617  0.0102  0.0004  0.0048  0.0001  0.0003 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0364  0.0908  0.0136  0.2057  0.0103  0.0008  0.0063  0.0006  0.0008 </r>
+        <r>  0.0364  0.0908  0.0136  0.2058  0.0102  0.0008  0.0063  0.0006  0.0008 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0068  0.1075  0.1625  0.0293  0.0105  0.0145  0.0049  0.0009  0.0029 </r>
+        <r>  0.0068  0.1075  0.1625  0.0293  0.0105  0.0145  0.0049  0.0009  0.0029 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0070  0.1297  0.1044  0.0531  0.0061  0.0013  0.0133  0.0049  0.0047 </r>
+        <r>  0.0070  0.1297  0.1044  0.0531  0.0061  0.0013  0.0133  0.0049  0.0047 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0001  0.0087  0.0385  0.0079  0.0219  0.0161  0.0796  0.0011  0.0004 </r>
+        <r>  0.0001  0.0087  0.0385  0.0079  0.0218  0.0161  0.0795  0.0011  0.0004 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0006  0.0023  0.0143  0.0061  0.0092  0.0439  0.0079  0.0785  0.0666 </r>
+        <r>  0.0006  0.0023  0.0143  0.0061  0.0092  0.0438  0.0079  0.0786  0.0666 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0124  0.0030  0.0062  0.0190  0.0060  0.0174  0.0065  0.0470  0.0795 </r>
+        <r>  0.0124  0.0030  0.0062  0.0190  0.0060  0.0175  0.0065  0.0469  0.0796 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0507  0.0058  0.0034  0.0388  0.0376  0.0333  0.0121  0.0266  0.0224 </r>
+        <r>  0.0506  0.0058  0.0034  0.0388  0.0375  0.0333  0.0121  0.0266  0.0224 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0087  0.0050  0.0263  0.0140  0.0096  0.1314  0.0061  0.0673  0.0105 </r>
+        <r>  0.0087  0.0050  0.0263  0.0140  0.0096  0.1313  0.0061  0.0672  0.0106 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0010  0.0034  0.0054  0.0296  0.0246  0.0417  0.0007  0.0180 </r>
+        <r>  0.0000  0.0010  0.0034  0.0054  0.0295  0.0246  0.0416  0.0007  0.0180 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0083  0.0066  0.0046  0.0362  0.0549  0.0008  0.0117  0.1173  0.0379 </r>
+        <r>  0.0083  0.0066  0.0045  0.0361  0.0549  0.0008  0.0118  0.1172  0.0380 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0226  0.0151  0.0012  0.0381  0.0987  0.0015  0.0393  0.0390  0.0503 </r>
+        <r>  0.0227  0.0151  0.0012  0.0381  0.0987  0.0015  0.0393  0.0390  0.0503 </r>
+       </set>
+      </set>
+      <set comment="kpoint 11">
+       <set comment="band 1">
+        <r>  0.3910  0.0001  0.0021  0.0152  0.0004  0.0002  0.0002  0.0000  0.0001 </r>
+        <r>  0.3908  0.0001  0.0021  0.0152  0.0004  0.0002  0.0002  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4079  0.0024  0.0005  0.0218  0.0014  0.0004  0.0001  0.0001  0.0000 </r>
+        <r>  0.4078  0.0024  0.0005  0.0218  0.0014  0.0004  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0066  0.0736  0.1836  0.0501  0.0023  0.0052  0.0040  0.0002  0.0006 </r>
+        <r>  0.0066  0.0734  0.1835  0.0502  0.0023  0.0052  0.0041  0.0002  0.0006 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0190  0.1685  0.0064  0.1194  0.0075  0.0007  0.0024  0.0004  0.0013 </r>
+        <r>  0.0190  0.1685  0.0064  0.1195  0.0075  0.0007  0.0024  0.0004  0.0013 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0246  0.0666  0.1501  0.0826  0.0026  0.0040  0.0058  0.0009  0.0020 </r>
+        <r>  0.0246  0.0666  0.1500  0.0826  0.0026  0.0040  0.0058  0.0009  0.0020 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0359  0.0949  0.0886  0.0911  0.0038  0.0132  0.0027  0.0008  0.0041 </r>
+        <r>  0.0359  0.0949  0.0886  0.0911  0.0038  0.0132  0.0027  0.0008  0.0041 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0173  0.1467  0.0272  0.1341  0.0211  0.0045  0.0087  0.0001  0.0010 </r>
+        <r>  0.0173  0.1467  0.0272  0.1342  0.0211  0.0045  0.0087  0.0001  0.0009 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0122  0.0830  0.1771  0.0272  0.0028  0.0173  0.0055  0.0039  0.0047 </r>
+        <r>  0.0122  0.0831  0.1771  0.0271  0.0028  0.0173  0.0055  0.0039  0.0047 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0020  0.0155  0.0030  0.0227  0.0309  0.0140  0.0882  0.0005  0.0018 </r>
+        <r>  0.0020  0.0155  0.0030  0.0227  0.0308  0.0140  0.0881  0.0005  0.0018 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0021  0.0038  0.0069  0.0308  0.0055  0.0152  0.0127  0.0342  0.1058 </r>
+        <r>  0.0021  0.0038  0.0070  0.0308  0.0055  0.0152  0.0127  0.0342  0.1059 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0010  0.0005  0.0179  0.0324  0.0032  0.0310  0.0024  0.0586  0.0136 </r>
+        <r>  0.0010  0.0005  0.0179  0.0324  0.0032  0.0310  0.0024  0.0586  0.0136 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0028  0.0039  0.0084  0.0549  0.0015  0.0078  0.0036  0.1091  0.0870 </r>
+        <r>  0.0028  0.0039  0.0084  0.0549  0.0015  0.0078  0.0036  0.1090  0.0870 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0229  0.0127  0.0319  0.0288  0.0201  0.0858  0.0056  0.0076  0.0009 </r>
+        <r>  0.0228  0.0127  0.0319  0.0288  0.0201  0.0857  0.0056  0.0075  0.0009 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0127  0.0135  0.0164  0.0145  0.0228  0.0748  0.0130  0.1826  0.0021 </r>
+        <r>  0.0127  0.0136  0.0164  0.0145  0.0226  0.0747  0.0131  0.1825  0.0021 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0299  0.0166  0.0075  0.0070  0.0586  0.0044  0.0068  0.0833  0.0550 </r>
+        <r>  0.0299  0.0166  0.0075  0.0070  0.0586  0.0044  0.0068  0.0833  0.0551 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0020  0.0011  0.0011  0.0122  0.0308  0.0187  0.0348  0.0211  0.0404 </r>
+        <r>  0.0020  0.0011  0.0011  0.0122  0.0307  0.0187  0.0348  0.0210  0.0406 </r>
+       </set>
+      </set>
+      <set comment="kpoint 12">
+       <set comment="band 1">
+        <r>  0.3973  0.0017  0.0013  0.0202  0.0007  0.0003  0.0002  0.0001  0.0002 </r>
+        <r>  0.3972  0.0017  0.0013  0.0202  0.0007  0.0003  0.0002  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3924  0.0056  0.0003  0.0191  0.0009  0.0004  0.0002  0.0001  0.0000 </r>
+        <r>  0.3924  0.0056  0.0003  0.0191  0.0009  0.0004  0.0002  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0122  0.1103  0.0380  0.1465  0.0080  0.0023  0.0019  0.0003  0.0008 </r>
+        <r>  0.0122  0.1101  0.0380  0.1467  0.0080  0.0023  0.0019  0.0003  0.0008 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0207  0.1093  0.1302  0.0491  0.0005  0.0042  0.0052  0.0002  0.0009 </r>
+        <r>  0.0207  0.1094  0.1302  0.0490  0.0005  0.0042  0.0052  0.0002  0.0009 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0251  0.0705  0.1787  0.0533  0.0007  0.0064  0.0068  0.0021  0.0027 </r>
+        <r>  0.0251  0.0704  0.1786  0.0532  0.0007  0.0064  0.0068  0.0021  0.0027 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0336  0.1058  0.1120  0.0443  0.0006  0.0188  0.0040  0.0005  0.0026 </r>
+        <r>  0.0336  0.1058  0.1121  0.0444  0.0006  0.0188  0.0040  0.0005  0.0026 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0221  0.0854  0.1382  0.0445  0.0011  0.0204  0.0109  0.0030  0.0043 </r>
+        <r>  0.0221  0.0853  0.1382  0.0446  0.0011  0.0204  0.0109  0.0030  0.0043 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0134  0.1275  0.0347  0.1440  0.0267  0.0026  0.0081  0.0012  0.0020 </r>
+        <r>  0.0134  0.1276  0.0347  0.1440  0.0267  0.0026  0.0081  0.0012  0.0020 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0029  0.0296  0.0005  0.0367  0.0379  0.0070  0.0830  0.0012  0.0046 </r>
+        <r>  0.0029  0.0296  0.0005  0.0367  0.0378  0.0070  0.0830  0.0012  0.0046 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0041  0.0007  0.0040  0.0457  0.0052  0.0131  0.0011  0.0394  0.0555 </r>
+        <r>  0.0041  0.0007  0.0040  0.0457  0.0052  0.0131  0.0011  0.0394  0.0556 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0016  0.0019  0.0170  0.0496  0.0088  0.0287  0.0041  0.0692  0.0338 </r>
+        <r>  0.0016  0.0019  0.0170  0.0496  0.0088  0.0287  0.0041  0.0692  0.0337 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0015  0.0059  0.0073  0.0568  0.0031  0.0156  0.0136  0.0286  0.0892 </r>
+        <r>  0.0015  0.0059  0.0073  0.0568  0.0031  0.0155  0.0136  0.0286  0.0892 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0025  0.0007  0.0249  0.0081  0.0019  0.0267  0.0043  0.1616  0.0249 </r>
+        <r>  0.0025  0.0007  0.0249  0.0081  0.0019  0.0267  0.0043  0.1615  0.0249 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0021  0.0667  0.0031  0.0223  0.0120  0.0042  0.0872  0.0177  0.0435 </r>
+        <r>  0.0021  0.0666  0.0031  0.0223  0.0119  0.0042  0.0873  0.0177  0.0434 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0244  0.0032  0.0138  0.0197  0.1000  0.0516  0.0443  0.0384  0.0607 </r>
+        <r>  0.0248  0.0033  0.0138  0.0196  0.0989  0.0518  0.0446  0.0385  0.0608 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0182  0.0104  0.0145  0.0057  0.0771  0.0684  0.0169  0.1269  0.0504 </r>
+        <r>  0.0179  0.0104  0.0144  0.0057  0.0780  0.0681  0.0167  0.1268  0.0506 </r>
+       </set>
+      </set>
+      <set comment="kpoint 13">
+       <set comment="band 1">
+        <r>  0.3904  0.0066  0.0002  0.0135  0.0007  0.0003  0.0000  0.0002  0.0001 </r>
+        <r>  0.3903  0.0065  0.0002  0.0136  0.0007  0.0003  0.0000  0.0002  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4025  0.0062  0.0009  0.0194  0.0005  0.0006  0.0005  0.0001  0.0002 </r>
+        <r>  0.4024  0.0062  0.0009  0.0193  0.0005  0.0006  0.0005  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0086  0.1246  0.0008  0.1790  0.0055  0.0001  0.0007  0.0001  0.0022 </r>
+        <r>  0.0086  0.1245  0.0008  0.1791  0.0055  0.0001  0.0007  0.0001  0.0022 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0232  0.0887  0.1609  0.0355  0.0004  0.0073  0.0054  0.0017  0.0006 </r>
+        <r>  0.0232  0.0886  0.1610  0.0354  0.0004  0.0073  0.0054  0.0017  0.0006 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0255  0.0812  0.1912  0.0507  0.0004  0.0049  0.0052  0.0034  0.0026 </r>
+        <r>  0.0255  0.0812  0.1910  0.0507  0.0004  0.0049  0.0052  0.0034  0.0026 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0287  0.0840  0.1290  0.0360  0.0002  0.0213  0.0067  0.0007  0.0006 </r>
+        <r>  0.0287  0.0841  0.1291  0.0361  0.0002  0.0213  0.0067  0.0007  0.0006 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0265  0.0856  0.1472  0.0390  0.0003  0.0174  0.0105  0.0038  0.0029 </r>
+        <r>  0.0265  0.0856  0.1472  0.0390  0.0003  0.0174  0.0105  0.0038  0.0029 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0086  0.1284  0.0083  0.1659  0.0224  0.0006  0.0105  0.0038  0.0042 </r>
+        <r>  0.0086  0.1284  0.0083  0.1659  0.0224  0.0006  0.0105  0.0038  0.0042 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0037  0.0072  0.0003  0.0368  0.0075  0.0101  0.0002  0.0306  0.0613 </r>
+        <r>  0.0037  0.0072  0.0003  0.0368  0.0075  0.0101  0.0002  0.0306  0.0614 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0042  0.0004  0.0080  0.0278  0.0109  0.0373  0.0070  0.0957  0.0246 </r>
+        <r>  0.0042  0.0004  0.0080  0.0278  0.0110  0.0372  0.0070  0.0957  0.0246 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0006  0.0388  0.0014  0.0538  0.0582  0.0049  0.0624  0.0004  0.0089 </r>
+        <r>  0.0006  0.0388  0.0014  0.0538  0.0580  0.0049  0.0623  0.0004  0.0089 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0119  0.0257  0.0030  0.0562  0.0480  0.0098  0.0666  0.0055  0.0099 </r>
+        <r>  0.0119  0.0257  0.0030  0.0562  0.0479  0.0098  0.0666  0.0055  0.0099 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0082  0.0353  0.0032  0.0214  0.0391  0.0052  0.1126  0.0099  0.0240 </r>
+        <r>  0.0082  0.0352  0.0032  0.0214  0.0390  0.0052  0.1127  0.0099  0.0238 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0010  0.0003  0.0299  0.0008  0.0087  0.0233  0.0040  0.1780  0.0071 </r>
+        <r>  0.0010  0.0003  0.0298  0.0008  0.0086  0.0232  0.0040  0.1780  0.0071 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0179  0.0036  0.0004  0.0242  0.0596  0.0024  0.0123  0.0026  0.2366 </r>
+        <r>  0.0181  0.0036  0.0004  0.0242  0.0595  0.0024  0.0123  0.0025  0.2371 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0018  0.0020  0.0097  0.0122  0.0126  0.0486  0.0032  0.0359  0.0470 </r>
+        <r>  0.0018  0.0020  0.0097  0.0123  0.0129  0.0486  0.0032  0.0360  0.0473 </r>
+       </set>
+      </set>
+      <set comment="kpoint 14">
+       <set comment="band 1">
+        <r>  0.3880  0.0066  0.0007  0.0066  0.0003  0.0002  0.0000  0.0001  0.0000 </r>
+        <r>  0.3879  0.0066  0.0007  0.0066  0.0003  0.0002  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4190  0.0116  0.0002  0.0129  0.0004  0.0006  0.0005  0.0002  0.0002 </r>
+        <r>  0.4190  0.0116  0.0002  0.0128  0.0004  0.0006  0.0005  0.0002  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0019  0.1140  0.0005  0.2083  0.0031  0.0000  0.0001  0.0001  0.0036 </r>
+        <r>  0.0019  0.1140  0.0005  0.2084  0.0031  0.0000  0.0001  0.0001  0.0036 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0272  0.1165  0.1517  0.0315  0.0006  0.0071  0.0045  0.0054  0.0004 </r>
+        <r>  0.0273  0.1156  0.1531  0.0312  0.0006  0.0071  0.0045  0.0054  0.0004 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0163  0.0732  0.2094  0.0478  0.0010  0.0042  0.0043  0.0009  0.0017 </r>
+        <r>  0.0162  0.0739  0.2079  0.0481  0.0010  0.0042  0.0043  0.0009  0.0016 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0316  0.0701  0.1358  0.0609  0.0000  0.0151  0.0085  0.0021  0.0014 </r>
+        <r>  0.0317  0.0701  0.1359  0.0609  0.0000  0.0150  0.0085  0.0021  0.0014 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0219  0.0884  0.1457  0.0332  0.0007  0.0141  0.0066  0.0070  0.0005 </r>
+        <r>  0.0219  0.0885  0.1457  0.0333  0.0007  0.0141  0.0066  0.0070  0.0005 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0017  0.1166  0.0011  0.1833  0.0086  0.0045  0.0085  0.0119  0.0060 </r>
+        <r>  0.0017  0.1166  0.0011  0.1834  0.0086  0.0045  0.0085  0.0119  0.0060 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0015  0.0156  0.0008  0.0334  0.0092  0.0055  0.0011  0.0156  0.0723 </r>
+        <r>  0.0015  0.0156  0.0008  0.0334  0.0092  0.0055  0.0011  0.0156  0.0724 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0031  0.0032  0.0012  0.0180  0.0126  0.0491  0.0051  0.1006  0.0142 </r>
+        <r>  0.0031  0.0032  0.0012  0.0180  0.0126  0.0491  0.0051  0.1006  0.0143 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0395  0.0052  0.0025  0.0386  0.1075  0.0024  0.0321  0.0041  0.0193 </r>
+        <r>  0.0397  0.0054  0.0025  0.0388  0.1066  0.0025  0.0329  0.0040  0.0190 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0034  0.0383  0.0043  0.0125  0.0467  0.0128  0.1223  0.0082  0.0189 </r>
+        <r>  0.0032  0.0381  0.0043  0.0123  0.0474  0.0127  0.1213  0.0083  0.0190 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0008  0.0711  0.0039  0.0348  0.0019  0.0130  0.0896  0.0024  0.0002 </r>
+        <r>  0.0008  0.0711  0.0039  0.0347  0.0019  0.0130  0.0896  0.0024  0.0002 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0009  0.0005  0.0012  0.0063  0.0202  0.0015  0.0111  0.0045  0.0778 </r>
+        <r>  0.0009  0.0005  0.0012  0.0063  0.0202  0.0015  0.0111  0.0045  0.0781 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0185  0.0003  0.0234  0.0004  0.0873  0.1139  0.0253  0.0533  0.0197 </r>
+        <r>  0.0183  0.0003  0.0234  0.0004  0.0872  0.1137  0.0253  0.0533  0.0197 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0220  0.0144  0.0213  0.0136  0.1389  0.0632  0.0019  0.0345  0.0330 </r>
+        <r>  0.0218  0.0144  0.0213  0.0136  0.1389  0.0632  0.0019  0.0345  0.0329 </r>
+       </set>
+      </set>
+      <set comment="kpoint 15">
+       <set comment="band 1">
+        <r>  0.3883  0.0052  0.0013  0.0018  0.0000  0.0001  0.0000  0.0001  0.0000 </r>
+        <r>  0.3881  0.0052  0.0013  0.0018  0.0000  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4355  0.0157  0.0005  0.0035  0.0001  0.0004  0.0002  0.0002  0.0001 </r>
+        <r>  0.4355  0.0157  0.0005  0.0035  0.0001  0.0004  0.0002  0.0002  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0008  0.0797  0.0035  0.2580  0.0023  0.0004  0.0003  0.0002  0.0035 </r>
+        <r>  0.0008  0.0797  0.0035  0.2581  0.0023  0.0004  0.0003  0.0002  0.0035 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0101  0.1255  0.1871  0.0271  0.0003  0.0011  0.0035  0.0031  0.0022 </r>
+        <r>  0.0101  0.1254  0.1871  0.0271  0.0003  0.0011  0.0035  0.0031  0.0022 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0206  0.1081  0.2018  0.0357  0.0022  0.0060  0.0031  0.0013  0.0006 </r>
+        <r>  0.0206  0.1080  0.2016  0.0357  0.0022  0.0060  0.0031  0.0013  0.0006 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0294  0.0983  0.0951  0.0612  0.0011  0.0048  0.0040  0.0109  0.0004 </r>
+        <r>  0.0294  0.0983  0.0952  0.0612  0.0011  0.0048  0.0040  0.0109  0.0004 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0143  0.0659  0.1590  0.0549  0.0013  0.0159  0.0046  0.0062  0.0004 </r>
+        <r>  0.0143  0.0659  0.1590  0.0549  0.0013  0.0159  0.0046  0.0062  0.0004 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0029  0.1024  0.0055  0.1995  0.0018  0.0058  0.0078  0.0087  0.0049 </r>
+        <r>  0.0029  0.1024  0.0055  0.1996  0.0018  0.0058  0.0078  0.0087  0.0049 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0002  0.0118  0.0019  0.0107  0.0117  0.0044  0.0043  0.0166  0.0856 </r>
+        <r>  0.0002  0.0118  0.0019  0.0107  0.0117  0.0044  0.0043  0.0166  0.0857 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0016  0.0008  0.0009  0.0196  0.0073  0.0540  0.0048  0.0944  0.0129 </r>
+        <r>  0.0016  0.0008  0.0009  0.0196  0.0073  0.0539  0.0048  0.0944  0.0129 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0011  0.0175  0.0019  0.0090  0.0524  0.0140  0.1261  0.0151  0.0038 </r>
+        <r>  0.0011  0.0175  0.0019  0.0090  0.0521  0.0140  0.1260  0.0150  0.0037 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0652  0.0396  0.0027  0.0012  0.0794  0.0027  0.0303  0.0034  0.0100 </r>
+        <r>  0.0653  0.0396  0.0027  0.0012  0.0794  0.0027  0.0303  0.0034  0.0100 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0093  0.0185  0.0033  0.0100  0.0513  0.0314  0.0087  0.0035  0.0451 </r>
+        <r>  0.0093  0.0185  0.0033  0.0100  0.0513  0.0313  0.0087  0.0035  0.0451 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0074  0.0149  0.0060  0.0103  0.0456  0.0264  0.0344  0.0180  0.0550 </r>
+        <r>  0.0073  0.0149  0.0060  0.0103  0.0456  0.0263  0.0344  0.0179  0.0550 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0091  0.0213  0.0341  0.0086  0.0255  0.1279  0.0166  0.0695  0.0024 </r>
+        <r>  0.0091  0.0214  0.0341  0.0086  0.0255  0.1278  0.0166  0.0695  0.0024 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0070  0.0050  0.0014  0.0101  0.1750  0.0167  0.0604  0.0021  0.0049 </r>
+        <r>  0.0069  0.0050  0.0014  0.0101  0.1747  0.0167  0.0604  0.0021  0.0049 </r>
+       </set>
+      </set>
+      <set comment="kpoint 16">
+       <set comment="band 1">
+        <r>  0.3919  0.0029  0.0029  0.0060  0.0007  0.0000  0.0002  0.0000  0.0001 </r>
+        <r>  0.3917  0.0029  0.0029  0.0060  0.0006  0.0000  0.0002  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4322  0.0035  0.0030  0.0072  0.0020  0.0000  0.0006  0.0000  0.0003 </r>
+        <r>  0.4323  0.0035  0.0030  0.0072  0.0020  0.0000  0.0006  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0074  0.0387  0.1880  0.0806  0.0050  0.0010  0.0013  0.0022  0.0007 </r>
+        <r>  0.0074  0.0387  0.1880  0.0806  0.0049  0.0010  0.0013  0.0022  0.0007 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2304  0.0000  0.1106  0.0004  0.0014  0.0000  0.0007  0.0031 </r>
+        <r>  0.0000  0.2302  0.0000  0.1106  0.0004  0.0014  0.0000  0.0007  0.0031 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0202  0.0487  0.1363  0.1015  0.0045  0.0002  0.0034  0.0005  0.0006 </r>
+        <r>  0.0202  0.0487  0.1363  0.1015  0.0045  0.0002  0.0034  0.0005  0.0006 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0318  0.0746  0.0720  0.1553  0.0018  0.0004  0.0273  0.0009  0.0003 </r>
+        <r>  0.0318  0.0746  0.0719  0.1553  0.0018  0.0004  0.0273  0.0009  0.0002 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0052  0.0331  0.1163  0.0690  0.0387  0.0005  0.0265  0.0010  0.0054 </r>
+        <r>  0.0052  0.0331  0.1163  0.0690  0.0386  0.0005  0.0265  0.0010  0.0054 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2315  0.0000  0.1112  0.0007  0.0073  0.0000  0.0035  0.0053 </r>
+        <r>  0.0000  0.2315  0.0000  0.1112  0.0007  0.0073  0.0000  0.0035  0.0053 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0026  0.0021  0.1547  0.0044  0.0079  0.0039  0.0500  0.0082  0.0011 </r>
+        <r>  0.0026  0.0021  0.1547  0.0044  0.0079  0.0039  0.0500  0.0082  0.0011 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0808  0.0084  0.0081  0.0175  0.0409  0.0019  0.0179  0.0038  0.0058 </r>
+        <r>  0.0807  0.0084  0.0081  0.0175  0.0408  0.0018  0.0179  0.0038  0.0057 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0019  0.0004  0.0348  0.0009  0.0153  0.0572  0.0058  0.1190  0.0021 </r>
+        <r>  0.0019  0.0004  0.0348  0.0009  0.0152  0.0571  0.0058  0.1191  0.0021 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0156  0.0000  0.0075  0.0172  0.0793  0.0000  0.0381  0.1224 </r>
+        <r>  0.0000  0.0156  0.0000  0.0075  0.0172  0.0793  0.0000  0.0381  0.1225 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0056  0.0000  0.0027  0.0082  0.1266  0.0000  0.0608  0.0582 </r>
+        <r>  0.0000  0.0056  0.0000  0.0027  0.0082  0.1264  0.0000  0.0607  0.0583 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0001  0.0003  0.0006  0.0005  0.0146  0.0026  0.0518  0.0053  0.0021 </r>
+        <r>  0.0001  0.0003  0.0006  0.0005  0.0145  0.0026  0.0517  0.0053  0.0020 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0276  0.0145  0.0107  0.0301  0.0084  0.0545  0.0048  0.1135  0.0012 </r>
+        <r>  0.0276  0.0145  0.0106  0.0301  0.0083  0.0545  0.0048  0.1135  0.0012 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0086  0.0000  0.0041  0.0182  0.0563  0.0000  0.0270  0.1297 </r>
+        <r>  0.0000  0.0087  0.0000  0.0042  0.0183  0.0562  0.0000  0.0270  0.1300 </r>
+       </set>
+      </set>
+      <set comment="kpoint 17">
+       <set comment="band 1">
+        <r>  0.3968  0.0004  0.0032  0.0100  0.0011  0.0001  0.0004  0.0000  0.0002 </r>
+        <r>  0.3966  0.0004  0.0032  0.0100  0.0011  0.0001  0.0004  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4242  0.0008  0.0018  0.0120  0.0026  0.0001  0.0006  0.0000  0.0002 </r>
+        <r>  0.4242  0.0008  0.0018  0.0120  0.0026  0.0001  0.0006  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0111  0.0765  0.0741  0.1386  0.0055  0.0012  0.0018  0.0004  0.0001 </r>
+        <r>  0.0111  0.0764  0.0741  0.1387  0.0055  0.0012  0.0018  0.0004  0.0001 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0045  0.1459  0.0922  0.0767  0.0005  0.0012  0.0019  0.0002  0.0011 </r>
+        <r>  0.0045  0.1459  0.0922  0.0766  0.0005  0.0012  0.0019  0.0002  0.0011 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0151  0.0944  0.1580  0.0599  0.0009  0.0023  0.0026  0.0010  0.0014 </r>
+        <r>  0.0151  0.0943  0.1580  0.0599  0.0009  0.0023  0.0026  0.0009  0.0013 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0141  0.0440  0.1800  0.0325  0.0057  0.0090  0.0293  0.0007  0.0027 </r>
+        <r>  0.0141  0.0440  0.1800  0.0325  0.0057  0.0090  0.0293  0.0007  0.0027 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0127  0.1458  0.0114  0.0564  0.0266  0.0035  0.0221  0.0008  0.0079 </r>
+        <r>  0.0127  0.1456  0.0114  0.0566  0.0266  0.0035  0.0221  0.0008  0.0079 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0198  0.1452  0.0009  0.1953  0.0199  0.0013  0.0077  0.0008  0.0008 </r>
+        <r>  0.0198  0.1454  0.0009  0.1951  0.0199  0.0013  0.0077  0.0008  0.0008 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0006  0.0220  0.1429  0.0291  0.0039  0.0197  0.0478  0.0025  0.0004 </r>
+        <r>  0.0006  0.0219  0.1429  0.0291  0.0038  0.0197  0.0477  0.0025  0.0004 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0376  0.0081  0.0045  0.0540  0.0274  0.0287  0.0114  0.0305  0.0264 </r>
+        <r>  0.0375  0.0081  0.0045  0.0540  0.0274  0.0286  0.0114  0.0306  0.0263 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0012  0.0006  0.0181  0.0298  0.0051  0.0695  0.0005  0.0271  0.0462 </r>
+        <r>  0.0012  0.0007  0.0182  0.0298  0.0051  0.0694  0.0005  0.0272  0.0463 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0013  0.0024  0.0232  0.0108  0.0082  0.0378  0.0052  0.0907  0.0756 </r>
+        <r>  0.0013  0.0024  0.0232  0.0108  0.0082  0.0379  0.0052  0.0904  0.0758 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0066  0.0020  0.0093  0.0140  0.0061  0.0636  0.0031  0.0172  0.0519 </r>
+        <r>  0.0066  0.0019  0.0093  0.0140  0.0061  0.0636  0.0031  0.0172  0.0518 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0346  0.0101  0.0070  0.0013  0.0368  0.0468  0.0099  0.1802  0.0188 </r>
+        <r>  0.0345  0.0101  0.0070  0.0013  0.0367  0.0466  0.0099  0.1802  0.0188 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0246  0.0044  0.0036  0.0175  0.0384  0.0075  0.0008  0.1081  0.0454 </r>
+        <r>  0.0246  0.0044  0.0036  0.0176  0.0383  0.0075  0.0008  0.1081  0.0455 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0041  0.0025  0.0012  0.0057  0.0233  0.0426  0.0333  0.0020  0.0261 </r>
+        <r>  0.0041  0.0025  0.0012  0.0057  0.0234  0.0427  0.0333  0.0020  0.0265 </r>
+       </set>
+      </set>
+      <set comment="kpoint 18">
+       <set comment="band 1">
+        <r>  0.4031  0.0010  0.0031  0.0120  0.0015  0.0002  0.0006  0.0001  0.0003 </r>
+        <r>  0.4029  0.0010  0.0031  0.0119  0.0015  0.0002  0.0006  0.0001  0.0003 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4087  0.0058  0.0005  0.0126  0.0023  0.0003  0.0004  0.0001  0.0002 </r>
+        <r>  0.4088  0.0058  0.0005  0.0126  0.0023  0.0003  0.0004  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0081  0.1044  0.0097  0.1730  0.0037  0.0004  0.0009  0.0002  0.0005 </r>
+        <r>  0.0081  0.1044  0.0097  0.1731  0.0037  0.0004  0.0009  0.0002  0.0005 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0095  0.0983  0.1560  0.0464  0.0000  0.0028  0.0043  0.0002  0.0004 </r>
+        <r>  0.0095  0.0983  0.1560  0.0464  0.0000  0.0028  0.0043  0.0002  0.0004 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0206  0.0924  0.1636  0.0474  0.0004  0.0040  0.0053  0.0017  0.0013 </r>
+        <r>  0.0206  0.0924  0.1635  0.0474  0.0004  0.0040  0.0053  0.0017  0.0013 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0270  0.1118  0.1426  0.0398  0.0010  0.0173  0.0042  0.0021  0.0020 </r>
+        <r>  0.0270  0.1118  0.1426  0.0398  0.0010  0.0173  0.0042  0.0021  0.0020 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0162  0.0953  0.1505  0.0448  0.0028  0.0122  0.0119  0.0030  0.0056 </r>
+        <r>  0.0161  0.0953  0.1505  0.0449  0.0028  0.0122  0.0119  0.0030  0.0056 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0079  0.1438  0.0014  0.1249  0.0497  0.0036  0.0094  0.0004  0.0010 </r>
+        <r>  0.0079  0.1438  0.0014  0.1249  0.0496  0.0036  0.0094  0.0004  0.0010 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0049  0.0051  0.0235  0.0947  0.0077  0.0125  0.0814  0.0035  0.0055 </r>
+        <r>  0.0049  0.0050  0.0235  0.0947  0.0077  0.0125  0.0814  0.0035  0.0055 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0022  0.0079  0.0007  0.0474  0.0048  0.0114  0.0000  0.0360  0.0633 </r>
+        <r>  0.0022  0.0079  0.0007  0.0474  0.0048  0.0114  0.0000  0.0359  0.0633 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0034  0.0017  0.0133  0.0389  0.0065  0.0496  0.0037  0.0469  0.0284 </r>
+        <r>  0.0035  0.0017  0.0133  0.0389  0.0065  0.0495  0.0037  0.0469  0.0283 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0056  0.0063  0.0071  0.0547  0.0267  0.0173  0.0184  0.0287  0.0512 </r>
+        <r>  0.0056  0.0063  0.0071  0.0547  0.0266  0.0172  0.0183  0.0288  0.0513 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0001  0.0014  0.0268  0.0088  0.0113  0.0208  0.0070  0.1413  0.0189 </r>
+        <r>  0.0001  0.0014  0.0268  0.0088  0.0112  0.0209  0.0070  0.1412  0.0189 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0382  0.0189  0.0091  0.0073  0.0261  0.0859  0.0054  0.1291  0.0165 </r>
+        <r>  0.0382  0.0189  0.0091  0.0073  0.0260  0.0859  0.0054  0.1290  0.0165 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0350  0.0257  0.0286  0.0216  0.0485  0.0816  0.0218  0.0734  0.0041 </r>
+        <r>  0.0350  0.0257  0.0286  0.0216  0.0482  0.0815  0.0218  0.0733  0.0042 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0492  0.0088  0.0003  0.0078  0.1066  0.0055  0.0346  0.0182  0.1570 </r>
+        <r>  0.0492  0.0087  0.0003  0.0078  0.1063  0.0055  0.0349  0.0182  0.1575 </r>
+       </set>
+      </set>
+      <set comment="kpoint 19">
+       <set comment="band 1">
+        <r>  0.3981  0.0101  0.0002  0.0107  0.0014  0.0003  0.0001  0.0002  0.0002 </r>
+        <r>  0.3980  0.0101  0.0002  0.0107  0.0014  0.0003  0.0001  0.0002  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4070  0.0079  0.0021  0.0084  0.0015  0.0004  0.0008  0.0001  0.0003 </r>
+        <r>  0.4070  0.0079  0.0021  0.0084  0.0015  0.0004  0.0008  0.0001  0.0003 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0013  0.1075  0.0001  0.1895  0.0018  0.0000  0.0001  0.0001  0.0020 </r>
+        <r>  0.0013  0.1075  0.0001  0.1896  0.0018  0.0000  0.0001  0.0001  0.0020 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0186  0.0855  0.1584  0.0417  0.0002  0.0042  0.0057  0.0016  0.0005 </r>
+        <r>  0.0186  0.0854  0.1584  0.0416  0.0002  0.0041  0.0057  0.0016  0.0005 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0228  0.0774  0.1791  0.0440  0.0004  0.0053  0.0068  0.0036  0.0009 </r>
+        <r>  0.0228  0.0774  0.1790  0.0440  0.0004  0.0053  0.0068  0.0036  0.0009 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0314  0.1098  0.1325  0.0389  0.0007  0.0157  0.0054  0.0037  0.0007 </r>
+        <r>  0.0314  0.1098  0.1325  0.0390  0.0007  0.0157  0.0054  0.0037  0.0007 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0230  0.0830  0.1728  0.0422  0.0003  0.0183  0.0082  0.0062  0.0018 </r>
+        <r>  0.0231  0.0830  0.1728  0.0422  0.0003  0.0183  0.0082  0.0062  0.0018 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0027  0.1187  0.0019  0.2039  0.0130  0.0031  0.0059  0.0093  0.0096 </r>
+        <r>  0.0027  0.1188  0.0019  0.2039  0.0130  0.0031  0.0059  0.0093  0.0096 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0002  0.0527  0.0004  0.0175  0.0254  0.0001  0.0478  0.0141  0.0307 </r>
+        <r>  0.0002  0.0527  0.0004  0.0175  0.0254  0.0001  0.0477  0.0141  0.0308 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0018  0.0045  0.0002  0.0625  0.0310  0.0142  0.0297  0.0061  0.0482 </r>
+        <r>  0.0018  0.0046  0.0002  0.0625  0.0309  0.0142  0.0297  0.0061  0.0482 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0028  0.0033  0.0019  0.0202  0.0104  0.0435  0.0041  0.0935  0.0199 </r>
+        <r>  0.0028  0.0033  0.0019  0.0202  0.0104  0.0434  0.0040  0.0935  0.0199 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0338  0.0013  0.0023  0.0276  0.0818  0.0054  0.0659  0.0057  0.0057 </r>
+        <r>  0.0338  0.0014  0.0023  0.0276  0.0817  0.0054  0.0658  0.0057  0.0057 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0038  0.0581  0.0292  0.0268  0.0063  0.0138  0.0788  0.0392  0.0043 </r>
+        <r>  0.0038  0.0580  0.0291  0.0267  0.0062  0.0138  0.0789  0.0391  0.0043 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0023  0.0225  0.0122  0.0097  0.0383  0.0084  0.0263  0.0600  0.0046 </r>
+        <r>  0.0024  0.0225  0.0122  0.0096  0.0383  0.0084  0.0262  0.0602  0.0045 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0244  0.0022  0.0011  0.0280  0.0378  0.0137  0.0053  0.0209  0.2073 </r>
+        <r>  0.0245  0.0022  0.0011  0.0280  0.0376  0.0137  0.0053  0.0209  0.2074 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0029  0.0087  0.0023  0.0056  0.0265  0.0867  0.0010  0.1493  0.0844 </r>
+        <r>  0.0028  0.0088  0.0023  0.0057  0.0264  0.0869  0.0010  0.1492  0.0851 </r>
+       </set>
+      </set>
+      <set comment="kpoint 20">
+       <set comment="band 1">
+        <r>  0.3900  0.0135  0.0002  0.0053  0.0006  0.0003  0.0000  0.0002  0.0002 </r>
+        <r>  0.3899  0.0135  0.0002  0.0053  0.0006  0.0003  0.0000  0.0002  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4108  0.0175  0.0011  0.0046  0.0009  0.0005  0.0007  0.0003  0.0002 </r>
+        <r>  0.4108  0.0174  0.0011  0.0045  0.0009  0.0005  0.0007  0.0003  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0010  0.0961  0.0027  0.2091  0.0012  0.0001  0.0001  0.0000  0.0043 </r>
+        <r>  0.0011  0.0961  0.0027  0.2091  0.0012  0.0001  0.0001  0.0000  0.0043 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0247  0.0870  0.1518  0.0408  0.0006  0.0050  0.0057  0.0038  0.0010 </r>
+        <r>  0.0247  0.0869  0.1519  0.0407  0.0006  0.0050  0.0057  0.0038  0.0010 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0221  0.0742  0.1974  0.0524  0.0003  0.0033  0.0053  0.0065  0.0009 </r>
+        <r>  0.0221  0.0742  0.1973  0.0523  0.0003  0.0033  0.0053  0.0065  0.0009 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0279  0.0909  0.1296  0.0283  0.0009  0.0153  0.0087  0.0045  0.0004 </r>
+        <r>  0.0279  0.0909  0.1297  0.0283  0.0009  0.0153  0.0086  0.0045  0.0004 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0299  0.0838  0.1595  0.0518  0.0007  0.0111  0.0082  0.0093  0.0003 </r>
+        <r>  0.0299  0.0838  0.1595  0.0518  0.0007  0.0111  0.0082  0.0093  0.0003 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0030  0.0915  0.0024  0.2265  0.0015  0.0059  0.0068  0.0091  0.0124 </r>
+        <r>  0.0030  0.0915  0.0024  0.2265  0.0015  0.0059  0.0068  0.0091  0.0124 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0004  0.0302  0.0006  0.0251  0.0132  0.0062  0.0041  0.0144  0.0785 </r>
+        <r>  0.0004  0.0302  0.0006  0.0251  0.0132  0.0062  0.0041  0.0144  0.0786 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0007  0.0018  0.0005  0.0217  0.0029  0.0567  0.0001  0.0968  0.0106 </r>
+        <r>  0.0007  0.0018  0.0005  0.0217  0.0030  0.0566  0.0001  0.0967  0.0106 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0020  0.0782  0.0020  0.0137  0.1033  0.0009  0.0253  0.0038  0.0147 </r>
+        <r>  0.0020  0.0782  0.0020  0.0137  0.1030  0.0009  0.0252  0.0038  0.0147 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0378  0.0021  0.0007  0.0089  0.0389  0.0029  0.1190  0.0007  0.0057 </r>
+        <r>  0.0378  0.0021  0.0007  0.0089  0.0389  0.0029  0.1190  0.0007  0.0057 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0020  0.0491  0.0053  0.0274  0.0632  0.0088  0.1227  0.0063  0.0050 </r>
+        <r>  0.0020  0.0490  0.0053  0.0273  0.0630  0.0088  0.1226  0.0063  0.0049 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0085  0.0142  0.0133  0.0015  0.0790  0.0751  0.0007  0.0385  0.0282 </r>
+        <r>  0.0085  0.0142  0.0133  0.0015  0.0790  0.0750  0.0007  0.0385  0.0282 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0052  0.0105  0.0031  0.0035  0.0273  0.0085  0.0029  0.0060  0.0661 </r>
+        <r>  0.0052  0.0104  0.0031  0.0035  0.0272  0.0085  0.0029  0.0060  0.0666 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0132  0.0104  0.0294  0.0116  0.0460  0.0762  0.0110  0.0882  0.0505 </r>
+        <r>  0.0131  0.0104  0.0294  0.0116  0.0461  0.0762  0.0110  0.0881  0.0507 </r>
+       </set>
+      </set>
+      <set comment="kpoint 21">
+       <set comment="band 1">
+        <r>  0.3875  0.0130  0.0008  0.0016  0.0001  0.0002  0.0000  0.0001  0.0001 </r>
+        <r>  0.3874  0.0130  0.0008  0.0016  0.0001  0.0002  0.0000  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4112  0.0265  0.0001  0.0011  0.0002  0.0005  0.0003  0.0003  0.0002 </r>
+        <r>  0.4112  0.0264  0.0001  0.0011  0.0002  0.0005  0.0003  0.0003  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0066  0.0700  0.0084  0.2416  0.0026  0.0006  0.0010  0.0001  0.0058 </r>
+        <r>  0.0066  0.0700  0.0084  0.2416  0.0026  0.0006  0.0010  0.0001  0.0058 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0190  0.0956  0.1885  0.0364  0.0001  0.0014  0.0044  0.0073  0.0021 </r>
+        <r>  0.0191  0.0955  0.1887  0.0363  0.0001  0.0014  0.0044  0.0073  0.0021 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0259  0.0954  0.1570  0.0428  0.0017  0.0052  0.0048  0.0038  0.0019 </r>
+        <r>  0.0259  0.0954  0.1567  0.0428  0.0017  0.0052  0.0048  0.0038  0.0018 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0348  0.0932  0.1258  0.0578  0.0009  0.0048  0.0053  0.0114  0.0004 </r>
+        <r>  0.0348  0.0933  0.1259  0.0578  0.0009  0.0048  0.0053  0.0113  0.0004 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0213  0.0772  0.1492  0.0263  0.0018  0.0137  0.0078  0.0086  0.0005 </r>
+        <r>  0.0213  0.0772  0.1492  0.0263  0.0018  0.0137  0.0078  0.0086  0.0005 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0077  0.0610  0.0124  0.2283  0.0062  0.0034  0.0120  0.0013  0.0123 </r>
+        <r>  0.0077  0.0610  0.0124  0.2283  0.0063  0.0034  0.0120  0.0013  0.0123 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0021  0.0390  0.0019  0.0047  0.0123  0.0079  0.0043  0.0192  0.0763 </r>
+        <r>  0.0021  0.0389  0.0019  0.0047  0.0123  0.0079  0.0043  0.0192  0.0764 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0030  0.0025  0.0040  0.0050  0.0061  0.0609  0.0019  0.0927  0.0112 </r>
+        <r>  0.0030  0.0025  0.0040  0.0050  0.0061  0.0609  0.0019  0.0927  0.0112 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0017  0.0233  0.0032  0.0217  0.0705  0.0077  0.1147  0.0076  0.0007 </r>
+        <r>  0.0017  0.0234  0.0032  0.0217  0.0701  0.0076  0.1146  0.0076  0.0007 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0275  0.0950  0.0026  0.0077  0.0833  0.0064  0.0147  0.0065  0.0173 </r>
+        <r>  0.0275  0.0950  0.0026  0.0077  0.0832  0.0064  0.0146  0.0065  0.0172 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0001  0.0501  0.0046  0.0415  0.0076  0.0178  0.0957  0.0022  0.0029 </r>
+        <r>  0.0001  0.0501  0.0046  0.0415  0.0075  0.0178  0.0957  0.0022  0.0029 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0054  0.0089  0.0044  0.0028  0.0287  0.0256  0.0354  0.0045  0.0708 </r>
+        <r>  0.0054  0.0089  0.0044  0.0027  0.0287  0.0256  0.0354  0.0045  0.0708 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0095  0.0097  0.0206  0.0010  0.0975  0.0446  0.0008  0.0631  0.0288 </r>
+        <r>  0.0095  0.0097  0.0206  0.0010  0.0976  0.0445  0.0008  0.0632  0.0289 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0121  0.0026  0.0231  0.0008  0.0688  0.0783  0.0178  0.0553  0.0325 </r>
+        <r>  0.0120  0.0026  0.0231  0.0008  0.0687  0.0783  0.0177  0.0553  0.0325 </r>
+       </set>
+      </set>
+      <set comment="kpoint 22">
+       <set comment="band 1">
+        <r>  0.4038  0.0019  0.0042  0.0039  0.0020  0.0000  0.0006  0.0000  0.0003 </r>
+        <r>  0.4036  0.0019  0.0042  0.0039  0.0020  0.0000  0.0006  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4310  0.0023  0.0025  0.0047  0.0033  0.0000  0.0010  0.0000  0.0005 </r>
+        <r>  0.4310  0.0023  0.0025  0.0047  0.0034  0.0000  0.0010  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0097  0.0835  0.0244  0.1738  0.0021  0.0002  0.0014  0.0004  0.0003 </r>
+        <r>  0.0097  0.0835  0.0244  0.1739  0.0021  0.0002  0.0014  0.0003  0.0003 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0078  0.0060  0.2930  0.0116  0.0007  0.0005  0.0011  0.0011  0.0001 </r>
+        <r>  0.0078  0.0053  0.2930  0.0123  0.0007  0.0006  0.0011  0.0011  0.0001 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.2272  0.0002  0.1094  0.0002  0.0012  0.0000  0.0006  0.0011 </r>
+        <r>  0.0000  0.2277  0.0002  0.1087  0.0002  0.0011  0.0000  0.0006  0.0011 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0019  0.0004  0.1129  0.0008  0.0246  0.0001  0.0723  0.0002  0.0035 </r>
+        <r>  0.0019  0.0004  0.1129  0.0008  0.0245  0.0001  0.0723  0.0002  0.0034 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2446  0.0000  0.1175  0.0005  0.0082  0.0000  0.0040  0.0034 </r>
+        <r>  0.0000  0.2447  0.0000  0.1175  0.0005  0.0082  0.0000  0.0040  0.0034 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0156  0.0250  0.1860  0.0520  0.0156  0.0018  0.0131  0.0037  0.0022 </r>
+        <r>  0.0156  0.0250  0.1860  0.0520  0.0156  0.0018  0.0131  0.0037  0.0022 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0088  0.0974  0.0648  0.2028  0.0074  0.0002  0.0188  0.0004  0.0011 </r>
+        <r>  0.0089  0.0974  0.0647  0.2028  0.0074  0.0002  0.0188  0.0004  0.0010 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0674  0.0124  0.0127  0.0258  0.0427  0.0012  0.0182  0.0024  0.0061 </r>
+        <r>  0.0672  0.0124  0.0127  0.0258  0.0426  0.0012  0.0182  0.0024  0.0060 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0060  0.0000  0.0029  0.0041  0.1778  0.0000  0.0852  0.0292 </r>
+        <r>  0.0000  0.0060  0.0000  0.0029  0.0041  0.1775  0.0000  0.0851  0.0293 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0288  0.0123  0.0211  0.0257  0.0183  0.0226  0.0088  0.0471  0.0026 </r>
+        <r>  0.0287  0.0123  0.0211  0.0257  0.0183  0.0224  0.0088  0.0468  0.0026 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0224  0.0007  0.0139  0.0015  0.0008  0.0668  0.0013  0.1389  0.0001 </r>
+        <r>  0.0224  0.0007  0.0139  0.0015  0.0009  0.0668  0.0013  0.1392  0.0001 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0006  0.0000  0.0003  0.0191  0.0971  0.0000  0.0469  0.1362 </r>
+        <r>  0.0000  0.0007  0.0000  0.0003  0.0191  0.0970  0.0000  0.0468  0.1363 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0188  0.0000  0.0091  0.0121  0.0003  0.0000  0.0001  0.0848 </r>
+        <r>  0.0000  0.0188  0.0000  0.0091  0.0121  0.0003  0.0000  0.0001  0.0849 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0001  0.0082  0.0000  0.0046  0.0346  0.0364  0.0000  0.0261  0.2358 </r>
+        <r>  0.0001  0.0079  0.0000  0.0050  0.0322  0.0357  0.0000  0.0266  0.2393 </r>
+       </set>
+      </set>
+      <set comment="kpoint 23">
+       <set comment="band 1">
+        <r>  0.4107  0.0007  0.0045  0.0032  0.0024  0.0001  0.0009  0.0000  0.0004 </r>
+        <r>  0.4105  0.0007  0.0045  0.0032  0.0024  0.0001  0.0009  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4229  0.0044  0.0017  0.0073  0.0033  0.0001  0.0007  0.0001  0.0004 </r>
+        <r>  0.4229  0.0044  0.0017  0.0073  0.0033  0.0001  0.0007  0.0001  0.0004 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0055  0.0942  0.0046  0.1836  0.0006  0.0001  0.0008  0.0002  0.0002 </r>
+        <r>  0.0055  0.0941  0.0046  0.1837  0.0006  0.0001  0.0008  0.0002  0.0002 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0017  0.0967  0.1688  0.0505  0.0001  0.0014  0.0019  0.0001  0.0002 </r>
+        <r>  0.0017  0.0967  0.1688  0.0505  0.0001  0.0014  0.0019  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0119  0.1169  0.1474  0.0542  0.0004  0.0014  0.0021  0.0015  0.0006 </r>
+        <r>  0.0119  0.1169  0.1474  0.0542  0.0004  0.0014  0.0021  0.0015  0.0006 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0050  0.0169  0.1455  0.0073  0.0226  0.0023  0.0536  0.0009  0.0024 </r>
+        <r>  0.0050  0.0170  0.1455  0.0073  0.0225  0.0023  0.0536  0.0009  0.0024 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0155  0.1725  0.0128  0.0766  0.0054  0.0100  0.0193  0.0032  0.0050 </r>
+        <r>  0.0155  0.1725  0.0128  0.0766  0.0054  0.0100  0.0193  0.0032  0.0050 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0021  0.0532  0.1900  0.0246  0.0079  0.0119  0.0225  0.0046  0.0000 </r>
+        <r>  0.0021  0.0532  0.1900  0.0246  0.0078  0.0118  0.0224  0.0046  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0041  0.1297  0.0043  0.2649  0.0065  0.0001  0.0066  0.0022  0.0018 </r>
+        <r>  0.0041  0.1297  0.0043  0.2649  0.0065  0.0001  0.0066  0.0022  0.0018 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0191  0.0002  0.0452  0.0098  0.0100  0.0012  0.0311  0.0591 </r>
+        <r>  0.0000  0.0191  0.0002  0.0452  0.0098  0.0100  0.0012  0.0311  0.0592 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0348  0.0026  0.0058  0.0239  0.0158  0.1153  0.0082  0.0010  0.0163 </r>
+        <r>  0.0347  0.0026  0.0058  0.0239  0.0158  0.1150  0.0081  0.0010  0.0162 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0308  0.0131  0.0048  0.0063  0.0272  0.0465  0.0094  0.1153  0.0081 </r>
+        <r>  0.0307  0.0131  0.0048  0.0063  0.0272  0.0465  0.0094  0.1152  0.0081 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0491  0.0170  0.0257  0.0130  0.0464  0.0772  0.0179  0.0635  0.0073 </r>
+        <r>  0.0490  0.0170  0.0256  0.0129  0.0462  0.0770  0.0179  0.0634  0.0074 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0233  0.0027  0.0024  0.0125  0.0716  0.0652  0.0246  0.0289  0.0236 </r>
+        <r>  0.0233  0.0027  0.0024  0.0125  0.0717  0.0653  0.0247  0.0289  0.0239 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0093  0.0009  0.0219  0.0001  0.0333  0.0266  0.0061  0.0676  0.0290 </r>
+        <r>  0.0093  0.0009  0.0219  0.0001  0.0332  0.0265  0.0061  0.0675  0.0291 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0111  0.0030  0.0080  0.0085  0.0317  0.0208  0.0050  0.1006  0.1258 </r>
+        <r>  0.0112  0.0029  0.0080  0.0085  0.0313  0.0207  0.0050  0.1000  0.1277 </r>
+       </set>
+      </set>
+      <set comment="kpoint 24">
+       <set comment="band 1">
+        <r>  0.4094  0.0071  0.0036  0.0016  0.0021  0.0002  0.0009  0.0001  0.0003 </r>
+        <r>  0.4092  0.0071  0.0036  0.0016  0.0021  0.0002  0.0009  0.0001  0.0003 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4088  0.0123  0.0006  0.0066  0.0023  0.0002  0.0003  0.0002  0.0004 </r>
+        <r>  0.4089  0.0123  0.0006  0.0066  0.0023  0.0002  0.0003  0.0002  0.0004 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0021  0.0950  0.0008  0.1927  0.0003  0.0000  0.0002  0.0001  0.0016 </r>
+        <r>  0.0021  0.0950  0.0008  0.1927  0.0003  0.0000  0.0002  0.0001  0.0016 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0106  0.0871  0.1638  0.0479  0.0000  0.0019  0.0045  0.0012  0.0006 </r>
+        <r>  0.0106  0.0870  0.1638  0.0479  0.0000  0.0019  0.0045  0.0012  0.0006 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0194  0.0936  0.1639  0.0476  0.0005  0.0025  0.0052  0.0030  0.0003 </r>
+        <r>  0.0194  0.0935  0.1638  0.0476  0.0005  0.0025  0.0052  0.0030  0.0003 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0251  0.0990  0.1477  0.0453  0.0041  0.0121  0.0045  0.0080  0.0003 </r>
+        <r>  0.0251  0.0990  0.1477  0.0453  0.0041  0.0121  0.0045  0.0080  0.0003 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0164  0.0938  0.1396  0.0546  0.0060  0.0054  0.0180  0.0050  0.0028 </r>
+        <r>  0.0164  0.0937  0.1396  0.0547  0.0060  0.0054  0.0180  0.0050  0.0028 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0014  0.0194  0.0353  0.0227  0.0322  0.0117  0.0694  0.0089  0.0052 </r>
+        <r>  0.0014  0.0194  0.0353  0.0227  0.0321  0.0117  0.0693  0.0089  0.0052 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0043  0.1200  0.0033  0.2455  0.0013  0.0024  0.0083  0.0031  0.0106 </r>
+        <r>  0.0043  0.1199  0.0033  0.2455  0.0013  0.0024  0.0083  0.0030  0.0106 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0006  0.0348  0.0013  0.0254  0.0201  0.0125  0.0022  0.0201  0.0713 </r>
+        <r>  0.0006  0.0348  0.0013  0.0254  0.0201  0.0125  0.0022  0.0201  0.0714 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0004  0.0041  0.0006  0.0197  0.0023  0.0495  0.0002  0.0827  0.0176 </r>
+        <r>  0.0004  0.0041  0.0006  0.0197  0.0024  0.0494  0.0002  0.0826  0.0176 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0294  0.0306  0.0049  0.0003  0.0623  0.0042  0.0589  0.0046  0.0246 </r>
+        <r>  0.0294  0.0306  0.0049  0.0003  0.0621  0.0042  0.0588  0.0046  0.0245 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0465  0.0297  0.0197  0.0139  0.0277  0.1335  0.0145  0.0410  0.0150 </r>
+        <r>  0.0458  0.0297  0.0193  0.0138  0.0284  0.1313  0.0146  0.0421  0.0147 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0111  0.0018  0.0186  0.0038  0.0623  0.0655  0.0010  0.0419  0.0132 </r>
+        <r>  0.0116  0.0018  0.0190  0.0038  0.0616  0.0673  0.0009  0.0410  0.0135 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0366  0.0423  0.0321  0.0121  0.0417  0.1351  0.0201  0.0570  0.0222 </r>
+        <r>  0.0365  0.0424  0.0322  0.0121  0.0417  0.1351  0.0201  0.0570  0.0223 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0040  0.0064  0.0108  0.0052  0.0377  0.0067  0.0000  0.0932  0.1109 </r>
+        <r>  0.0040  0.0064  0.0108  0.0054  0.0382  0.0069  0.0000  0.0929  0.1123 </r>
+       </set>
+      </set>
+      <set comment="kpoint 25">
+       <set comment="band 1">
+        <r>  0.3978  0.0194  0.0003  0.0032  0.0011  0.0003  0.0002  0.0001  0.0004 </r>
+        <r>  0.3976  0.0194  0.0003  0.0032  0.0011  0.0003  0.0002  0.0001  0.0004 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4006  0.0177  0.0017  0.0011  0.0012  0.0003  0.0005  0.0003  0.0001 </r>
+        <r>  0.4007  0.0177  0.0017  0.0011  0.0012  0.0003  0.0005  0.0003  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0064  0.0840  0.0120  0.1999  0.0014  0.0002  0.0005  0.0003  0.0038 </r>
+        <r>  0.0064  0.0840  0.0120  0.2000  0.0014  0.0002  0.0005  0.0003  0.0038 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0212  0.0854  0.1439  0.0529  0.0002  0.0025  0.0061  0.0031  0.0018 </r>
+        <r>  0.0212  0.0853  0.1440  0.0529  0.0002  0.0025  0.0061  0.0031  0.0018 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0216  0.0738  0.1860  0.0467  0.0005  0.0030  0.0062  0.0063  0.0001 </r>
+        <r>  0.0216  0.0738  0.1859  0.0466  0.0005  0.0030  0.0062  0.0063  0.0001 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0293  0.0931  0.1185  0.0444  0.0025  0.0106  0.0074  0.0092  0.0016 </r>
+        <r>  0.0293  0.0931  0.1185  0.0444  0.0025  0.0106  0.0074  0.0092  0.0016 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0261  0.0780  0.1661  0.0563  0.0011  0.0093  0.0054  0.0144  0.0007 </r>
+        <r>  0.0261  0.0780  0.1661  0.0564  0.0011  0.0093  0.0054  0.0144  0.0007 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0095  0.0717  0.0149  0.2389  0.0080  0.0019  0.0090  0.0008  0.0196 </r>
+        <r>  0.0095  0.0717  0.0149  0.2389  0.0080  0.0019  0.0090  0.0008  0.0196 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0025  0.0562  0.0004  0.0094  0.0360  0.0017  0.0826  0.0068  0.0059 </r>
+        <r>  0.0025  0.0562  0.0004  0.0093  0.0359  0.0017  0.0825  0.0068  0.0059 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0016  0.0492  0.0022  0.0109  0.0276  0.0157  0.0004  0.0150  0.0708 </r>
+        <r>  0.0016  0.0493  0.0022  0.0109  0.0276  0.0157  0.0004  0.0150  0.0708 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0027  0.0034  0.0051  0.0063  0.0040  0.0551  0.0016  0.0840  0.0112 </r>
+        <r>  0.0027  0.0034  0.0051  0.0063  0.0040  0.0551  0.0015  0.0840  0.0112 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0027  0.0378  0.0078  0.0085  0.0049  0.0339  0.0276  0.0238  0.0504 </r>
+        <r>  0.0027  0.0378  0.0078  0.0086  0.0049  0.0338  0.0276  0.0238  0.0504 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0231  0.0213  0.0126  0.0176  0.0878  0.0494  0.0263  0.0499  0.0003 </r>
+        <r>  0.0231  0.0213  0.0126  0.0176  0.0878  0.0493  0.0263  0.0499  0.0003 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0046  0.0689  0.0134  0.0357  0.0155  0.0315  0.0908  0.0122  0.0048 </r>
+        <r>  0.0046  0.0688  0.0134  0.0356  0.0155  0.0315  0.0908  0.0122  0.0048 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0206  0.0132  0.0114  0.0002  0.1746  0.0396  0.0146  0.0189  0.0461 </r>
+        <r>  0.0207  0.0132  0.0114  0.0002  0.1746  0.0393  0.0147  0.0190  0.0463 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0187  0.0019  0.0217  0.0022  0.0925  0.1707  0.0230  0.0276  0.0190 </r>
+        <r>  0.0186  0.0019  0.0218  0.0022  0.0927  0.1709  0.0229  0.0274  0.0188 </r>
+       </set>
+      </set>
+      <set comment="kpoint 26">
+       <set comment="band 1">
+        <r>  0.3909  0.0215  0.0003  0.0012  0.0003  0.0003  0.0000  0.0002  0.0003 </r>
+        <r>  0.3908  0.0215  0.0003  0.0012  0.0003  0.0003  0.0000  0.0002  0.0003 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3939  0.0276  0.0006  0.0001  0.0003  0.0004  0.0003  0.0003  0.0001 </r>
+        <r>  0.3939  0.0276  0.0006  0.0001  0.0003  0.0004  0.0003  0.0003  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0124  0.0598  0.0380  0.2069  0.0038  0.0011  0.0018  0.0014  0.0051 </r>
+        <r>  0.0124  0.0598  0.0380  0.2068  0.0037  0.0011  0.0018  0.0014  0.0051 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0293  0.1035  0.1700  0.0098  0.0001  0.0029  0.0021  0.0093  0.0052 </r>
+        <r>  0.0295  0.1026  0.1713  0.0098  0.0001  0.0028  0.0022  0.0093  0.0052 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0221  0.0707  0.1335  0.1064  0.0008  0.0013  0.0083  0.0036  0.0005 </r>
+        <r>  0.0219  0.0715  0.1320  0.1063  0.0008  0.0013  0.0082  0.0036  0.0005 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0259  0.0788  0.1287  0.0247  0.0022  0.0115  0.0100  0.0097  0.0019 </r>
+        <r>  0.0259  0.0788  0.1287  0.0247  0.0021  0.0115  0.0099  0.0098  0.0019 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0359  0.0877  0.1111  0.0743  0.0028  0.0041  0.0034  0.0132  0.0038 </r>
+        <r>  0.0359  0.0877  0.1111  0.0744  0.0028  0.0041  0.0034  0.0132  0.0038 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0085  0.0437  0.0501  0.2053  0.0077  0.0030  0.0147  0.0020  0.0136 </r>
+        <r>  0.0085  0.0437  0.0501  0.2053  0.0077  0.0030  0.0147  0.0020  0.0136 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0043  0.0673  0.0033  0.0063  0.0136  0.0102  0.0036  0.0171  0.0689 </r>
+        <r>  0.0043  0.0673  0.0033  0.0063  0.0136  0.0102  0.0035  0.0171  0.0689 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0015  0.0107  0.0129  0.0017  0.0039  0.0577  0.0010  0.0780  0.0078 </r>
+        <r>  0.0015  0.0108  0.0129  0.0017  0.0040  0.0576  0.0010  0.0780  0.0078 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0032  0.0869  0.0026  0.0087  0.0315  0.0032  0.0598  0.0115  0.0195 </r>
+        <r>  0.0032  0.0870  0.0026  0.0088  0.0313  0.0032  0.0597  0.0115  0.0195 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0033  0.0089  0.0104  0.0136  0.0346  0.0630  0.0292  0.0382  0.0379 </r>
+        <r>  0.0033  0.0088  0.0104  0.0136  0.0345  0.0630  0.0291  0.0382  0.0379 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0011  0.0318  0.0035  0.0303  0.0756  0.0046  0.1026  0.0048  0.0010 </r>
+        <r>  0.0011  0.0318  0.0036  0.0302  0.0755  0.0046  0.1029  0.0048  0.0010 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0061  0.0444  0.0157  0.0252  0.0108  0.0485  0.0229  0.0601  0.0168 </r>
+        <r>  0.0061  0.0444  0.0157  0.0252  0.0108  0.0484  0.0229  0.0601  0.0168 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0163  0.0041  0.0085  0.0092  0.2643  0.0033  0.0330  0.0114  0.0071 </r>
+        <r>  0.0163  0.0041  0.0085  0.0092  0.2644  0.0034  0.0330  0.0114  0.0072 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0165  0.0140  0.0161  0.0017  0.0073  0.1339  0.0046  0.0218  0.0385 </r>
+        <r>  0.0164  0.0140  0.0160  0.0018  0.0072  0.1340  0.0046  0.0218  0.0385 </r>
+       </set>
+      </set>
+      <set comment="kpoint 27">
+       <set comment="band 1">
+        <r>  0.4115  0.0005  0.0048  0.0011  0.0027  0.0000  0.0009  0.0000  0.0004 </r>
+        <r>  0.4112  0.0005  0.0048  0.0011  0.0027  0.0000  0.0009  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4278  0.0030  0.0027  0.0063  0.0036  0.0000  0.0009  0.0000  0.0005 </r>
+        <r>  0.4279  0.0030  0.0027  0.0063  0.0036  0.0000  0.0009  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0097  0.0894  0.0012  0.1862  0.0002  0.0001  0.0011  0.0001  0.0000 </r>
+        <r>  0.0097  0.0894  0.0012  0.1862  0.0002  0.0001  0.0012  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0045  0.0001  0.3170  0.0003  0.0005  0.0005  0.0007  0.0010  0.0001 </r>
+        <r>  0.0045  0.0001  0.3170  0.0003  0.0005  0.0005  0.0007  0.0010  0.0001 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.2275  0.0000  0.1092  0.0001  0.0012  0.0000  0.0006  0.0006 </r>
+        <r>  0.0000  0.2273  0.0000  0.1092  0.0001  0.0012  0.0000  0.0006  0.0006 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0017  0.0002  0.1002  0.0004  0.0271  0.0001  0.0734  0.0001  0.0038 </r>
+        <r>  0.0017  0.0002  0.1002  0.0004  0.0270  0.0001  0.0734  0.0001  0.0038 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2457  0.0000  0.1180  0.0003  0.0097  0.0000  0.0047  0.0024 </r>
+        <r>  0.0000  0.2457  0.0000  0.1180  0.0003  0.0097  0.0000  0.0047  0.0024 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0081  0.0000  0.2619  0.0000  0.0058  0.0007  0.0223  0.0015  0.0008 </r>
+        <r>  0.0081  0.0000  0.2619  0.0000  0.0058  0.0007  0.0223  0.0015  0.0008 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0059  0.1329  0.0016  0.2767  0.0042  0.0007  0.0053  0.0014  0.0006 </r>
+        <r>  0.0059  0.1329  0.0016  0.2767  0.0042  0.0007  0.0053  0.0014  0.0006 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0379  0.0175  0.0139  0.0365  0.0286  0.0115  0.0107  0.0241  0.0040 </r>
+        <r>  0.0378  0.0175  0.0139  0.0365  0.0285  0.0115  0.0107  0.0240  0.0040 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0118  0.0000  0.0057  0.0037  0.1741  0.0000  0.0836  0.0265 </r>
+        <r>  0.0000  0.0118  0.0000  0.0057  0.0037  0.1737  0.0000  0.0835  0.0265 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0902  0.0097  0.0199  0.0201  0.0563  0.0014  0.0178  0.0029  0.0079 </r>
+        <r>  0.0899  0.0097  0.0199  0.0201  0.0563  0.0014  0.0178  0.0029  0.0079 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0016  0.0000  0.0008  0.0068  0.1275  0.0000  0.0612  0.0481 </r>
+        <r>  0.0000  0.0016  0.0000  0.0008  0.0068  0.1274  0.0000  0.0612  0.0483 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0126  0.0034  0.0146  0.0070  0.0163  0.0543  0.0012  0.1131  0.0023 </r>
+        <r>  0.0126  0.0034  0.0146  0.0070  0.0163  0.0543  0.0012  0.1131  0.0023 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0041  0.0000  0.0019  0.0332  0.0013  0.0000  0.0006  0.2357 </r>
+        <r>  0.0000  0.0041  0.0000  0.0019  0.0334  0.0013  0.0000  0.0006  0.2377 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0247  0.0054  0.0019  0.0113  0.0511  0.0824  0.0109  0.1717  0.0072 </r>
+        <r>  0.0247  0.0054  0.0019  0.0113  0.0510  0.0823  0.0109  0.1714  0.0072 </r>
+       </set>
+      </set>
+      <set comment="kpoint 28">
+       <set comment="band 1">
+        <r>  0.4037  0.0056  0.0038  0.0016  0.0020  0.0001  0.0007  0.0000  0.0002 </r>
+        <r>  0.4035  0.0056  0.0037  0.0016  0.0020  0.0001  0.0007  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4230  0.0088  0.0021  0.0042  0.0029  0.0001  0.0006  0.0001  0.0006 </r>
+        <r>  0.4231  0.0088  0.0021  0.0042  0.0029  0.0001  0.0006  0.0001  0.0006 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0117  0.0870  0.0049  0.1876  0.0014  0.0000  0.0010  0.0002  0.0011 </r>
+        <r>  0.0117  0.0870  0.0049  0.1876  0.0014  0.0000  0.0010  0.0002  0.0011 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0034  0.0916  0.1713  0.0517  0.0000  0.0011  0.0023  0.0007  0.0009 </r>
+        <r>  0.0034  0.0915  0.1713  0.0517  0.0000  0.0011  0.0023  0.0007  0.0009 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0104  0.1178  0.1463  0.0575  0.0006  0.0006  0.0020  0.0026  0.0003 </r>
+        <r>  0.0104  0.1177  0.1462  0.0575  0.0006  0.0006  0.0020  0.0025  0.0003 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0070  0.0248  0.1635  0.0099  0.0221  0.0026  0.0415  0.0035  0.0011 </r>
+        <r>  0.0070  0.0249  0.1635  0.0099  0.0221  0.0026  0.0415  0.0035  0.0011 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0125  0.1385  0.0027  0.0848  0.0078  0.0065  0.0296  0.0058  0.0053 </r>
+        <r>  0.0125  0.1385  0.0027  0.0848  0.0078  0.0065  0.0296  0.0058  0.0053 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0089  0.0532  0.1295  0.0888  0.0136  0.0032  0.0124  0.0095  0.0047 </r>
+        <r>  0.0090  0.0534  0.1296  0.0887  0.0135  0.0032  0.0124  0.0095  0.0047 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0108  0.1080  0.0456  0.1879  0.0034  0.0009  0.0212  0.0052  0.0055 </r>
+        <r>  0.0108  0.1079  0.0456  0.1880  0.0034  0.0009  0.0212  0.0052  0.0055 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0134  0.0670  0.0081  0.0114  0.0414  0.0282  0.0072  0.0069  0.0181 </r>
+        <r>  0.0134  0.0670  0.0081  0.0114  0.0413  0.0282  0.0072  0.0069  0.0182 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0209  0.0055  0.0129  0.0004  0.0135  0.0411  0.0034  0.1071  0.0297 </r>
+        <r>  0.0208  0.0055  0.0129  0.0004  0.0135  0.0409  0.0034  0.1071  0.0296 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0008  0.0001  0.0172  0.0108  0.0149  0.0666  0.0055  0.0613  0.0212 </r>
+        <r>  0.0008  0.0001  0.0172  0.0108  0.0149  0.0665  0.0055  0.0612  0.0212 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0317  0.0009  0.0060  0.0186  0.0021  0.0889  0.0068  0.0088  0.0709 </r>
+        <r>  0.0316  0.0009  0.0060  0.0186  0.0021  0.0888  0.0068  0.0089  0.0710 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0141  0.0358  0.0102  0.0036  0.0040  0.1167  0.0067  0.0090  0.0730 </r>
+        <r>  0.0140  0.0359  0.0102  0.0035  0.0039  0.1167  0.0068  0.0090  0.0732 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0298  0.0161  0.0114  0.0069  0.0042  0.1265  0.0046  0.0611  0.0532 </r>
+        <r>  0.0297  0.0160  0.0114  0.0069  0.0042  0.1264  0.0046  0.0612  0.0533 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0163  0.0020  0.0015  0.0199  0.0423  0.0116  0.0044  0.1159  0.1182 </r>
+        <r>  0.0162  0.0020  0.0015  0.0199  0.0426  0.0116  0.0044  0.1159  0.1189 </r>
+       </set>
+      </set>
+      <set comment="kpoint 29">
+       <set comment="band 1">
+        <r>  0.3947  0.0142  0.0024  0.0013  0.0010  0.0002  0.0004  0.0001  0.0002 </r>
+        <r>  0.3946  0.0142  0.0024  0.0013  0.0010  0.0002  0.0004  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4088  0.0198  0.0008  0.0017  0.0015  0.0002  0.0002  0.0003  0.0005 </r>
+        <r>  0.4088  0.0198  0.0008  0.0018  0.0015  0.0002  0.0002  0.0003  0.0005 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0095  0.0777  0.0483  0.1694  0.0030  0.0002  0.0007  0.0010  0.0023 </r>
+        <r>  0.0095  0.0777  0.0483  0.1694  0.0029  0.0002  0.0007  0.0010  0.0023 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0186  0.0938  0.1117  0.0816  0.0005  0.0010  0.0058  0.0015  0.0031 </r>
+        <r>  0.0186  0.0938  0.1117  0.0816  0.0005  0.0010  0.0058  0.0015  0.0031 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0178  0.0867  0.1755  0.0495  0.0007  0.0012  0.0047  0.0054  0.0002 </r>
+        <r>  0.0178  0.0867  0.1754  0.0495  0.0007  0.0012  0.0047  0.0054  0.0002 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0241  0.0869  0.1259  0.0516  0.0058  0.0091  0.0048  0.0113  0.0015 </r>
+        <r>  0.0241  0.0869  0.1259  0.0516  0.0058  0.0091  0.0048  0.0113  0.0015 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0315  0.0960  0.0720  0.1341  0.0026  0.0029  0.0072  0.0061  0.0067 </r>
+        <r>  0.0315  0.0960  0.0720  0.1342  0.0026  0.0029  0.0072  0.0061  0.0067 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0061  0.0567  0.0952  0.1614  0.0172  0.0013  0.0081  0.0070  0.0126 </r>
+        <r>  0.0061  0.0567  0.0952  0.1613  0.0172  0.0013  0.0081  0.0070  0.0126 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0020  0.0395  0.0123  0.0021  0.0253  0.0051  0.0860  0.0117  0.0039 </r>
+        <r>  0.0020  0.0395  0.0123  0.0021  0.0252  0.0051  0.0860  0.0117  0.0039 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0003  0.0801  0.0052  0.0086  0.0279  0.0222  0.0018  0.0086  0.0408 </r>
+        <r>  0.0003  0.0801  0.0052  0.0086  0.0279  0.0221  0.0017  0.0086  0.0410 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0013  0.0190  0.0113  0.0003  0.0212  0.0263  0.0125  0.0451  0.0539 </r>
+        <r>  0.0013  0.0190  0.0113  0.0003  0.0212  0.0262  0.0125  0.0452  0.0539 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0045  0.0108  0.0234  0.0005  0.0163  0.0244  0.0006  0.1024  0.0121 </r>
+        <r>  0.0044  0.0108  0.0234  0.0005  0.0163  0.0243  0.0006  0.1023  0.0121 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0008  0.0423  0.0182  0.0128  0.0134  0.0592  0.0036  0.0586  0.0539 </r>
+        <r>  0.0008  0.0423  0.0182  0.0128  0.0133  0.0592  0.0037  0.0585  0.0540 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0385  0.0094  0.0083  0.0129  0.0058  0.1791  0.0139  0.0048  0.0547 </r>
+        <r>  0.0384  0.0094  0.0083  0.0129  0.0058  0.1789  0.0139  0.0048  0.0546 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0308  0.0221  0.0192  0.0099  0.0074  0.1678  0.0086  0.0258  0.0466 </r>
+        <r>  0.0308  0.0221  0.0192  0.0099  0.0073  0.1677  0.0086  0.0258  0.0466 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0161  0.0215  0.0026  0.0120  0.1212  0.0122  0.0078  0.0012  0.0125 </r>
+        <r>  0.0161  0.0215  0.0026  0.0120  0.1211  0.0121  0.0079  0.0012  0.0125 </r>
+       </set>
+      </set>
+      <set comment="kpoint 30">
+       <set comment="band 1">
+        <r>  0.3964  0.0028  0.0033  0.0057  0.0014  0.0000  0.0004  0.0000  0.0002 </r>
+        <r>  0.3963  0.0028  0.0033  0.0057  0.0014  0.0000  0.0004  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4311  0.0033  0.0031  0.0070  0.0029  0.0000  0.0007  0.0000  0.0004 </r>
+        <r>  0.4312  0.0033  0.0031  0.0070  0.0029  0.0000  0.0007  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0199  0.0797  0.0314  0.1660  0.0045  0.0001  0.0018  0.0003  0.0006 </r>
+        <r>  0.0199  0.0797  0.0314  0.1661  0.0045  0.0001  0.0018  0.0003  0.0006 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2285  0.0000  0.1099  0.0003  0.0013  0.0000  0.0006  0.0019 </r>
+        <r>  0.0000  0.2286  0.0000  0.1096  0.0003  0.0012  0.0000  0.0006  0.0019 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0054  0.0078  0.2903  0.0159  0.0009  0.0008  0.0014  0.0018  0.0001 </r>
+        <r>  0.0054  0.0076  0.2903  0.0161  0.0009  0.0008  0.0014  0.0017  0.0001 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0030  0.0003  0.1407  0.0006  0.0245  0.0003  0.0623  0.0007  0.0035 </r>
+        <r>  0.0030  0.0003  0.1407  0.0006  0.0245  0.0003  0.0623  0.0007  0.0034 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0289  0.1091  0.0012  0.2273  0.0202  0.0008  0.0054  0.0018  0.0028 </r>
+        <r>  0.0289  0.1091  0.0012  0.2273  0.0202  0.0008  0.0054  0.0018  0.0028 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2319  0.0000  0.1114  0.0008  0.0100  0.0000  0.0048  0.0056 </r>
+        <r>  0.0000  0.2319  0.0000  0.1114  0.0008  0.0100  0.0000  0.0048  0.0055 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0072  0.0003  0.1943  0.0006  0.0062  0.0030  0.0360  0.0062  0.0009 </r>
+        <r>  0.0072  0.0003  0.1942  0.0006  0.0061  0.0030  0.0360  0.0062  0.0009 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0626  0.0063  0.0321  0.0131  0.0514  0.0104  0.0180  0.0218  0.0072 </r>
+        <r>  0.0625  0.0063  0.0321  0.0131  0.0513  0.0105  0.0180  0.0218  0.0072 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0177  0.0000  0.0085  0.0073  0.1474  0.0000  0.0707  0.0521 </r>
+        <r>  0.0000  0.0177  0.0000  0.0085  0.0073  0.1471  0.0000  0.0707  0.0523 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0058  0.0110  0.0271  0.0230  0.0010  0.0431  0.0082  0.0899  0.0001 </r>
+        <r>  0.0058  0.0110  0.0271  0.0229  0.0010  0.0432  0.0082  0.0898  0.0001 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0121  0.0000  0.0058  0.0173  0.0481  0.0000  0.0231  0.1227 </r>
+        <r>  0.0000  0.0121  0.0000  0.0058  0.0173  0.0481  0.0000  0.0231  0.1231 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0029  0.0000  0.0014  0.0124  0.1070  0.0000  0.0514  0.0881 </r>
+        <r>  0.0000  0.0029  0.0000  0.0014  0.0125  0.1070  0.0000  0.0513  0.0885 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0537  0.0170  0.0030  0.0353  0.0134  0.0113  0.0236  0.0234  0.0019 </r>
+        <r>  0.0536  0.0169  0.0030  0.0353  0.0132  0.0112  0.0237  0.0236  0.0019 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0099  0.0008  0.0023  0.0017  0.0214  0.0220  0.0259  0.0457  0.0030 </r>
+        <r>  0.0099  0.0008  0.0023  0.0017  0.0215  0.0219  0.0258  0.0457  0.0030 </r>
+       </set>
+      </set>
+      <set comment="kpoint 31">
+       <set comment="band 1">
+        <r>  0.3905  0.0077  0.0026  0.0030  0.0007  0.0000  0.0002  0.0000  0.0001 </r>
+        <r>  0.3903  0.0077  0.0025  0.0030  0.0007  0.0000  0.0002  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4254  0.0140  0.0021  0.0029  0.0017  0.0000  0.0004  0.0002  0.0005 </r>
+        <r>  0.4254  0.0140  0.0021  0.0029  0.0017  0.0000  0.0004  0.0002  0.0005 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0046  0.0674  0.1469  0.1007  0.0033  0.0006  0.0002  0.0019  0.0010 </r>
+        <r>  0.0046  0.0674  0.1469  0.1006  0.0032  0.0006  0.0002  0.0019  0.0010 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0173  0.1724  0.0148  0.1204  0.0016  0.0007  0.0046  0.0010  0.0039 </r>
+        <r>  0.0174  0.1723  0.0148  0.1205  0.0016  0.0007  0.0046  0.0010  0.0039 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0136  0.0507  0.1700  0.0818  0.0032  0.0001  0.0023  0.0030  0.0008 </r>
+        <r>  0.0136  0.0508  0.1700  0.0817  0.0032  0.0001  0.0023  0.0030  0.0008 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0339  0.0989  0.0049  0.2142  0.0083  0.0010  0.0085  0.0005  0.0072 </r>
+        <r>  0.0338  0.0993  0.0048  0.2138  0.0084  0.0010  0.0085  0.0005  0.0072 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0129  0.0538  0.1773  0.0372  0.0150  0.0063  0.0094  0.0083  0.0005 </r>
+        <r>  0.0130  0.0534  0.1773  0.0377  0.0149  0.0063  0.0094  0.0083  0.0005 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0048  0.1104  0.0485  0.0822  0.0138  0.0014  0.0294  0.0044  0.0055 </r>
+        <r>  0.0048  0.1105  0.0485  0.0821  0.0138  0.0014  0.0294  0.0044  0.0055 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0305  0.0864  0.0101  0.0103  0.0020  0.0554  0.0181  0.0045 </r>
+        <r>  0.0000  0.0305  0.0864  0.0101  0.0103  0.0020  0.0553  0.0181  0.0045 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0004  0.0031  0.0192  0.0066  0.0227  0.0394  0.0130  0.0594  0.0452 </r>
+        <r>  0.0004  0.0031  0.0192  0.0066  0.0227  0.0393  0.0130  0.0595  0.0453 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0516  0.0428  0.0030  0.0021  0.0390  0.0527  0.0146  0.0201  0.0031 </r>
+        <r>  0.0515  0.0428  0.0029  0.0021  0.0390  0.0527  0.0146  0.0200  0.0031 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0018  0.0329  0.0146  0.0034  0.0279  0.0516  0.0016  0.0550  0.0842 </r>
+        <r>  0.0019  0.0329  0.0147  0.0033  0.0279  0.0516  0.0016  0.0549  0.0843 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0035  0.0363  0.0276  0.0030  0.0080  0.0702  0.0009  0.0727  0.0141 </r>
+        <r>  0.0035  0.0362  0.0276  0.0030  0.0080  0.0701  0.0009  0.0727  0.0141 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0014  0.0040  0.0025  0.0002  0.0063  0.0146  0.0350  0.0195  0.0399 </r>
+        <r>  0.0014  0.0040  0.0025  0.0001  0.0062  0.0146  0.0350  0.0195  0.0398 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0187  0.0053  0.0008  0.0082  0.0039  0.1857  0.0095  0.0040  0.0754 </r>
+        <r>  0.0186  0.0053  0.0009  0.0082  0.0039  0.1857  0.0095  0.0040  0.0755 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0195  0.0170  0.0078  0.0104  0.0021  0.0797  0.0044  0.0183  0.0919 </r>
+        <r>  0.0194  0.0170  0.0078  0.0104  0.0021  0.0796  0.0044  0.0184  0.0920 </r>
+       </set>
+      </set>
+      <set comment="kpoint 32">
+       <set comment="band 1">
+        <r>  0.3888  0.0024  0.0024  0.0050  0.0004  0.0000  0.0001  0.0000  0.0001 </r>
+        <r>  0.3886  0.0024  0.0024  0.0050  0.0004  0.0000  0.0001  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4367  0.0045  0.0029  0.0093  0.0014  0.0000  0.0003  0.0001  0.0002 </r>
+        <r>  0.4368  0.0045  0.0029  0.0093  0.0014  0.0000  0.0003  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0049  0.0101  0.2955  0.0210  0.0024  0.0014  0.0001  0.0029  0.0003 </r>
+        <r>  0.0049  0.0101  0.2954  0.0210  0.0024  0.0014  0.0001  0.0029  0.0003 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2354  0.0000  0.1130  0.0005  0.0016  0.0000  0.0008  0.0035 </r>
+        <r>  0.0000  0.2353  0.0000  0.1130  0.0005  0.0016  0.0000  0.0008  0.0035 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0226  0.0805  0.0387  0.1677  0.0098  0.0001  0.0045  0.0003  0.0014 </r>
+        <r>  0.0226  0.0805  0.0387  0.1677  0.0098  0.0001  0.0045  0.0003  0.0014 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0333  0.1014  0.0001  0.2111  0.0097  0.0007  0.0064  0.0014  0.0014 </r>
+        <r>  0.0333  0.1014  0.0001  0.2112  0.0097  0.0007  0.0064  0.0014  0.0014 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0058  0.0001  0.2423  0.0003  0.0173  0.0020  0.0304  0.0041  0.0024 </r>
+        <r>  0.0058  0.0001  0.2423  0.0003  0.0173  0.0020  0.0304  0.0041  0.0024 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2225  0.0000  0.1068  0.0006  0.0087  0.0000  0.0042  0.0042 </r>
+        <r>  0.0000  0.2225  0.0000  0.1068  0.0006  0.0088  0.0000  0.0042  0.0042 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0037  0.0005  0.0744  0.0011  0.0157  0.0035  0.0651  0.0072  0.0022 </r>
+        <r>  0.0037  0.0005  0.0744  0.0011  0.0157  0.0034  0.0650  0.0072  0.0022 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0120  0.0015  0.0237  0.0031  0.0304  0.0469  0.0132  0.0976  0.0043 </r>
+        <r>  0.0119  0.0015  0.0237  0.0031  0.0304  0.0469  0.0132  0.0976  0.0043 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0160  0.0000  0.0077  0.0226  0.0302  0.0000  0.0145  0.1605 </r>
+        <r>  0.0000  0.0160  0.0000  0.0077  0.0226  0.0301  0.0000  0.0145  0.1606 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0727  0.0091  0.0284  0.0189  0.0269  0.0053  0.0182  0.0111  0.0038 </r>
+        <r>  0.0726  0.0091  0.0284  0.0189  0.0268  0.0053  0.0182  0.0111  0.0038 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0063  0.0000  0.0030  0.0029  0.1789  0.0000  0.0859  0.0205 </r>
+        <r>  0.0000  0.0063  0.0000  0.0030  0.0029  0.1788  0.0000  0.0859  0.0205 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0001  0.0004  0.0031  0.0009  0.0148  0.0075  0.0474  0.0156  0.0021 </r>
+        <r>  0.0001  0.0004  0.0031  0.0009  0.0147  0.0075  0.0474  0.0156  0.0021 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0087  0.0289  0.0005  0.0602  0.1451  0.0031  0.0528  0.0064  0.0204 </r>
+        <r>  0.0087  0.0289  0.0005  0.0601  0.1451  0.0031  0.0529  0.0064  0.0204 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0064  0.0000  0.0031  0.0143  0.0710  0.0000  0.0341  0.1016 </r>
+        <r>  0.0000  0.0064  0.0000  0.0031  0.0144  0.0709  0.0000  0.0341  0.1021 </r>
+       </set>
+      </set>
+      <set comment="kpoint 33">
+       <set comment="band 1">
+        <r>  0.3898  0.0007  0.0047  0.0014  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.3896  0.0007  0.0047  0.0014  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4311  0.0020  0.0142  0.0042  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.4311  0.0020  0.0142  0.0042  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0421  0.0291  0.2047  0.0607  0.0006  0.0019  0.0027  0.0039  0.0001 </r>
+        <r>  0.0421  0.0291  0.2049  0.0606  0.0006  0.0019  0.0027  0.0039  0.0001 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0071  0.0677  0.2867  0.0079  0.0034  0.0001  0.0001  0.0001 </r>
+        <r>  0.0000  0.0071  0.0675  0.2867  0.0078  0.0034  0.0001  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.3198  0.0428  0.0002  0.0017  0.0019  0.0000  0.0029  0.0047 </r>
+        <r>  0.0000  0.3197  0.0428  0.0002  0.0017  0.0019  0.0000  0.0029  0.0046 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0325  0.0283  0.1980  0.0589  0.0012  0.0039  0.0056  0.0082  0.0002 </r>
+        <r>  0.0325  0.0283  0.1979  0.0589  0.0012  0.0039  0.0056  0.0082  0.0002 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0275  0.0862  0.1885  0.0216  0.0019  0.0032  0.0002  0.0022 </r>
+        <r>  0.0000  0.0275  0.0862  0.1885  0.0218  0.0016  0.0032  0.0004  0.0020 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2448  0.0063  0.0512  0.0009  0.0166  0.0002  0.0088  0.0025 </r>
+        <r>  0.0000  0.2449  0.0063  0.0512  0.0007  0.0169  0.0002  0.0086  0.0027 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0167  0.0015  0.0105  0.0031  0.0062  0.0209  0.0296  0.0435  0.0009 </r>
+        <r>  0.0167  0.0015  0.0105  0.0031  0.0062  0.0209  0.0296  0.0435  0.0009 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0031  0.0021  0.0020  0.0159  0.0245  0.0942  0.0452  0.0251 </r>
+        <r>  0.0000  0.0031  0.0021  0.0020  0.0152  0.0251  0.0942  0.0447  0.0256 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0034  0.0001  0.0037  0.0367  0.0013  0.0056  0.0053  0.1558 </r>
+        <r>  0.0000  0.0034  0.0001  0.0037  0.0373  0.0007  0.0056  0.0059  0.1555 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0469  0.0039  0.0271  0.0081  0.0015  0.0050  0.0071  0.0105  0.0002 </r>
+        <r>  0.0468  0.0039  0.0271  0.0081  0.0015  0.0050  0.0071  0.0105  0.0002 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0425  0.0061  0.0425  0.0126  0.0036  0.0120  0.0170  0.0249  0.0005 </r>
+        <r>  0.0424  0.0061  0.0425  0.0126  0.0036  0.0120  0.0170  0.0250  0.0005 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0108  0.0094  0.0113  0.1891  0.0059  0.0714  0.0014  0.0274 </r>
+        <r>  0.0000  0.0108  0.0094  0.0113  0.1881  0.0068  0.0713  0.0005  0.0284 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0176  0.0002  0.0136  0.0046  0.1925  0.0016  0.0950  0.0015 </r>
+        <r>  0.0000  0.0176  0.0002  0.0136  0.0056  0.1914  0.0016  0.0958  0.0006 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0171  0.0023  0.0000  0.0122  0.0537  0.0589  0.0018  0.0994 </r>
+        <r>  0.0000  0.0171  0.0023  0.0000  0.0123  0.0537  0.0590  0.0018  0.0995 </r>
+       </set>
+      </set>
+      <set comment="kpoint 34">
+       <set comment="band 1">
+        <r>  0.3898  0.0003  0.0046  0.0055  0.0000  0.0001  0.0000  0.0000  0.0000 </r>
+        <r>  0.3897  0.0003  0.0046  0.0055  0.0000  0.0001  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4200  0.0004  0.0100  0.0128  0.0001  0.0004  0.0001  0.0001  0.0000 </r>
+        <r>  0.4200  0.0004  0.0100  0.0128  0.0001  0.0004  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0043  0.1009  0.1634  0.0587  0.0031  0.0017  0.0025  0.0022  0.0009 </r>
+        <r>  0.0043  0.1008  0.1634  0.0586  0.0031  0.0017  0.0025  0.0022  0.0009 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2465  0.0837  0.0346  0.0094  0.0018  0.0011  0.0027  0.0042 </r>
+        <r>  0.0000  0.2464  0.0837  0.0346  0.0094  0.0018  0.0011  0.0027  0.0042 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0487  0.0028  0.0570  0.2337  0.0016  0.0065  0.0012  0.0010  0.0016 </r>
+        <r>  0.0488  0.0028  0.0570  0.2336  0.0016  0.0065  0.0012  0.0010  0.0016 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0386  0.0044  0.0900  0.1781  0.0027  0.0091  0.0022  0.0006  0.0005 </r>
+        <r>  0.0386  0.0044  0.0899  0.1782  0.0027  0.0091  0.0022  0.0006  0.0005 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.1954  0.0663  0.0275  0.0152  0.0062  0.0063  0.0018  0.0022 </r>
+        <r>  0.0000  0.1954  0.0664  0.0274  0.0152  0.0062  0.0063  0.0018  0.0022 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0003  0.1006  0.1530  0.0606  0.0103  0.0013  0.0051  0.0123  0.0008 </r>
+        <r>  0.0003  0.1006  0.1530  0.0606  0.0103  0.0013  0.0051  0.0123  0.0008 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0044  0.0162  0.0240  0.0114  0.0175  0.0143  0.0410  0.0149  0.0088 </r>
+        <r>  0.0044  0.0163  0.0240  0.0114  0.0175  0.0143  0.0409  0.0149  0.0088 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0008  0.0003  0.0001  0.0065  0.0208  0.0715  0.0345  0.0704 </r>
+        <r>  0.0000  0.0008  0.0003  0.0001  0.0064  0.0207  0.0715  0.0346  0.0704 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0177  0.0009  0.0079  0.0206  0.0162  0.0218  0.0013  0.0525  0.0753 </r>
+        <r>  0.0177  0.0009  0.0079  0.0206  0.0162  0.0219  0.0013  0.0524  0.0754 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0368  0.0020  0.0172  0.0079  0.0267  0.0848  0.0119  0.0513  0.0152 </r>
+        <r>  0.0368  0.0020  0.0172  0.0079  0.0267  0.0847  0.0119  0.0512  0.0153 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0035  0.0010  0.0021  0.0105  0.0254  0.0064  0.0309  0.0115  0.0185 </r>
+        <r>  0.0035  0.0010  0.0021  0.0106  0.0253  0.0064  0.0309  0.0116  0.0186 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0142  0.0004  0.0322  0.0693  0.0221  0.0636  0.0111  0.0223  0.0044 </r>
+        <r>  0.0142  0.0004  0.0322  0.0693  0.0221  0.0636  0.0111  0.0223  0.0044 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0306  0.0104  0.0043  0.1382  0.0528  0.0512  0.0188  0.0238 </r>
+        <r>  0.0000  0.0306  0.0104  0.0043  0.1381  0.0528  0.0512  0.0188  0.0238 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0339  0.0004  0.0017  0.0048  0.0004  0.0025  0.0044  0.1431  0.0926 </r>
+        <r>  0.0339  0.0004  0.0017  0.0048  0.0004  0.0025  0.0044  0.1431  0.0926 </r>
+       </set>
+      </set>
+      <set comment="kpoint 35">
+       <set comment="band 1">
+        <r>  0.3906  0.0005  0.0038  0.0120  0.0001  0.0003  0.0000  0.0001  0.0000 </r>
+        <r>  0.3905  0.0005  0.0038  0.0120  0.0001  0.0003  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4098  0.0007  0.0032  0.0195  0.0005  0.0009  0.0001  0.0003  0.0000 </r>
+        <r>  0.4098  0.0007  0.0032  0.0195  0.0005  0.0009  0.0001  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0008  0.0956  0.1630  0.0504  0.0017  0.0027  0.0034  0.0008  0.0013 </r>
+        <r>  0.0008  0.0955  0.1630  0.0504  0.0017  0.0027  0.0034  0.0008  0.0013 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2321  0.0789  0.0326  0.0120  0.0035  0.0027  0.0023  0.0032 </r>
+        <r>  0.0000  0.2321  0.0788  0.0326  0.0120  0.0035  0.0027  0.0023  0.0032 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0510  0.0050  0.0575  0.1712  0.0034  0.0098  0.0013  0.0003  0.0014 </r>
+        <r>  0.0511  0.0050  0.0574  0.1712  0.0034  0.0098  0.0013  0.0003  0.0014 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0528  0.0001  0.0900  0.2108  0.0048  0.0046  0.0001  0.0006  0.0034 </r>
+        <r>  0.0528  0.0001  0.0900  0.2110  0.0048  0.0046  0.0001  0.0006  0.0034 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2051  0.0696  0.0289  0.0134  0.0085  0.0111  0.0007  0.0007 </r>
+        <r>  0.0000  0.2051  0.0697  0.0288  0.0134  0.0085  0.0111  0.0007  0.0007 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0043  0.1016  0.1734  0.0414  0.0042  0.0042  0.0071  0.0083  0.0021 </r>
+        <r>  0.0043  0.1016  0.1734  0.0414  0.0042  0.0042  0.0071  0.0083  0.0021 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0009  0.0179  0.0196  0.0205  0.0237  0.0248  0.0452  0.0113  0.0134 </r>
+        <r>  0.0009  0.0179  0.0197  0.0205  0.0237  0.0248  0.0452  0.0113  0.0134 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0028  0.0009  0.0004  0.0090  0.0175  0.0643  0.0356  0.0717 </r>
+        <r>  0.0000  0.0027  0.0009  0.0004  0.0089  0.0175  0.0642  0.0357  0.0716 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0130  0.0038  0.0051  0.0687  0.0037  0.0136  0.0021  0.0471  0.0250 </r>
+        <r>  0.0129  0.0038  0.0051  0.0687  0.0037  0.0136  0.0021  0.0471  0.0250 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0229  0.0053  0.0144  0.0139  0.0314  0.0811  0.0079  0.0420  0.0126 </r>
+        <r>  0.0229  0.0053  0.0144  0.0139  0.0313  0.0810  0.0079  0.0420  0.0126 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0128  0.0007  0.0147  0.0169  0.0089  0.0283  0.0015  0.1065  0.0899 </r>
+        <r>  0.0128  0.0007  0.0147  0.0169  0.0089  0.0284  0.0015  0.1064  0.0900 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0038  0.0017  0.0003  0.0164  0.0339  0.0016  0.0352  0.0104  0.0378 </r>
+        <r>  0.0038  0.0017  0.0003  0.0164  0.0338  0.0016  0.0352  0.0104  0.0379 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0333  0.0113  0.0047  0.1304  0.0502  0.0488  0.0175  0.0221 </r>
+        <r>  0.0000  0.0333  0.0113  0.0046  0.1305  0.0502  0.0489  0.0175  0.0221 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0299  0.0007  0.0186  0.0651  0.0210  0.0449  0.0092  0.1113  0.0261 </r>
+        <r>  0.0299  0.0007  0.0186  0.0651  0.0210  0.0448  0.0092  0.1113  0.0261 </r>
+       </set>
+      </set>
+      <set comment="kpoint 36">
+       <set comment="band 1">
+        <r>  0.3966  0.0010  0.0024  0.0187  0.0003  0.0006  0.0001  0.0003  0.0001 </r>
+        <r>  0.3965  0.0010  0.0024  0.0187  0.0003  0.0006  0.0001  0.0003  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3967  0.0027  0.0002  0.0206  0.0005  0.0009  0.0001  0.0005  0.0000 </r>
+        <r>  0.3967  0.0027  0.0002  0.0206  0.0005  0.0009  0.0001  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0080  0.0905  0.1602  0.0426  0.0006  0.0043  0.0036  0.0002  0.0014 </r>
+        <r>  0.0080  0.0904  0.1602  0.0426  0.0006  0.0043  0.0036  0.0002  0.0014 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2254  0.0766  0.0317  0.0087  0.0036  0.0037  0.0011  0.0013 </r>
+        <r>  0.0000  0.2253  0.0765  0.0317  0.0087  0.0036  0.0037  0.0011  0.0013 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0496  0.0038  0.0689  0.1730  0.0047  0.0072  0.0005  0.0002  0.0022 </r>
+        <r>  0.0496  0.0038  0.0688  0.1731  0.0047  0.0072  0.0005  0.0002  0.0022 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0506  0.0002  0.0906  0.1859  0.0071  0.0059  0.0006  0.0012  0.0046 </r>
+        <r>  0.0506  0.0002  0.0906  0.1860  0.0071  0.0059  0.0006  0.0011  0.0045 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2076  0.0704  0.0292  0.0152  0.0115  0.0162  0.0006  0.0006 </r>
+        <r>  0.0000  0.2075  0.0705  0.0292  0.0153  0.0115  0.0162  0.0006  0.0006 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0138  0.0928  0.1687  0.0304  0.0006  0.0183  0.0109  0.0042  0.0038 </r>
+        <r>  0.0138  0.0927  0.1688  0.0304  0.0006  0.0183  0.0109  0.0042  0.0038 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0061  0.0156  0.0101  0.0419  0.0258  0.0268  0.0379  0.0151  0.0205 </r>
+        <r>  0.0061  0.0155  0.0101  0.0419  0.0257  0.0269  0.0378  0.0151  0.0206 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0014  0.0044  0.0074  0.0468  0.0070  0.0038  0.0051  0.0560  0.0393 </r>
+        <r>  0.0014  0.0044  0.0073  0.0468  0.0069  0.0038  0.0052  0.0560  0.0393 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0108  0.0037  0.0016  0.0113  0.0142  0.0562  0.0356  0.0712 </r>
+        <r>  0.0000  0.0108  0.0037  0.0015  0.0112  0.0142  0.0562  0.0359  0.0708 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0091  0.0293  0.0257  0.0598  0.0062  0.0661  0.0214  0.0098  0.0059 </r>
+        <r>  0.0091  0.0292  0.0258  0.0599  0.0064  0.0657  0.0216  0.0098  0.0059 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0085  0.0028  0.0159  0.0308  0.0008  0.0237  0.0057  0.1093  0.0600 </r>
+        <r>  0.0086  0.0027  0.0160  0.0309  0.0008  0.0236  0.0056  0.1092  0.0601 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0265  0.0091  0.0034  0.0296  0.0070  0.0375  0.0431  0.0818 </r>
+        <r>  0.0000  0.0262  0.0089  0.0037  0.0298  0.0072  0.0377  0.0433  0.0807 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0255  0.0015  0.0008  0.0183  0.1294  0.0270  0.0262  0.1678  0.0021 </r>
+        <r>  0.0254  0.0014  0.0008  0.0185  0.1245  0.0280  0.0278  0.1697  0.0024 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0008  0.0269  0.0075  0.0109  0.1096  0.0381  0.0197  0.0302  0.0348 </r>
+        <r>  0.0008  0.0291  0.0095  0.0066  0.1456  0.0268  0.0195  0.0196  0.0223 </r>
+       </set>
+      </set>
+      <set comment="kpoint 37">
+       <set comment="band 1">
+        <r>  0.3967  0.0023  0.0004  0.0171  0.0006  0.0007  0.0000  0.0005  0.0000 </r>
+        <r>  0.3965  0.0023  0.0004  0.0171  0.0006  0.0007  0.0000  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3971  0.0037  0.0011  0.0216  0.0002  0.0010  0.0002  0.0003  0.0001 </r>
+        <r>  0.3971  0.0037  0.0011  0.0216  0.0002  0.0010  0.0002  0.0003  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0182  0.0879  0.1546  0.0378  0.0002  0.0059  0.0031  0.0007  0.0012 </r>
+        <r>  0.0182  0.0877  0.1547  0.0378  0.0002  0.0059  0.0031  0.0007  0.0012 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2269  0.0772  0.0319  0.0049  0.0027  0.0034  0.0005  0.0007 </r>
+        <r>  0.0000  0.2270  0.0771  0.0319  0.0049  0.0027  0.0034  0.0005  0.0007 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0400  0.0020  0.0806  0.1865  0.0048  0.0043  0.0004  0.0002  0.0025 </r>
+        <r>  0.0400  0.0020  0.0806  0.1865  0.0048  0.0043  0.0004  0.0002  0.0025 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0396  0.0006  0.0907  0.1745  0.0080  0.0087  0.0017  0.0031  0.0052 </r>
+        <r>  0.0396  0.0006  0.0907  0.1746  0.0080  0.0087  0.0017  0.0031  0.0052 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2027  0.0688  0.0285  0.0160  0.0133  0.0193  0.0004  0.0004 </r>
+        <r>  0.0000  0.2026  0.0689  0.0285  0.0160  0.0133  0.0193  0.0004  0.0004 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0216  0.0903  0.1654  0.0292  0.0003  0.0195  0.0111  0.0039  0.0046 </r>
+        <r>  0.0216  0.0903  0.1654  0.0292  0.0003  0.0195  0.0111  0.0039  0.0046 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0058  0.0011  0.0047  0.0255  0.0071  0.0147  0.0002  0.0480  0.0485 </r>
+        <r>  0.0058  0.0011  0.0047  0.0255  0.0071  0.0147  0.0002  0.0480  0.0485 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0017  0.0225  0.0062  0.0839  0.0309  0.0105  0.0349  0.0248  0.0084 </r>
+        <r>  0.0017  0.0225  0.0062  0.0839  0.0308  0.0105  0.0348  0.0249  0.0084 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0279  0.0095  0.0040  0.0026  0.0173  0.0576  0.0247  0.0512 </r>
+        <r>  0.0000  0.0281  0.0095  0.0039  0.0025  0.0173  0.0572  0.0247  0.0511 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0052  0.0221  0.0116  0.0627  0.0207  0.0301  0.0506  0.0354  0.0028 </r>
+        <r>  0.0052  0.0220  0.0117  0.0628  0.0206  0.0299  0.0508  0.0353  0.0027 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0197  0.0067  0.0028  0.0319  0.0082  0.0433  0.0479  0.0909 </r>
+        <r>  0.0000  0.0196  0.0067  0.0028  0.0317  0.0083  0.0435  0.0479  0.0908 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0058  0.0006  0.0299  0.0503  0.0015  0.0377  0.0166  0.0901  0.0319 </r>
+        <r>  0.0058  0.0006  0.0299  0.0503  0.0015  0.0377  0.0165  0.0899  0.0319 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0187  0.0064  0.0026  0.1869  0.0491  0.0385  0.0430  0.0640 </r>
+        <r>  0.0000  0.0188  0.0064  0.0026  0.1866  0.0491  0.0386  0.0431  0.0641 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0713  0.0012  0.0098  0.0119  0.0014  0.0337  0.0266  0.0726  0.0645 </r>
+        <r>  0.0713  0.0012  0.0098  0.0119  0.0014  0.0337  0.0268  0.0726  0.0646 </r>
+       </set>
+      </set>
+      <set comment="kpoint 38">
+       <set comment="band 1">
+        <r>  0.3903  0.0030  0.0017  0.0100  0.0003  0.0004  0.0000  0.0003  0.0000 </r>
+        <r>  0.3902  0.0030  0.0017  0.0100  0.0003  0.0004  0.0000  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4165  0.0041  0.0006  0.0190  0.0004  0.0013  0.0003  0.0004  0.0001 </r>
+        <r>  0.4165  0.0041  0.0006  0.0190  0.0004  0.0013  0.0003  0.0004  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0295  0.0653  0.1168  0.0971  0.0023  0.0048  0.0012  0.0022  0.0001 </r>
+        <r>  0.0295  0.0648  0.1173  0.0972  0.0023  0.0048  0.0012  0.0022  0.0001 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2309  0.0785  0.0325  0.0023  0.0016  0.0026  0.0005  0.0009 </r>
+        <r>  0.0000  0.2310  0.0784  0.0324  0.0023  0.0016  0.0026  0.0005  0.0009 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0163  0.0231  0.1260  0.1494  0.0023  0.0042  0.0019  0.0005  0.0029 </r>
+        <r>  0.0163  0.0233  0.1256  0.1494  0.0023  0.0042  0.0019  0.0005  0.0028 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0300  0.0744  0.1300  0.0797  0.0023  0.0224  0.0103  0.0001  0.0027 </r>
+        <r>  0.0300  0.0743  0.1300  0.0798  0.0023  0.0224  0.0103  0.0001  0.0027 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0218  0.0216  0.1159  0.1327  0.0044  0.0048  0.0000  0.0134  0.0102 </r>
+        <r>  0.0219  0.0216  0.1160  0.1327  0.0044  0.0048  0.0000  0.0134  0.0102 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2062  0.0701  0.0290  0.0128  0.0115  0.0171  0.0001  0.0001 </r>
+        <r>  0.0000  0.2063  0.0700  0.0290  0.0128  0.0115  0.0171  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0080  0.0015  0.0118  0.0228  0.0100  0.0129  0.0003  0.0384  0.0448 </r>
+        <r>  0.0080  0.0015  0.0118  0.0228  0.0100  0.0129  0.0003  0.0384  0.0448 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0106  0.0092  0.0021  0.0458  0.0324  0.0329  0.0555  0.0463  0.0043 </r>
+        <r>  0.0106  0.0092  0.0021  0.0458  0.0324  0.0328  0.0555  0.0463  0.0043 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0272  0.0093  0.0038  0.0298  0.0188  0.0569  0.0372  0.0716 </r>
+        <r>  0.0000  0.0272  0.0092  0.0038  0.0297  0.0189  0.0569  0.0371  0.0715 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0255  0.0167  0.0054  0.1110  0.0158  0.0114  0.0043  0.0304  0.0013 </r>
+        <r>  0.0255  0.0167  0.0054  0.1111  0.0158  0.0114  0.0044  0.0304  0.0013 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0265  0.0090  0.0037  0.0720  0.0499  0.0716  0.0073  0.0112 </r>
+        <r>  0.0000  0.0266  0.0090  0.0037  0.0719  0.0498  0.0715  0.0073  0.0111 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0250  0.0103  0.0168  0.0108  0.0044  0.0376  0.0464  0.0142  0.0311 </r>
+        <r>  0.0250  0.0104  0.0168  0.0107  0.0036  0.0380  0.0455  0.0126  0.0339 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0033  0.0009  0.0004  0.1265  0.0052  0.0075  0.0734  0.1275 </r>
+        <r>  0.0000  0.0032  0.0009  0.0005  0.1265  0.0047  0.0084  0.0751  0.1252 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0256  0.0024  0.0045  0.0039  0.0413  0.0220  0.0545  0.0102  0.0375 </r>
+        <r>  0.0255  0.0023  0.0045  0.0039  0.0418  0.0220  0.0546  0.0102  0.0372 </r>
+       </set>
+      </set>
+      <set comment="kpoint 39">
+       <set comment="band 1">
+        <r>  0.3913  0.0022  0.0053  0.0046  0.0002  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.3912  0.0022  0.0053  0.0046  0.0002  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4135  0.0036  0.0130  0.0075  0.0005  0.0000  0.0003  0.0000  0.0001 </r>
+        <r>  0.4135  0.0036  0.0130  0.0075  0.0005  0.0000  0.0003  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0233  0.0198  0.2384  0.0413  0.0067  0.0017  0.0018  0.0036  0.0009 </r>
+        <r>  0.0233  0.0198  0.2383  0.0413  0.0067  0.0017  0.0018  0.0036  0.0009 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2330  0.0000  0.1119  0.0006  0.0041  0.0000  0.0020  0.0042 </r>
+        <r>  0.0000  0.2328  0.0000  0.1118  0.0006  0.0041  0.0000  0.0020  0.0042 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0257  0.0710  0.0625  0.1479  0.0105  0.0002  0.0041  0.0004  0.0015 </r>
+        <r>  0.0257  0.0710  0.0625  0.1479  0.0105  0.0002  0.0041  0.0004  0.0015 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0344  0.0893  0.0354  0.1860  0.0083  0.0015  0.0075  0.0030  0.0012 </r>
+        <r>  0.0344  0.0893  0.0354  0.1860  0.0083  0.0014  0.0075  0.0030  0.0012 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0163  0.0153  0.2535  0.0317  0.0171  0.0013  0.0038  0.0026  0.0024 </r>
+        <r>  0.0163  0.0152  0.2535  0.0317  0.0171  0.0013  0.0038  0.0026  0.0024 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2103  0.0000  0.1010  0.0006  0.0197  0.0000  0.0095  0.0043 </r>
+        <r>  0.0000  0.2104  0.0000  0.1010  0.0006  0.0197  0.0000  0.0095  0.0043 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0074  0.0006  0.0220  0.0013  0.0214  0.0016  0.0863  0.0033  0.0030 </r>
+        <r>  0.0074  0.0006  0.0221  0.0013  0.0213  0.0016  0.0863  0.0033  0.0030 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0053  0.0046  0.0136  0.0095  0.0052  0.0489  0.0161  0.1018  0.0007 </r>
+        <r>  0.0053  0.0046  0.0135  0.0095  0.0052  0.0489  0.0161  0.1018  0.0007 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0156  0.0000  0.0075  0.0252  0.0016  0.0000  0.0008  0.1793 </r>
+        <r>  0.0000  0.0156  0.0000  0.0075  0.0252  0.0016  0.0000  0.0008  0.1794 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0534  0.0049  0.0709  0.0102  0.0400  0.0013  0.0254  0.0028  0.0056 </r>
+        <r>  0.0533  0.0049  0.0710  0.0102  0.0399  0.0013  0.0254  0.0028  0.0056 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0226  0.0000  0.0109  0.0003  0.1785  0.0000  0.0857  0.0020 </r>
+        <r>  0.0000  0.0227  0.0000  0.0109  0.0003  0.1783  0.0000  0.0856  0.0020 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0009  0.0001  0.0083  0.0002  0.0198  0.0102  0.0451  0.0213  0.0028 </r>
+        <r>  0.0009  0.0001  0.0082  0.0002  0.0198  0.0102  0.0450  0.0212  0.0028 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0091  0.0252  0.0065  0.0526  0.0508  0.0378  0.0172  0.0786  0.0071 </r>
+        <r>  0.0091  0.0252  0.0065  0.0525  0.0507  0.0378  0.0173  0.0787  0.0071 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0091  0.0000  0.0044  0.0211  0.0559  0.0000  0.0268  0.1502 </r>
+        <r>  0.0000  0.0091  0.0000  0.0044  0.0211  0.0559  0.0000  0.0268  0.1503 </r>
+       </set>
+      </set>
+      <set comment="kpoint 40">
+       <set comment="band 1">
+        <r>  0.3934  0.0005  0.0055  0.0095  0.0004  0.0001  0.0001  0.0000  0.0001 </r>
+        <r>  0.3933  0.0005  0.0055  0.0095  0.0004  0.0001  0.0001  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4114  0.0001  0.0087  0.0117  0.0012  0.0003  0.0004  0.0001  0.0001 </r>
+        <r>  0.4114  0.0001  0.0087  0.0117  0.0012  0.0003  0.0004  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0053  0.0729  0.1591  0.0746  0.0047  0.0018  0.0024  0.0017  0.0003 </r>
+        <r>  0.0053  0.0728  0.1590  0.0746  0.0046  0.0017  0.0024  0.0017  0.0003 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0153  0.1693  0.0018  0.1255  0.0065  0.0014  0.0019  0.0014  0.0021 </r>
+        <r>  0.0153  0.1693  0.0018  0.1254  0.0065  0.0014  0.0019  0.0014  0.0021 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0251  0.0827  0.1479  0.0760  0.0033  0.0046  0.0021  0.0006  0.0028 </r>
+        <r>  0.0251  0.0826  0.1479  0.0760  0.0033  0.0046  0.0021  0.0006  0.0028 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0312  0.0853  0.1235  0.0743  0.0032  0.0137  0.0040  0.0013  0.0040 </r>
+        <r>  0.0312  0.0853  0.1235  0.0743  0.0032  0.0137  0.0040  0.0013  0.0040 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0213  0.1329  0.0176  0.1743  0.0180  0.0044  0.0047  0.0024  0.0005 </r>
+        <r>  0.0213  0.1329  0.0176  0.1744  0.0180  0.0044  0.0047  0.0024  0.0005 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0001  0.0976  0.1294  0.0451  0.0169  0.0021  0.0228  0.0056  0.0028 </r>
+        <r>  0.0001  0.0976  0.1294  0.0451  0.0169  0.0021  0.0228  0.0056  0.0028 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0025  0.0245  0.0513  0.0238  0.0168  0.0038  0.0719  0.0037  0.0011 </r>
+        <r>  0.0025  0.0245  0.0513  0.0238  0.0167  0.0038  0.0719  0.0037  0.0011 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0063  0.0118  0.0060  0.0039  0.0378  0.0119  0.0546  0.0722 </r>
+        <r>  0.0000  0.0063  0.0118  0.0060  0.0039  0.0376  0.0120  0.0547  0.0722 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0329  0.0047  0.0210  0.0269  0.0187  0.0407  0.0092  0.0461  0.0208 </r>
+        <r>  0.0328  0.0047  0.0210  0.0268  0.0186  0.0407  0.0092  0.0460  0.0208 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0123  0.0013  0.0067  0.0225  0.0199  0.0771  0.0038  0.0005  0.0272 </r>
+        <r>  0.0123  0.0013  0.0067  0.0225  0.0199  0.0770  0.0038  0.0005  0.0272 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0043  0.0003  0.0179  0.0257  0.0087  0.0162  0.0020  0.1053  0.1164 </r>
+        <r>  0.0043  0.0004  0.0179  0.0257  0.0087  0.0162  0.0020  0.1051  0.1165 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0229  0.0112  0.0114  0.0072  0.0284  0.0294  0.0224  0.1132  0.0044 </r>
+        <r>  0.0229  0.0112  0.0114  0.0072  0.0282  0.0293  0.0225  0.1133  0.0044 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0054  0.0043  0.0131  0.0014  0.0446  0.0569  0.0323  0.0291  0.0096 </r>
+        <r>  0.0054  0.0044  0.0131  0.0014  0.0446  0.0568  0.0322  0.0290  0.0097 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0106  0.0274  0.0030  0.0070  0.0008  0.0891  0.0017  0.0110  0.0870 </r>
+        <r>  0.0105  0.0274  0.0030  0.0070  0.0008  0.0891  0.0017  0.0110  0.0871 </r>
+       </set>
+      </set>
+      <set comment="kpoint 41">
+       <set comment="band 1">
+        <r>  0.3992  0.0001  0.0049  0.0141  0.0008  0.0003  0.0003  0.0001  0.0002 </r>
+        <r>  0.3991  0.0001  0.0049  0.0141  0.0008  0.0003  0.0003  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4066  0.0015  0.0025  0.0139  0.0015  0.0007  0.0003  0.0003  0.0001 </r>
+        <r>  0.4066  0.0015  0.0025  0.0138  0.0015  0.0007  0.0003  0.0003  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0013  0.0836  0.1535  0.0623  0.0020  0.0022  0.0033  0.0004  0.0006 </r>
+        <r>  0.0013  0.0835  0.1535  0.0623  0.0020  0.0022  0.0033  0.0004  0.0006 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0160  0.1318  0.0034  0.1522  0.0064  0.0003  0.0017  0.0006  0.0003 </r>
+        <r>  0.0160  0.1318  0.0034  0.1522  0.0064  0.0003  0.0017  0.0006  0.0003 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0255  0.0926  0.1829  0.0494  0.0011  0.0062  0.0040  0.0026  0.0039 </r>
+        <r>  0.0255  0.0925  0.1828  0.0493  0.0011  0.0062  0.0040  0.0025  0.0039 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0320  0.1062  0.1141  0.0433  0.0012  0.0187  0.0013  0.0002  0.0025 </r>
+        <r>  0.0320  0.1063  0.1142  0.0433  0.0012  0.0187  0.0013  0.0002  0.0025 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0202  0.1275  0.0020  0.1949  0.0260  0.0002  0.0081  0.0021  0.0010 </r>
+        <r>  0.0202  0.1274  0.0020  0.1950  0.0260  0.0002  0.0081  0.0021  0.0010 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0042  0.0988  0.1599  0.0379  0.0102  0.0029  0.0175  0.0029  0.0049 </r>
+        <r>  0.0042  0.0989  0.1599  0.0378  0.0102  0.0029  0.0175  0.0029  0.0049 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0011  0.0246  0.0330  0.0224  0.0219  0.0184  0.0824  0.0003  0.0012 </r>
+        <r>  0.0011  0.0246  0.0330  0.0224  0.0218  0.0184  0.0824  0.0003  0.0011 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0036  0.0028  0.0064  0.0396  0.0047  0.0099  0.0002  0.0518  0.0539 </r>
+        <r>  0.0036  0.0028  0.0064  0.0396  0.0047  0.0099  0.0002  0.0518  0.0540 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0030  0.0042  0.0120  0.0127  0.0090  0.0314  0.0125  0.0543  0.0730 </r>
+        <r>  0.0030  0.0042  0.0120  0.0127  0.0089  0.0313  0.0125  0.0544  0.0730 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0332  0.0059  0.0063  0.0306  0.0232  0.0940  0.0065  0.0176  0.0023 </r>
+        <r>  0.0332  0.0059  0.0063  0.0306  0.0231  0.0939  0.0065  0.0175  0.0023 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0022  0.0006  0.0196  0.0374  0.0104  0.0165  0.0058  0.1012  0.0701 </r>
+        <r>  0.0023  0.0006  0.0196  0.0374  0.0104  0.0165  0.0057  0.1010  0.0701 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0139  0.0053  0.0024  0.0249  0.0231  0.0136  0.0015  0.1543  0.0473 </r>
+        <r>  0.0139  0.0053  0.0024  0.0249  0.0231  0.0136  0.0015  0.1544  0.0473 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0060  0.0296  0.0027  0.0003  0.0117  0.0455  0.0155  0.0686  0.0987 </r>
+        <r>  0.0060  0.0295  0.0027  0.0003  0.0118  0.0455  0.0156  0.0687  0.0992 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0195  0.0230  0.0145  0.0054  0.0940  0.0636  0.0133  0.0368  0.0284 </r>
+        <r>  0.0192  0.0228  0.0145  0.0056  0.0957  0.0646  0.0138  0.0364  0.0279 </r>
+       </set>
+      </set>
+      <set comment="kpoint 42">
+       <set comment="band 1">
+        <r>  0.4060  0.0026  0.0016  0.0143  0.0011  0.0008  0.0002  0.0005  0.0001 </r>
+        <r>  0.4058  0.0026  0.0016  0.0143  0.0011  0.0008  0.0002  0.0004  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4000  0.0048  0.0018  0.0135  0.0011  0.0007  0.0004  0.0003  0.0001 </r>
+        <r>  0.4001  0.0047  0.0018  0.0135  0.0011  0.0007  0.0004  0.0003  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0095  0.0861  0.1536  0.0466  0.0002  0.0028  0.0036  0.0005  0.0008 </r>
+        <r>  0.0095  0.0859  0.1536  0.0466  0.0002  0.0028  0.0036  0.0005  0.0008 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0096  0.1199  0.0008  0.1762  0.0044  0.0002  0.0008  0.0003  0.0008 </r>
+        <r>  0.0096  0.1199  0.0008  0.1762  0.0044  0.0002  0.0008  0.0003  0.0008 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0263  0.0977  0.1752  0.0437  0.0002  0.0076  0.0024  0.0026  0.0026 </r>
+        <r>  0.0263  0.0976  0.1751  0.0437  0.0002  0.0076  0.0024  0.0026  0.0026 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0288  0.0892  0.1376  0.0428  0.0008  0.0171  0.0068  0.0018  0.0014 </r>
+        <r>  0.0288  0.0892  0.1376  0.0428  0.0008  0.0171  0.0068  0.0018  0.0014 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0093  0.1205  0.0011  0.1796  0.0226  0.0039  0.0114  0.0059  0.0076 </r>
+        <r>  0.0092  0.1204  0.0011  0.1797  0.0226  0.0039  0.0114  0.0059  0.0076 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0146  0.1011  0.1782  0.0326  0.0025  0.0142  0.0082  0.0054  0.0052 </r>
+        <r>  0.0146  0.1013  0.1782  0.0324  0.0025  0.0142  0.0082  0.0054  0.0052 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0067  0.0160  0.0005  0.0405  0.0071  0.0151  0.0001  0.0412  0.0464 </r>
+        <r>  0.0067  0.0159  0.0005  0.0405  0.0071  0.0151  0.0001  0.0412  0.0464 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0019  0.0249  0.0024  0.0309  0.0379  0.0109  0.0853  0.0006  0.0045 </r>
+        <r>  0.0019  0.0249  0.0024  0.0309  0.0378  0.0109  0.0853  0.0006  0.0044 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0042  0.0022  0.0062  0.0522  0.0234  0.0105  0.0210  0.0417  0.0311 </r>
+        <r>  0.0042  0.0021  0.0062  0.0522  0.0234  0.0105  0.0210  0.0417  0.0311 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0025  0.0059  0.0175  0.0445  0.0030  0.0553  0.0072  0.0383  0.0445 </r>
+        <r>  0.0025  0.0059  0.0175  0.0445  0.0030  0.0552  0.0072  0.0384  0.0445 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0266  0.0152  0.0085  0.0212  0.1024  0.0184  0.0404  0.0389  0.0426 </r>
+        <r>  0.0266  0.0152  0.0085  0.0213  0.1021  0.0184  0.0406  0.0387  0.0424 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0165  0.0406  0.0092  0.0165  0.0079  0.0210  0.0468  0.1025  0.0171 </r>
+        <r>  0.0165  0.0406  0.0092  0.0165  0.0079  0.0210  0.0467  0.1027  0.0172 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0142  0.0020  0.0183  0.0153  0.0253  0.0246  0.0064  0.0555  0.1616 </r>
+        <r>  0.0145  0.0020  0.0183  0.0153  0.0247  0.0247  0.0065  0.0547  0.1621 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0260  0.0152  0.0080  0.0018  0.1402  0.0582  0.0551  0.0839  0.0029 </r>
+        <r>  0.0257  0.0152  0.0081  0.0019  0.1405  0.0579  0.0548  0.0843  0.0031 </r>
+       </set>
+      </set>
+      <set comment="kpoint 43">
+       <set comment="band 1">
+        <r>  0.3955  0.0070  0.0004  0.0086  0.0008  0.0007  0.0000  0.0004  0.0001 </r>
+        <r>  0.3954  0.0070  0.0004  0.0086  0.0008  0.0007  0.0000  0.0004  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4143  0.0082  0.0015  0.0111  0.0009  0.0011  0.0006  0.0004  0.0002 </r>
+        <r>  0.4143  0.0082  0.0015  0.0111  0.0009  0.0011  0.0006  0.0004  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0110  0.1015  0.0658  0.1277  0.0019  0.0012  0.0009  0.0004  0.0006 </r>
+        <r>  0.0110  0.1014  0.0658  0.1279  0.0019  0.0012  0.0009  0.0004  0.0006 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0109  0.0935  0.0839  0.1139  0.0007  0.0028  0.0025  0.0018  0.0024 </r>
+        <r>  0.0109  0.0936  0.0839  0.1138  0.0007  0.0028  0.0025  0.0018  0.0024 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0202  0.1017  0.1768  0.0444  0.0001  0.0041  0.0027  0.0025  0.0015 </r>
+        <r>  0.0202  0.1017  0.1767  0.0444  0.0001  0.0041  0.0027  0.0025  0.0015 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0229  0.0736  0.1487  0.0463  0.0004  0.0183  0.0085  0.0044  0.0013 </r>
+        <r>  0.0229  0.0735  0.1487  0.0463  0.0004  0.0183  0.0085  0.0044  0.0013 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0254  0.0937  0.1708  0.0461  0.0006  0.0180  0.0116  0.0053  0.0014 </r>
+        <r>  0.0254  0.0935  0.1709  0.0463  0.0006  0.0180  0.0116  0.0053  0.0014 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0007  0.0857  0.0031  0.1122  0.0126  0.0074  0.0066  0.0255  0.0261 </r>
+        <r>  0.0007  0.0859  0.0031  0.1121  0.0126  0.0074  0.0066  0.0255  0.0261 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0042  0.0599  0.0017  0.1070  0.0050  0.0082  0.0013  0.0183  0.0345 </r>
+        <r>  0.0042  0.0599  0.0017  0.1070  0.0050  0.0082  0.0013  0.0183  0.0346 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0119  0.0194  0.0003  0.0406  0.0919  0.0071  0.0015  0.0350  0.0315 </r>
+        <r>  0.0120  0.0194  0.0003  0.0404  0.0916  0.0071  0.0016  0.0351  0.0314 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0015  0.0241  0.0037  0.0385  0.0096  0.0330  0.0584  0.0295  0.0124 </r>
+        <r>  0.0015  0.0241  0.0037  0.0386  0.0095  0.0330  0.0582  0.0294  0.0125 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0237  0.0077  0.0032  0.0129  0.0398  0.0151  0.0833  0.0192  0.0027 </r>
+        <r>  0.0237  0.0077  0.0032  0.0130  0.0398  0.0151  0.0833  0.0192  0.0027 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0055  0.0486  0.0063  0.0166  0.0384  0.0132  0.1106  0.0126  0.0208 </r>
+        <r>  0.0055  0.0485  0.0063  0.0165  0.0382  0.0132  0.1106  0.0125  0.0206 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0036  0.0082  0.0057  0.0123  0.1153  0.0166  0.0136  0.0497  0.0618 </r>
+        <r>  0.0037  0.0082  0.0057  0.0123  0.1151  0.0166  0.0136  0.0498  0.0619 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0535  0.0089  0.0413  0.0033  0.0448  0.1008  0.0165  0.0107  0.0009 </r>
+        <r>  0.0533  0.0090  0.0413  0.0033  0.0449  0.1009  0.0165  0.0106  0.0009 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0031  0.0095  0.0040  0.0088  0.0149  0.0560  0.0005  0.1058  0.1319 </r>
+        <r>  0.0031  0.0095  0.0040  0.0087  0.0149  0.0560  0.0005  0.1057  0.1327 </r>
+       </set>
+      </set>
+      <set comment="kpoint 44">
+       <set comment="band 1">
+        <r>  0.3982  0.0027  0.0068  0.0056  0.0010  0.0000  0.0003  0.0000  0.0001 </r>
+        <r>  0.3980  0.0027  0.0068  0.0056  0.0010  0.0000  0.0003  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4129  0.0020  0.0107  0.0041  0.0018  0.0000  0.0008  0.0000  0.0003 </r>
+        <r>  0.4129  0.0020  0.0107  0.0041  0.0018  0.0000  0.0008  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0138  0.0678  0.0781  0.1413  0.0057  0.0009  0.0020  0.0018  0.0008 </r>
+        <r>  0.0138  0.0678  0.0781  0.1413  0.0057  0.0009  0.0020  0.0018  0.0008 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2262  0.0000  0.1086  0.0003  0.0036  0.0000  0.0017  0.0024 </r>
+        <r>  0.0000  0.2260  0.0000  0.1086  0.0003  0.0036  0.0000  0.0017  0.0024 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0260  0.0214  0.2165  0.0447  0.0045  0.0004  0.0016  0.0009  0.0006 </r>
+        <r>  0.0261  0.0215  0.2165  0.0446  0.0045  0.0004  0.0016  0.0009  0.0006 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0254  0.0158  0.2249  0.0329  0.0062  0.0014  0.0279  0.0028  0.0009 </r>
+        <r>  0.0254  0.0158  0.2249  0.0329  0.0062  0.0014  0.0279  0.0028  0.0009 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2223  0.0000  0.1067  0.0006  0.0219  0.0000  0.0105  0.0045 </r>
+        <r>  0.0000  0.2223  0.0000  0.1068  0.0006  0.0219  0.0000  0.0105  0.0045 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0186  0.0838  0.0210  0.1746  0.0394  0.0007  0.0069  0.0015  0.0055 </r>
+        <r>  0.0186  0.0838  0.0210  0.1746  0.0394  0.0007  0.0069  0.0015  0.0055 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0110  0.0126  0.0752  0.0262  0.0093  0.0016  0.0704  0.0034  0.0013 </r>
+        <r>  0.0110  0.0126  0.0752  0.0263  0.0093  0.0017  0.0703  0.0034  0.0013 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0090  0.0150  0.0358  0.0313  0.0047  0.0180  0.0041  0.0374  0.0007 </r>
+        <r>  0.0090  0.0150  0.0357  0.0313  0.0047  0.0180  0.0041  0.0375  0.0007 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0201  0.0000  0.0097  0.0189  0.0477  0.0000  0.0229  0.1345 </r>
+        <r>  0.0000  0.0201  0.0000  0.0096  0.0190  0.0476  0.0000  0.0228  0.1348 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0078  0.0062  0.0475  0.0128  0.0230  0.0425  0.0161  0.0883  0.0032 </r>
+        <r>  0.0078  0.0062  0.0475  0.0129  0.0229  0.0423  0.0162  0.0882  0.0032 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0202  0.0000  0.0097  0.0131  0.0093  0.0000  0.0045  0.0933 </r>
+        <r>  0.0000  0.0202  0.0000  0.0097  0.0131  0.0093  0.0000  0.0045  0.0931 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0752  0.0023  0.0129  0.0047  0.0290  0.0438  0.0149  0.0913  0.0041 </r>
+        <r>  0.0750  0.0023  0.0129  0.0047  0.0289  0.0439  0.0149  0.0914  0.0041 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0045  0.0000  0.0021  0.0129  0.1861  0.0000  0.0894  0.0914 </r>
+        <r>  0.0000  0.0045  0.0000  0.0022  0.0129  0.1859  0.0000  0.0893  0.0917 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0004  0.0004  0.0042  0.0008  0.0138  0.0044  0.0466  0.0092  0.0020 </r>
+        <r>  0.0004  0.0004  0.0042  0.0008  0.0138  0.0044  0.0466  0.0091  0.0019 </r>
+       </set>
+      </set>
+      <set comment="kpoint 45">
+       <set comment="band 1">
+        <r>  0.4045  0.0002  0.0073  0.0074  0.0016  0.0001  0.0005  0.0000  0.0003 </r>
+        <r>  0.4043  0.0002  0.0073  0.0074  0.0016  0.0001  0.0005  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4142  0.0006  0.0067  0.0060  0.0024  0.0002  0.0008  0.0001  0.0002 </r>
+        <r>  0.4143  0.0006  0.0067  0.0060  0.0024  0.0002  0.0008  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0056  0.0816  0.0488  0.1589  0.0035  0.0010  0.0016  0.0010  0.0001 </r>
+        <r>  0.0056  0.0816  0.0487  0.1589  0.0035  0.0010  0.0016  0.0010  0.0001 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0043  0.1284  0.0997  0.0756  0.0012  0.0007  0.0013  0.0006  0.0004 </r>
+        <r>  0.0043  0.1284  0.0997  0.0756  0.0012  0.0007  0.0013  0.0006  0.0004 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0225  0.1053  0.1545  0.0520  0.0021  0.0042  0.0011  0.0016  0.0020 </r>
+        <r>  0.0225  0.1053  0.1545  0.0520  0.0021  0.0042  0.0011  0.0016  0.0020 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0247  0.0956  0.1636  0.0354  0.0034  0.0152  0.0059  0.0022  0.0024 </r>
+        <r>  0.0247  0.0957  0.1636  0.0354  0.0033  0.0152  0.0059  0.0022  0.0024 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0006  0.0757  0.0483  0.0362  0.0181  0.0068  0.0596  0.0021  0.0053 </r>
+        <r>  0.0006  0.0756  0.0483  0.0363  0.0180  0.0067  0.0595  0.0021  0.0053 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0145  0.1195  0.0107  0.1910  0.0293  0.0002  0.0039  0.0087  0.0007 </r>
+        <r>  0.0145  0.1197  0.0108  0.1909  0.0292  0.0002  0.0039  0.0087  0.0007 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0024  0.0704  0.1180  0.0823  0.0041  0.0012  0.0371  0.0011  0.0005 </r>
+        <r>  0.0024  0.0704  0.1180  0.0823  0.0041  0.0012  0.0371  0.0011  0.0005 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0028  0.0103  0.0043  0.0378  0.0043  0.0146  0.0002  0.0475  0.0534 </r>
+        <r>  0.0028  0.0103  0.0043  0.0378  0.0043  0.0146  0.0002  0.0475  0.0534 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0353  0.0065  0.0124  0.0053  0.0331  0.0948  0.0127  0.0324  0.0204 </r>
+        <r>  0.0352  0.0065  0.0124  0.0053  0.0331  0.0946  0.0127  0.0325  0.0204 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0053  0.0083  0.0132  0.0035  0.0003  0.0325  0.0041  0.0567  0.0385 </r>
+        <r>  0.0053  0.0083  0.0132  0.0035  0.0003  0.0325  0.0041  0.0566  0.0384 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0180  0.0099  0.0027  0.0070  0.0010  0.0986  0.0034  0.0009  0.1078 </r>
+        <r>  0.0179  0.0099  0.0027  0.0070  0.0010  0.0987  0.0034  0.0009  0.1081 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0071  0.0007  0.0141  0.0478  0.0789  0.0086  0.0179  0.0207  0.0261 </r>
+        <r>  0.0072  0.0007  0.0141  0.0477  0.0789  0.0086  0.0179  0.0205  0.0263 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0264  0.0137  0.0258  0.0167  0.0242  0.0663  0.0110  0.1741  0.0026 </r>
+        <r>  0.0263  0.0137  0.0259  0.0168  0.0242  0.0662  0.0110  0.1740  0.0026 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0483  0.0109  0.0017  0.0058  0.0956  0.0471  0.0272  0.0999  0.0769 </r>
+        <r>  0.0487  0.0109  0.0018  0.0058  0.0943  0.0466  0.0273  0.0976  0.0783 </r>
+       </set>
+      </set>
+      <set comment="kpoint 46">
+       <set comment="band 1">
+        <r>  0.4109  0.0020  0.0062  0.0072  0.0018  0.0004  0.0006  0.0002  0.0003 </r>
+        <r>  0.4107  0.0020  0.0062  0.0072  0.0018  0.0004  0.0006  0.0002  0.0003 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4097  0.0056  0.0020  0.0064  0.0022  0.0005  0.0005  0.0003  0.0002 </r>
+        <r>  0.4098  0.0055  0.0020  0.0064  0.0022  0.0005  0.0005  0.0003  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0023  0.0944  0.0159  0.1802  0.0014  0.0007  0.0009  0.0009  0.0010 </r>
+        <r>  0.0023  0.0943  0.0159  0.1803  0.0014  0.0007  0.0009  0.0009  0.0010 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0024  0.1044  0.1361  0.0563  0.0002  0.0007  0.0025  0.0000  0.0001 </r>
+        <r>  0.0024  0.1044  0.1361  0.0562  0.0002  0.0007  0.0025  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0249  0.0936  0.1771  0.0509  0.0014  0.0046  0.0041  0.0041  0.0016 </r>
+        <r>  0.0249  0.0935  0.1771  0.0509  0.0014  0.0046  0.0041  0.0041  0.0016 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0304  0.1097  0.1339  0.0383  0.0023  0.0157  0.0014  0.0033  0.0006 </r>
+        <r>  0.0304  0.1097  0.1339  0.0383  0.0023  0.0157  0.0014  0.0034  0.0006 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0039  0.0724  0.1004  0.0409  0.0172  0.0006  0.0465  0.0014  0.0058 </r>
+        <r>  0.0039  0.0722  0.1004  0.0410  0.0172  0.0006  0.0465  0.0014  0.0057 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0016  0.1010  0.0023  0.1752  0.0178  0.0073  0.0049  0.0157  0.0154 </r>
+        <r>  0.0016  0.1011  0.0023  0.1750  0.0178  0.0073  0.0050  0.0157  0.0154 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0020  0.0591  0.0940  0.0343  0.0130  0.0084  0.0510  0.0063  0.0030 </r>
+        <r>  0.0020  0.0592  0.0941  0.0343  0.0129  0.0084  0.0509  0.0063  0.0030 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0022  0.0472  0.0008  0.0926  0.0035  0.0170  0.0005  0.0275  0.0429 </r>
+        <r>  0.0022  0.0471  0.0008  0.0927  0.0035  0.0170  0.0005  0.0275  0.0430 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0227  0.0014  0.0064  0.0359  0.0196  0.1015  0.0114  0.0020  0.0265 </r>
+        <r>  0.0227  0.0014  0.0064  0.0359  0.0195  0.1013  0.0113  0.0020  0.0264 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0356  0.0122  0.0033  0.0170  0.0833  0.0266  0.0424  0.0362  0.0034 </r>
+        <r>  0.0355  0.0122  0.0034  0.0170  0.0833  0.0265  0.0424  0.0362  0.0034 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0285  0.0048  0.0134  0.0021  0.0918  0.0164  0.0189  0.0805  0.0018 </r>
+        <r>  0.0285  0.0048  0.0134  0.0021  0.0917  0.0164  0.0189  0.0805  0.0018 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0198  0.0073  0.0071  0.0044  0.0090  0.0639  0.0002  0.0189  0.0465 </r>
+        <r>  0.0198  0.0073  0.0071  0.0044  0.0090  0.0638  0.0002  0.0189  0.0464 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0015  0.0044  0.0019  0.0046  0.0177  0.0252  0.0037  0.1167  0.1172 </r>
+        <r>  0.0015  0.0043  0.0019  0.0046  0.0177  0.0250  0.0036  0.1159  0.1172 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0011  0.0033  0.0023  0.0016  0.0055  0.0364  0.0098  0.1107  0.1411 </r>
+        <r>  0.0011  0.0034  0.0023  0.0016  0.0056  0.0365  0.0099  0.1111  0.1418 </r>
+       </set>
+      </set>
+      <set comment="kpoint 47">
+       <set comment="band 1">
+        <r>  0.4035  0.0099  0.0004  0.0061  0.0013  0.0007  0.0001  0.0005  0.0002 </r>
+        <r>  0.4034  0.0099  0.0004  0.0061  0.0013  0.0007  0.0001  0.0005  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4099  0.0112  0.0034  0.0035  0.0015  0.0008  0.0007  0.0002  0.0002 </r>
+        <r>  0.4099  0.0112  0.0034  0.0035  0.0015  0.0008  0.0007  0.0002  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0019  0.1014  0.0593  0.1374  0.0005  0.0003  0.0006  0.0002  0.0007 </r>
+        <r>  0.0019  0.1013  0.0593  0.1375  0.0005  0.0003  0.0006  0.0002  0.0007 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0105  0.0830  0.0922  0.1099  0.0002  0.0014  0.0031  0.0016  0.0026 </r>
+        <r>  0.0105  0.0830  0.0922  0.1098  0.0002  0.0014  0.0031  0.0016  0.0026 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0236  0.0861  0.1873  0.0539  0.0004  0.0034  0.0030  0.0070  0.0013 </r>
+        <r>  0.0236  0.0860  0.1871  0.0539  0.0004  0.0034  0.0030  0.0070  0.0013 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0292  0.0975  0.1281  0.0336  0.0023  0.0140  0.0072  0.0039  0.0000 </r>
+        <r>  0.0292  0.0975  0.1282  0.0336  0.0023  0.0140  0.0072  0.0039  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0178  0.0947  0.1836  0.0548  0.0006  0.0110  0.0102  0.0084  0.0007 </r>
+        <r>  0.0178  0.0942  0.1835  0.0554  0.0006  0.0111  0.0102  0.0083  0.0007 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0034  0.0725  0.0024  0.1637  0.0065  0.0093  0.0045  0.0206  0.0233 </r>
+        <r>  0.0034  0.0730  0.0024  0.1631  0.0065  0.0093  0.0045  0.0207  0.0233 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0008  0.0591  0.0008  0.1011  0.0084  0.0115  0.0042  0.0195  0.0467 </r>
+        <r>  0.0008  0.0591  0.0008  0.1011  0.0083  0.0115  0.0042  0.0195  0.0467 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0009  0.0408  0.0027  0.0137  0.0472  0.0074  0.0767  0.0026  0.0065 </r>
+        <r>  0.0009  0.0408  0.0027  0.0137  0.0470  0.0074  0.0766  0.0026  0.0064 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0023  0.0088  0.0006  0.0209  0.0129  0.0453  0.0078  0.0701  0.0346 </r>
+        <r>  0.0023  0.0088  0.0006  0.0210  0.0129  0.0452  0.0078  0.0700  0.0345 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0314  0.0166  0.0038  0.0006  0.0652  0.0043  0.0634  0.0025  0.0121 </r>
+        <r>  0.0315  0.0166  0.0038  0.0006  0.0650  0.0043  0.0634  0.0025  0.0121 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0178  0.0022  0.0131  0.0052  0.1013  0.0446  0.0034  0.0344  0.0166 </r>
+        <r>  0.0177  0.0022  0.0131  0.0052  0.1012  0.0445  0.0035  0.0344  0.0166 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0243  0.0543  0.0148  0.0223  0.0010  0.0900  0.0431  0.0340  0.0038 </r>
+        <r>  0.0243  0.0543  0.0148  0.0223  0.0010  0.0900  0.0431  0.0339  0.0038 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0019  0.0009  0.0037  0.0141  0.0109  0.0132  0.0074  0.1133  0.1645 </r>
+        <r>  0.0019  0.0009  0.0038  0.0141  0.0107  0.0131  0.0077  0.1137  0.1643 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0258  0.0183  0.0108  0.0115  0.1128  0.1191  0.0576  0.0209  0.0407 </r>
+        <r>  0.0256  0.0183  0.0107  0.0116  0.1126  0.1192  0.0573  0.0207  0.0412 </r>
+       </set>
+      </set>
+      <set comment="kpoint 48">
+       <set comment="band 1">
+        <r>  0.4104  0.0008  0.0089  0.0017  0.0023  0.0000  0.0007  0.0000  0.0003 </r>
+        <r>  0.4102  0.0008  0.0089  0.0017  0.0023  0.0000  0.0007  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4156  0.0015  0.0085  0.0031  0.0027  0.0000  0.0010  0.0000  0.0004 </r>
+        <r>  0.4157  0.0015  0.0085  0.0031  0.0027  0.0000  0.0010  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0019  0.0869  0.0191  0.1809  0.0008  0.0005  0.0010  0.0011  0.0001 </r>
+        <r>  0.0019  0.0869  0.0191  0.1809  0.0008  0.0005  0.0010  0.0011  0.0001 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2246  0.0000  0.1078  0.0001  0.0034  0.0000  0.0016  0.0007 </r>
+        <r>  0.0000  0.2244  0.0000  0.1078  0.0001  0.0034  0.0000  0.0016  0.0007 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0244  0.0046  0.2744  0.0097  0.0042  0.0003  0.0007  0.0007  0.0006 </r>
+        <r>  0.0244  0.0047  0.2744  0.0097  0.0042  0.0003  0.0007  0.0007  0.0006 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0128  0.0005  0.2054  0.0010  0.0173  0.0002  0.0486  0.0004  0.0024 </r>
+        <r>  0.0128  0.0005  0.2054  0.0010  0.0172  0.0002  0.0485  0.0004  0.0024 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2321  0.0000  0.1115  0.0003  0.0246  0.0000  0.0118  0.0018 </r>
+        <r>  0.0000  0.2321  0.0000  0.1115  0.0003  0.0245  0.0000  0.0118  0.0018 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0220  0.0021  0.1242  0.0044  0.0192  0.0008  0.0473  0.0016  0.0027 </r>
+        <r>  0.0220  0.0021  0.1242  0.0044  0.0191  0.0008  0.0472  0.0016  0.0027 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0016  0.1251  0.0065  0.2605  0.0036  0.0025  0.0071  0.0053  0.0005 </r>
+        <r>  0.0016  0.1251  0.0065  0.2605  0.0036  0.0025  0.0071  0.0053  0.0005 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0002  0.0256  0.0005  0.0534  0.0052  0.0306  0.0015  0.0636  0.0007 </r>
+        <r>  0.0002  0.0257  0.0005  0.0534  0.0052  0.0305  0.0015  0.0636  0.0007 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0006  0.0000  0.0003  0.0195  0.0032  0.0000  0.0016  0.1387 </r>
+        <r>  0.0000  0.0007  0.0000  0.0003  0.0196  0.0032  0.0000  0.0015  0.1391 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0385  0.0005  0.0457  0.0010  0.1121  0.0001  0.0321  0.0003  0.0158 </r>
+        <r>  0.0387  0.0005  0.0455  0.0010  0.1116  0.0001  0.0320  0.0003  0.0157 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0250  0.0000  0.0120  0.0009  0.2548  0.0000  0.1223  0.0062 </r>
+        <r>  0.0000  0.0250  0.0000  0.0120  0.0009  0.2544  0.0000  0.1222  0.0062 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0945  0.0002  0.0443  0.0003  0.0527  0.0069  0.0134  0.0144  0.0074 </r>
+        <r>  0.0941  0.0002  0.0445  0.0003  0.0529  0.0069  0.0135  0.0144  0.0074 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0181  0.0000  0.0087  0.0094  0.0132  0.0000  0.0063  0.0666 </r>
+        <r>  0.0000  0.0181  0.0000  0.0087  0.0095  0.0131  0.0000  0.0063  0.0675 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0276  0.0030  0.0121  0.0062  0.0430  0.0829  0.0259  0.1727  0.0060 </r>
+        <r>  0.0276  0.0030  0.0122  0.0062  0.0428  0.0826  0.0258  0.1720  0.0060 </r>
+       </set>
+      </set>
+      <set comment="kpoint 49">
+       <set comment="band 1">
+        <r>  0.4114  0.0019  0.0083  0.0011  0.0024  0.0001  0.0007  0.0001  0.0003 </r>
+        <r>  0.4112  0.0019  0.0082  0.0011  0.0024  0.0001  0.0007  0.0001  0.0003 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4134  0.0046  0.0062  0.0051  0.0025  0.0002  0.0007  0.0002  0.0004 </r>
+        <r>  0.4134  0.0045  0.0062  0.0051  0.0025  0.0002  0.0007  0.0002  0.0004 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0044  0.0905  0.0067  0.1868  0.0003  0.0004  0.0009  0.0010  0.0006 </r>
+        <r>  0.0045  0.0905  0.0067  0.1868  0.0003  0.0004  0.0009  0.0010  0.0006 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0023  0.1093  0.1416  0.0567  0.0010  0.0012  0.0014  0.0001  0.0005 </r>
+        <r>  0.0023  0.1092  0.1416  0.0566  0.0010  0.0012  0.0014  0.0001  0.0005 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0212  0.1062  0.1561  0.0538  0.0025  0.0026  0.0010  0.0031  0.0006 </r>
+        <r>  0.0212  0.1061  0.1561  0.0538  0.0025  0.0026  0.0010  0.0031  0.0006 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0232  0.0815  0.1675  0.0386  0.0085  0.0098  0.0069  0.0074  0.0001 </r>
+        <r>  0.0232  0.0815  0.1674  0.0386  0.0084  0.0098  0.0069  0.0074  0.0001 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0008  0.0718  0.0308  0.0386  0.0179  0.0076  0.0634  0.0028  0.0064 </r>
+        <r>  0.0008  0.0717  0.0308  0.0386  0.0179  0.0076  0.0633  0.0028  0.0063 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0057  0.0847  0.1363  0.0396  0.0074  0.0007  0.0290  0.0042  0.0011 </r>
+        <r>  0.0057  0.0848  0.1363  0.0395  0.0073  0.0007  0.0290  0.0042  0.0011 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0050  0.1161  0.0040  0.2490  0.0056  0.0031  0.0041  0.0054  0.0039 </r>
+        <r>  0.0051  0.1161  0.0040  0.2490  0.0056  0.0031  0.0041  0.0054  0.0039 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0011  0.0275  0.0041  0.0289  0.0181  0.0278  0.0016  0.0388  0.0466 </r>
+        <r>  0.0011  0.0275  0.0041  0.0289  0.0181  0.0278  0.0016  0.0387  0.0467 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0344  0.0042  0.0130  0.0112  0.0075  0.0993  0.0089  0.0272  0.0438 </r>
+        <r>  0.0344  0.0042  0.0130  0.0112  0.0074  0.0991  0.0089  0.0272  0.0438 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0215  0.0038  0.0157  0.0268  0.0690  0.0149  0.0082  0.0399  0.0208 </r>
+        <r>  0.0214  0.0038  0.0157  0.0269  0.0690  0.0149  0.0082  0.0400  0.0209 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0215  0.0071  0.0056  0.0102  0.0460  0.0941  0.0022  0.0220  0.0067 </r>
+        <r>  0.0215  0.0071  0.0056  0.0102  0.0459  0.0941  0.0022  0.0220  0.0067 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0217  0.0194  0.0045  0.0014  0.0383  0.0060  0.0391  0.0345  0.0979 </r>
+        <r>  0.0217  0.0194  0.0045  0.0014  0.0383  0.0060  0.0391  0.0345  0.0981 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0029  0.0054  0.0021  0.0048  0.0140  0.0062  0.0061  0.1385  0.0783 </r>
+        <r>  0.0029  0.0055  0.0021  0.0047  0.0142  0.0063  0.0061  0.1389  0.0792 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0550  0.0237  0.0435  0.0124  0.0590  0.1498  0.0118  0.0292  0.0038 </r>
+        <r>  0.0547  0.0237  0.0435  0.0124  0.0592  0.1494  0.0119  0.0294  0.0037 </r>
+       </set>
+      </set>
+      <set comment="kpoint 50">
+       <set comment="band 1">
+        <r>  0.4042  0.0015  0.0076  0.0031  0.0021  0.0000  0.0006  0.0000  0.0003 </r>
+        <r>  0.4040  0.0015  0.0076  0.0031  0.0021  0.0000  0.0006  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4138  0.0031  0.0097  0.0065  0.0024  0.0000  0.0007  0.0000  0.0003 </r>
+        <r>  0.4139  0.0031  0.0097  0.0065  0.0024  0.0000  0.0007  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0131  0.0884  0.0044  0.1841  0.0019  0.0004  0.0015  0.0009  0.0003 </r>
+        <r>  0.0131  0.0884  0.0044  0.1841  0.0019  0.0004  0.0015  0.0009  0.0003 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2265  0.0000  0.1087  0.0001  0.0033  0.0000  0.0016  0.0008 </r>
+        <r>  0.0000  0.2262  0.0000  0.1087  0.0001  0.0033  0.0000  0.0016  0.0008 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0220  0.0008  0.2925  0.0017  0.0041  0.0006  0.0005  0.0011  0.0006 </r>
+        <r>  0.0220  0.0008  0.2925  0.0016  0.0041  0.0005  0.0005  0.0011  0.0006 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0154  0.0002  0.2190  0.0003  0.0194  0.0008  0.0371  0.0016  0.0027 </r>
+        <r>  0.0154  0.0002  0.2189  0.0003  0.0194  0.0008  0.0371  0.0016  0.0027 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2203  0.0000  0.1058  0.0007  0.0252  0.0000  0.0121  0.0047 </r>
+        <r>  0.0000  0.2203  0.0000  0.1058  0.0007  0.0252  0.0000  0.0121  0.0047 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0171  0.0027  0.0917  0.0057  0.0110  0.0012  0.0635  0.0025  0.0016 </r>
+        <r>  0.0172  0.0027  0.0918  0.0057  0.0110  0.0012  0.0635  0.0025  0.0015 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0170  0.1056  0.0036  0.2200  0.0212  0.0029  0.0044  0.0060  0.0030 </r>
+        <r>  0.0169  0.1056  0.0036  0.2199  0.0212  0.0029  0.0045  0.0060  0.0030 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0028  0.0216  0.0358  0.0449  0.0156  0.0244  0.0055  0.0507  0.0022 </r>
+        <r>  0.0028  0.0216  0.0358  0.0449  0.0156  0.0244  0.0055  0.0508  0.0022 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0232  0.0000  0.0111  0.0139  0.0170  0.0000  0.0082  0.0987 </r>
+        <r>  0.0000  0.0232  0.0000  0.0111  0.0139  0.0169  0.0000  0.0081  0.0988 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0180  0.0157  0.0360  0.0328  0.0316  0.0344  0.0029  0.0716  0.0045 </r>
+        <r>  0.0179  0.0158  0.0360  0.0328  0.0316  0.0344  0.0029  0.0716  0.0044 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0192  0.0000  0.0092  0.0171  0.1094  0.0000  0.0525  0.1217 </r>
+        <r>  0.0000  0.0192  0.0000  0.0092  0.0172  0.1092  0.0000  0.0525  0.1221 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0095  0.0000  0.0046  0.0116  0.1596  0.0000  0.0766  0.0822 </r>
+        <r>  0.0000  0.0095  0.0000  0.0045  0.0116  0.1595  0.0000  0.0766  0.0826 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0865  0.0041  0.0424  0.0086  0.0341  0.0145  0.0196  0.0303  0.0048 </r>
+        <r>  0.0863  0.0041  0.0424  0.0086  0.0340  0.0146  0.0197  0.0303  0.0048 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0328  0.0079  0.0063  0.0165  0.1189  0.0404  0.0877  0.0841  0.0166 </r>
+        <r>  0.0328  0.0079  0.0063  0.0164  0.1188  0.0405  0.0882  0.0843  0.0168 </r>
+       </set>
+      </set>
+      <set comment="kpoint 51">
+       <set comment="band 1">
+        <r>  0.3921  0.0014  0.0096  0.0029  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.3919  0.0014  0.0096  0.0029  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3968  0.0031  0.0214  0.0064  0.0000  0.0000  0.0000  0.0001  0.0000 </r>
+        <r>  0.3968  0.0031  0.0214  0.0064  0.0000  0.0000  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0720  0.0236  0.1646  0.0491  0.0011  0.0036  0.0051  0.0075  0.0002 </r>
+        <r>  0.0720  0.0235  0.1648  0.0489  0.0011  0.0036  0.0051  0.0075  0.0002 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0257  0.0523  0.2733  0.0113  0.0072  0.0001  0.0007  0.0005 </r>
+        <r>  0.0000  0.0256  0.0521  0.2733  0.0115  0.0070  0.0001  0.0009  0.0003 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.2915  0.0554  0.0053  0.0053  0.0028  0.0001  0.0047  0.0066 </r>
+        <r>  0.0000  0.2914  0.0553  0.0053  0.0052  0.0030  0.0001  0.0046  0.0067 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0543  0.0263  0.1842  0.0547  0.0004  0.0014  0.0020  0.0029  0.0001 </r>
+        <r>  0.0543  0.0263  0.1841  0.0549  0.0004  0.0014  0.0020  0.0029  0.0001 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.0217  0.0783  0.1924  0.0256  0.0036  0.0033  0.0007  0.0022 </r>
+        <r>  0.0000  0.0216  0.0785  0.1923  0.0257  0.0036  0.0033  0.0008  0.0021 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2417  0.0111  0.0396  0.0022  0.0188  0.0005  0.0102  0.0038 </r>
+        <r>  0.0000  0.2419  0.0110  0.0396  0.0021  0.0188  0.0005  0.0102  0.0039 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0081  0.0056  0.0394  0.0117  0.0055  0.0185  0.0263  0.0385  0.0008 </r>
+        <r>  0.0081  0.0056  0.0394  0.0117  0.0055  0.0185  0.0263  0.0385  0.0008 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0053  0.0045  0.0052  0.0160  0.0252  0.1008  0.0461  0.0143 </r>
+        <r>  0.0000  0.0053  0.0045  0.0052  0.0158  0.0252  0.1007  0.0461  0.0142 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0082  0.0001  0.0067  0.0316  0.0012  0.0024  0.0043  0.1626 </r>
+        <r>  0.0000  0.0082  0.0001  0.0067  0.0316  0.0012  0.0024  0.0043  0.1628 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0271  0.0106  0.0745  0.0222  0.0005  0.0017  0.0024  0.0036  0.0001 </r>
+        <r>  0.0271  0.0107  0.0745  0.0222  0.0005  0.0017  0.0024  0.0036  0.0001 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0088  0.0069  0.0480  0.0143  0.0071  0.0239  0.0337  0.0494  0.0010 </r>
+        <r>  0.0088  0.0069  0.0480  0.0143  0.0070  0.0237  0.0337  0.0496  0.0010 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0270  0.0155  0.0133  0.1525  0.0094  0.0319  0.0132  0.0313 </r>
+        <r>  0.0000  0.0270  0.0155  0.0133  0.1485  0.0130  0.0318  0.0096  0.0352 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0233  0.0016  0.0306  0.0248  0.1418  0.0036  0.0625  0.0078 </r>
+        <r>  0.0000  0.0233  0.0016  0.0306  0.0284  0.1385  0.0037  0.0657  0.0041 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0088  0.0017  0.0002  0.0219  0.0816  0.0956  0.0016  0.0655 </r>
+        <r>  0.0000  0.0088  0.0017  0.0002  0.0239  0.0797  0.0957  0.0035  0.0637 </r>
+       </set>
+      </set>
+      <set comment="kpoint 52">
+       <set comment="band 1">
+        <r>  0.3943  0.0008  0.0092  0.0070  0.0001  0.0001  0.0000  0.0001  0.0000 </r>
+        <r>  0.3941  0.0008  0.0092  0.0070  0.0001  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3947  0.0016  0.0165  0.0094  0.0001  0.0005  0.0001  0.0001  0.0000 </r>
+        <r>  0.3948  0.0016  0.0165  0.0094  0.0001  0.0005  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0162  0.0891  0.1399  0.0699  0.0046  0.0021  0.0021  0.0041  0.0009 </r>
+        <r>  0.0162  0.0890  0.1400  0.0699  0.0046  0.0021  0.0021  0.0041  0.0009 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2329  0.0791  0.0327  0.0139  0.0025  0.0011  0.0039  0.0059 </r>
+        <r>  0.0000  0.2328  0.0790  0.0327  0.0138  0.0025  0.0011  0.0039  0.0059 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0505  0.0112  0.0499  0.1795  0.0010  0.0118  0.0037  0.0007  0.0006 </r>
+        <r>  0.0505  0.0111  0.0498  0.1795  0.0010  0.0119  0.0037  0.0007  0.0006 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0482  0.0041  0.0753  0.2156  0.0032  0.0083  0.0009  0.0017  0.0012 </r>
+        <r>  0.0482  0.0041  0.0752  0.2158  0.0032  0.0083  0.0009  0.0017  0.0012 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2036  0.0690  0.0287  0.0152  0.0051  0.0045  0.0026  0.0036 </r>
+        <r>  0.0000  0.2035  0.0692  0.0285  0.0152  0.0050  0.0045  0.0026  0.0036 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0102  0.0961  0.1498  0.0668  0.0123  0.0056  0.0011  0.0116  0.0005 </r>
+        <r>  0.0102  0.0961  0.1497  0.0668  0.0123  0.0056  0.0011  0.0116  0.0005 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0048  0.0121  0.0352  0.0086  0.0184  0.0119  0.0394  0.0192  0.0093 </r>
+        <r>  0.0048  0.0121  0.0352  0.0086  0.0184  0.0119  0.0394  0.0192  0.0093 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0046  0.0015  0.0006  0.0045  0.0227  0.0742  0.0318  0.0656 </r>
+        <r>  0.0000  0.0046  0.0015  0.0006  0.0044  0.0227  0.0742  0.0318  0.0656 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0025  0.0044  0.0315  0.0379  0.0158  0.0038  0.0050  0.0334  0.0604 </r>
+        <r>  0.0025  0.0044  0.0315  0.0379  0.0158  0.0038  0.0050  0.0334  0.0604 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0089  0.0004  0.0090  0.0330  0.0176  0.0199  0.0010  0.0740  0.1028 </r>
+        <r>  0.0090  0.0004  0.0090  0.0329  0.0176  0.0200  0.0010  0.0739  0.1030 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0235  0.0137  0.0388  0.0054  0.0289  0.0898  0.0118  0.0323  0.0066 </r>
+        <r>  0.0234  0.0137  0.0388  0.0054  0.0288  0.0897  0.0118  0.0323  0.0066 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0034  0.0015  0.0043  0.0016  0.0156  0.0134  0.0349  0.0422  0.0033 </r>
+        <r>  0.0034  0.0015  0.0043  0.0016  0.0155  0.0134  0.0348  0.0423  0.0034 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0400  0.0136  0.0056  0.0302  0.0052  0.0290  0.0382  0.0714 </r>
+        <r>  0.0000  0.0399  0.0136  0.0056  0.0301  0.0053  0.0291  0.0382  0.0714 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0029  0.0061  0.0410  0.0192  0.0037  0.0892  0.0927  0.0184  0.0600 </r>
+        <r>  0.0029  0.0060  0.0410  0.0192  0.0037  0.0892  0.0928  0.0184  0.0602 </r>
+       </set>
+      </set>
+      <set comment="kpoint 53">
+       <set comment="band 1">
+        <r>  0.3990  0.0007  0.0075  0.0119  0.0002  0.0005  0.0000  0.0003  0.0000 </r>
+        <r>  0.3988  0.0007  0.0075  0.0119  0.0002  0.0005  0.0000  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4003  0.0004  0.0069  0.0118  0.0004  0.0012  0.0001  0.0005  0.0000 </r>
+        <r>  0.4003  0.0004  0.0069  0.0118  0.0004  0.0012  0.0001  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0025  0.0899  0.1463  0.0617  0.0025  0.0014  0.0020  0.0017  0.0011 </r>
+        <r>  0.0025  0.0898  0.1463  0.0617  0.0025  0.0014  0.0020  0.0017  0.0011 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2216  0.0753  0.0311  0.0101  0.0026  0.0019  0.0021  0.0030 </r>
+        <r>  0.0000  0.2216  0.0752  0.0312  0.0101  0.0026  0.0019  0.0021  0.0030 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0480  0.0071  0.0640  0.1730  0.0024  0.0094  0.0015  0.0000  0.0011 </r>
+        <r>  0.0480  0.0071  0.0640  0.1730  0.0024  0.0094  0.0015  0.0000  0.0011 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0545  0.0013  0.0740  0.2199  0.0031  0.0076  0.0008  0.0022  0.0024 </r>
+        <r>  0.0545  0.0012  0.0739  0.2200  0.0031  0.0076  0.0008  0.0022  0.0024 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2185  0.0742  0.0307  0.0186  0.0077  0.0082  0.0025  0.0033 </r>
+        <r>  0.0000  0.2185  0.0743  0.0307  0.0186  0.0077  0.0082  0.0025  0.0033 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0010  0.1070  0.1777  0.0505  0.0123  0.0007  0.0057  0.0103  0.0024 </r>
+        <r>  0.0010  0.1070  0.1776  0.0504  0.0123  0.0007  0.0056  0.0103  0.0024 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0004  0.0208  0.0206  0.0365  0.0148  0.0191  0.0348  0.0196  0.0226 </r>
+        <r>  0.0004  0.0208  0.0206  0.0365  0.0148  0.0191  0.0348  0.0196  0.0226 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0041  0.0058  0.0293  0.0191  0.0085  0.0038  0.0082  0.0481  0.0421 </r>
+        <r>  0.0041  0.0058  0.0293  0.0191  0.0085  0.0038  0.0082  0.0480  0.0422 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0010  0.0003  0.0001  0.0064  0.0195  0.0667  0.0323  0.0659 </r>
+        <r>  0.0000  0.0010  0.0003  0.0001  0.0063  0.0194  0.0667  0.0324  0.0658 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0420  0.0012  0.0093  0.0045  0.0361  0.1022  0.0124  0.0259  0.0029 </r>
+        <r>  0.0419  0.0012  0.0093  0.0045  0.0360  0.1021  0.0123  0.0258  0.0029 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0018  0.0004  0.0217  0.0429  0.0100  0.0221  0.0037  0.0972  0.1015 </r>
+        <r>  0.0018  0.0004  0.0217  0.0429  0.0100  0.0221  0.0037  0.0971  0.1017 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0226  0.0078  0.0032  0.0019  0.0228  0.0629  0.0165  0.0360 </r>
+        <r>  0.0000  0.0226  0.0078  0.0032  0.0019  0.0228  0.0631  0.0165  0.0360 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0129  0.0067  0.0185  0.0010  0.0316  0.0523  0.1112  0.0119  0.0344 </r>
+        <r>  0.0129  0.0066  0.0185  0.0010  0.0314  0.0521  0.1112  0.0120  0.0345 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0020  0.0060  0.0226  0.0196  0.0131  0.0283  0.0344  0.0090  0.0271 </r>
+        <r>  0.0020  0.0062  0.0224  0.0196  0.0132  0.0285  0.0341  0.0091  0.0272 </r>
+       </set>
+      </set>
+      <set comment="kpoint 54">
+       <set comment="band 1">
+        <r>  0.4087  0.0005  0.0034  0.0141  0.0006  0.0012  0.0001  0.0006  0.0000 </r>
+        <r>  0.4086  0.0005  0.0034  0.0141  0.0006  0.0012  0.0001  0.0006  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4013  0.0016  0.0017  0.0138  0.0005  0.0014  0.0002  0.0008  0.0000 </r>
+        <r>  0.4013  0.0016  0.0017  0.0138  0.0005  0.0014  0.0002  0.0008  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0016  0.0893  0.1501  0.0512  0.0007  0.0015  0.0018  0.0005  0.0010 </r>
+        <r>  0.0016  0.0891  0.1502  0.0512  0.0007  0.0015  0.0018  0.0005  0.0010 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2234  0.0759  0.0314  0.0054  0.0019  0.0018  0.0009  0.0012 </r>
+        <r>  0.0000  0.2234  0.0759  0.0314  0.0054  0.0019  0.0018  0.0009  0.0012 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0405  0.0041  0.0736  0.1857  0.0028  0.0061  0.0007  0.0000  0.0015 </r>
+        <r>  0.0405  0.0041  0.0736  0.1857  0.0028  0.0061  0.0007  0.0000  0.0015 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0412  0.0002  0.0863  0.2026  0.0049  0.0075  0.0005  0.0052  0.0061 </r>
+        <r>  0.0412  0.0002  0.0863  0.2027  0.0049  0.0075  0.0005  0.0052  0.0061 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2196  0.0746  0.0309  0.0193  0.0109  0.0137  0.0015  0.0018 </r>
+        <r>  0.0000  0.2196  0.0746  0.0309  0.0193  0.0109  0.0137  0.0015  0.0018 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0073  0.0650  0.1474  0.0114  0.0058  0.0001  0.0046  0.0176  0.0319 </r>
+        <r>  0.0073  0.0650  0.1475  0.0113  0.0058  0.0001  0.0046  0.0175  0.0319 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0062  0.0483  0.0510  0.0629  0.0035  0.0221  0.0041  0.0334  0.0208 </r>
+        <r>  0.0062  0.0483  0.0509  0.0631  0.0035  0.0221  0.0041  0.0335  0.0208 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0013  0.0210  0.0210  0.0283  0.0260  0.0212  0.0447  0.0188  0.0112 </r>
+        <r>  0.0013  0.0210  0.0210  0.0283  0.0260  0.0212  0.0447  0.0188  0.0112 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0044  0.0015  0.0006  0.0073  0.0163  0.0587  0.0314  0.0634 </r>
+        <r>  0.0000  0.0044  0.0015  0.0006  0.0072  0.0162  0.0587  0.0314  0.0633 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0294  0.0130  0.0061  0.0408  0.0180  0.0867  0.0181  0.0156  0.0009 </r>
+        <r>  0.0294  0.0130  0.0061  0.0408  0.0180  0.0867  0.0181  0.0156  0.0009 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0386  0.0130  0.0055  0.1106  0.0210  0.0144  0.0341  0.0532 </r>
+        <r>  0.0000  0.0385  0.0131  0.0054  0.1091  0.0210  0.0146  0.0340  0.0533 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0278  0.0005  0.0378  0.0788  0.0255  0.0458  0.0121  0.0129  0.0374 </r>
+        <r>  0.0278  0.0006  0.0376  0.0788  0.0257  0.0458  0.0121  0.0129  0.0373 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0144  0.0049  0.0020  0.0859  0.0573  0.0829  0.0114  0.0184 </r>
+        <r>  0.0000  0.0144  0.0050  0.0020  0.0858  0.0573  0.0832  0.0115  0.0186 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0144  0.0054  0.0071  0.0185  0.1059  0.0053  0.0444  0.1722  0.0153 </r>
+        <r>  0.0145  0.0055  0.0071  0.0185  0.1062  0.0052  0.0442  0.1712  0.0155 </r>
+       </set>
+      </set>
+      <set comment="kpoint 55">
+       <set comment="band 1">
+        <r>  0.3972  0.0026  0.0108  0.0053  0.0003  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.3971  0.0026  0.0107  0.0053  0.0003  0.0000  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3876  0.0028  0.0192  0.0058  0.0004  0.0000  0.0003  0.0000  0.0001 </r>
+        <r>  0.3877  0.0028  0.0192  0.0058  0.0004  0.0000  0.0003  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0346  0.0477  0.1281  0.0993  0.0091  0.0019  0.0029  0.0039  0.0013 </r>
+        <r>  0.0346  0.0477  0.1281  0.0993  0.0090  0.0019  0.0029  0.0039  0.0013 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2269  0.0000  0.1089  0.0006  0.0082  0.0000  0.0040  0.0041 </r>
+        <r>  0.0000  0.2266  0.0000  0.1089  0.0006  0.0082  0.0000  0.0040  0.0040 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0314  0.0428  0.1364  0.0891  0.0098  0.0005  0.0023  0.0011  0.0014 </r>
+        <r>  0.0314  0.0428  0.1364  0.0891  0.0098  0.0005  0.0023  0.0011  0.0014 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0380  0.0493  0.1396  0.1026  0.0120  0.0023  0.0068  0.0049  0.0017 </r>
+        <r>  0.0380  0.0493  0.1395  0.1027  0.0120  0.0023  0.0068  0.0049  0.0017 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2065  0.0000  0.0991  0.0006  0.0246  0.0000  0.0118  0.0043 </r>
+        <r>  0.0000  0.2065  0.0000  0.0992  0.0006  0.0246  0.0000  0.0118  0.0043 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0279  0.0521  0.1382  0.1085  0.0166  0.0008  0.0007  0.0016  0.0023 </r>
+        <r>  0.0279  0.0521  0.1382  0.1084  0.0166  0.0008  0.0007  0.0016  0.0023 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0041  0.0015  0.0404  0.0032  0.0203  0.0022  0.0879  0.0046  0.0029 </r>
+        <r>  0.0041  0.0015  0.0405  0.0032  0.0203  0.0022  0.0878  0.0046  0.0028 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0004  0.0128  0.0224  0.0267  0.0058  0.0318  0.0263  0.0662  0.0008 </r>
+        <r>  0.0004  0.0128  0.0224  0.0267  0.0058  0.0318  0.0263  0.0661  0.0008 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0181  0.0000  0.0087  0.0259  0.0033  0.0000  0.0016  0.1841 </r>
+        <r>  0.0000  0.0181  0.0000  0.0087  0.0259  0.0032  0.0000  0.0016  0.1843 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0080  0.0138  0.0419  0.0288  0.0026  0.0434  0.0054  0.0903  0.0004 </r>
+        <r>  0.0080  0.0138  0.0419  0.0288  0.0026  0.0434  0.0054  0.0903  0.0004 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0238  0.0000  0.0114  0.0171  0.0054  0.0000  0.0026  0.1215 </r>
+        <r>  0.0000  0.0238  0.0000  0.0114  0.0171  0.0054  0.0000  0.0026  0.1216 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0434  0.0005  0.0729  0.0011  0.0556  0.0196  0.0055  0.0408  0.0078 </r>
+        <r>  0.0433  0.0005  0.0729  0.0010  0.0554  0.0196  0.0055  0.0409  0.0078 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0164  0.0000  0.0079  0.0042  0.2093  0.0000  0.1005  0.0295 </r>
+        <r>  0.0000  0.0165  0.0000  0.0079  0.0042  0.2092  0.0000  0.1005  0.0296 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0009  0.0013  0.0112  0.0028  0.0191  0.0120  0.0543  0.0250  0.0027 </r>
+        <r>  0.0009  0.0013  0.0112  0.0028  0.0191  0.0120  0.0544  0.0249  0.0027 </r>
+       </set>
+      </set>
+      <set comment="kpoint 56">
+       <set comment="band 1">
+        <r>  0.4019  0.0006  0.0111  0.0081  0.0007  0.0002  0.0002  0.0001  0.0001 </r>
+        <r>  0.4017  0.0006  0.0111  0.0081  0.0007  0.0002  0.0002  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3938  0.0004  0.0139  0.0062  0.0010  0.0003  0.0004  0.0002  0.0001 </r>
+        <r>  0.3939  0.0004  0.0139  0.0062  0.0010  0.0003  0.0004  0.0002  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0145  0.0677  0.1149  0.1077  0.0062  0.0020  0.0021  0.0024  0.0001 </r>
+        <r>  0.0145  0.0676  0.1149  0.1077  0.0061  0.0020  0.0021  0.0024  0.0001 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0117  0.1540  0.0190  0.1205  0.0040  0.0013  0.0014  0.0026  0.0012 </r>
+        <r>  0.0117  0.1540  0.0190  0.1205  0.0040  0.0013  0.0014  0.0026  0.0012 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0275  0.0995  0.1490  0.0593  0.0044  0.0075  0.0006  0.0018  0.0045 </r>
+        <r>  0.0275  0.0994  0.1489  0.0593  0.0044  0.0075  0.0006  0.0018  0.0045 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0305  0.0987  0.1337  0.0446  0.0029  0.0160  0.0012  0.0007  0.0037 </r>
+        <r>  0.0305  0.0988  0.1337  0.0446  0.0028  0.0160  0.0012  0.0007  0.0037 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0186  0.1248  0.0086  0.1889  0.0140  0.0031  0.0097  0.0111  0.0004 </r>
+        <r>  0.0186  0.1247  0.0086  0.1890  0.0140  0.0031  0.0097  0.0111  0.0004 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0106  0.1008  0.1445  0.0787  0.0194  0.0065  0.0021  0.0050  0.0017 </r>
+        <r>  0.0106  0.1009  0.1444  0.0786  0.0194  0.0065  0.0021  0.0050  0.0017 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0033  0.0043  0.0283  0.0152  0.0198  0.0026  0.0867  0.0092  0.0025 </r>
+        <r>  0.0033  0.0043  0.0284  0.0152  0.0197  0.0026  0.0867  0.0092  0.0025 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0048  0.0029  0.0139  0.0291  0.0078  0.0127  0.0072  0.0420  0.0539 </r>
+        <r>  0.0048  0.0029  0.0139  0.0291  0.0078  0.0127  0.0071  0.0420  0.0540 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0014  0.0191  0.0113  0.0005  0.0007  0.0306  0.0130  0.0531  0.0608 </r>
+        <r>  0.0014  0.0190  0.0112  0.0005  0.0007  0.0305  0.0131  0.0532  0.0607 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0104  0.0282  0.0315  0.0020  0.0339  0.0219  0.0062  0.0295  0.0502 </r>
+        <r>  0.0104  0.0282  0.0315  0.0020  0.0339  0.0218  0.0062  0.0294  0.0502 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0214  0.0016  0.0150  0.0095  0.0099  0.1416  0.0082  0.0077  0.1117 </r>
+        <r>  0.0213  0.0016  0.0150  0.0094  0.0099  0.1416  0.0081  0.0076  0.1118 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0062  0.0044  0.0098  0.0441  0.0272  0.0356  0.0033  0.0573  0.0488 </r>
+        <r>  0.0062  0.0044  0.0097  0.0441  0.0272  0.0356  0.0033  0.0572  0.0489 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0284  0.0183  0.0006  0.0127  0.1047  0.0298  0.0599  0.0396  0.0299 </r>
+        <r>  0.0284  0.0183  0.0006  0.0127  0.1046  0.0298  0.0608  0.0395  0.0300 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0005  0.0088  0.0680  0.0082  0.0413  0.0440  0.0780  0.0550  0.0013 </r>
+        <r>  0.0005  0.0088  0.0680  0.0082  0.0415  0.0441  0.0778  0.0548  0.0013 </r>
+       </set>
+      </set>
+      <set comment="kpoint 57">
+       <set comment="band 1">
+        <r>  0.4088  0.0001  0.0088  0.0092  0.0010  0.0007  0.0003  0.0003  0.0001 </r>
+        <r>  0.4086  0.0001  0.0088  0.0092  0.0010  0.0007  0.0003  0.0003  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4049  0.0007  0.0058  0.0070  0.0014  0.0009  0.0004  0.0005  0.0001 </r>
+        <r>  0.4050  0.0007  0.0058  0.0070  0.0014  0.0009  0.0004  0.0005  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0009  0.0844  0.1361  0.0732  0.0023  0.0012  0.0018  0.0008  0.0005 </r>
+        <r>  0.0009  0.0843  0.1361  0.0732  0.0023  0.0012  0.0018  0.0008  0.0005 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0096  0.1263  0.0068  0.1609  0.0031  0.0006  0.0008  0.0013  0.0001 </r>
+        <r>  0.0096  0.1263  0.0068  0.1609  0.0031  0.0006  0.0008  0.0013  0.0001 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0270  0.1039  0.1595  0.0448  0.0009  0.0094  0.0008  0.0022  0.0030 </r>
+        <r>  0.0270  0.1038  0.1594  0.0448  0.0009  0.0094  0.0008  0.0022  0.0030 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0297  0.1044  0.1367  0.0525  0.0040  0.0136  0.0013  0.0024  0.0028 </r>
+        <r>  0.0297  0.1044  0.1367  0.0525  0.0039  0.0136  0.0013  0.0024  0.0028 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0085  0.1116  0.0004  0.1968  0.0194  0.0008  0.0072  0.0145  0.0077 </r>
+        <r>  0.0086  0.1115  0.0004  0.1968  0.0194  0.0008  0.0072  0.0145  0.0077 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0026  0.0972  0.1542  0.0293  0.0160  0.0068  0.0225  0.0020  0.0080 </r>
+        <r>  0.0026  0.0973  0.1541  0.0292  0.0160  0.0068  0.0225  0.0020  0.0080 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0059  0.0228  0.0098  0.0745  0.0036  0.0133  0.0009  0.0404  0.0393 </r>
+        <r>  0.0059  0.0228  0.0098  0.0746  0.0036  0.0133  0.0009  0.0404  0.0393 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0017  0.0360  0.0493  0.0139  0.0221  0.0014  0.0783  0.0007  0.0044 </r>
+        <r>  0.0017  0.0360  0.0493  0.0139  0.0221  0.0014  0.0782  0.0007  0.0043 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0025  0.0091  0.0163  0.0022  0.0084  0.0313  0.0126  0.0440  0.0666 </r>
+        <r>  0.0025  0.0091  0.0162  0.0022  0.0084  0.0311  0.0126  0.0442  0.0666 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0338  0.0016  0.0067  0.0110  0.0241  0.0922  0.0104  0.0315  0.0008 </r>
+        <r>  0.0338  0.0016  0.0068  0.0110  0.0240  0.0922  0.0103  0.0314  0.0008 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0366  0.0113  0.0030  0.0397  0.1511  0.0298  0.0375  0.0009  0.0073 </r>
+        <r>  0.0366  0.0113  0.0030  0.0398  0.1509  0.0298  0.0375  0.0009  0.0072 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0134  0.0125  0.0052  0.0082  0.0222  0.0714  0.0078  0.0005  0.0921 </r>
+        <r>  0.0134  0.0125  0.0052  0.0082  0.0222  0.0714  0.0078  0.0005  0.0921 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0007  0.0002  0.0131  0.0096  0.0235  0.0275  0.0177  0.1287  0.0724 </r>
+        <r>  0.0007  0.0002  0.0131  0.0096  0.0235  0.0275  0.0176  0.1288  0.0729 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0048  0.0046  0.0319  0.0214  0.0127  0.0345  0.0399  0.1010  0.1262 </r>
+        <r>  0.0048  0.0045  0.0320  0.0214  0.0126  0.0344  0.0401  0.1012  0.1263 </r>
+       </set>
+      </set>
+      <set comment="kpoint 58">
+       <set comment="band 1">
+        <r>  0.4053  0.0017  0.0139  0.0036  0.0012  0.0000  0.0003  0.0000  0.0002 </r>
+        <r>  0.4051  0.0017  0.0138  0.0036  0.0012  0.0000  0.0003  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3959  0.0009  0.0153  0.0018  0.0015  0.0000  0.0007  0.0000  0.0002 </r>
+        <r>  0.3959  0.0009  0.0153  0.0018  0.0015  0.0000  0.0007  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0097  0.0817  0.0361  0.1701  0.0037  0.0012  0.0015  0.0026  0.0005 </r>
+        <r>  0.0097  0.0817  0.0361  0.1701  0.0037  0.0012  0.0015  0.0026  0.0005 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2225  0.0000  0.1068  0.0002  0.0076  0.0000  0.0036  0.0016 </r>
+        <r>  0.0000  0.2223  0.0000  0.1068  0.0002  0.0076  0.0000  0.0036  0.0016 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0393  0.0110  0.2275  0.0230  0.0084  0.0004  0.0009  0.0007  0.0012 </r>
+        <r>  0.0393  0.0110  0.2276  0.0229  0.0084  0.0004  0.0009  0.0007  0.0012 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0432  0.0054  0.2765  0.0113  0.0097  0.0010  0.0084  0.0020  0.0014 </r>
+        <r>  0.0432  0.0054  0.2764  0.0113  0.0096  0.0010  0.0084  0.0020  0.0014 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2199  0.0000  0.1056  0.0004  0.0280  0.0000  0.0134  0.0027 </r>
+        <r>  0.0000  0.2199  0.0000  0.1056  0.0004  0.0279  0.0000  0.0134  0.0027 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0115  0.1040  0.0179  0.2166  0.0225  0.0031  0.0011  0.0065  0.0032 </r>
+        <r>  0.0115  0.1040  0.0179  0.2166  0.0224  0.0031  0.0011  0.0064  0.0032 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0053  0.0033  0.0320  0.0069  0.0165  0.0017  0.0971  0.0035  0.0023 </r>
+        <r>  0.0054  0.0033  0.0320  0.0069  0.0164  0.0017  0.0972  0.0035  0.0023 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0045  0.0179  0.0093  0.0373  0.0006  0.0300  0.0031  0.0625  0.0001 </r>
+        <r>  0.0045  0.0179  0.0093  0.0373  0.0006  0.0300  0.0031  0.0625  0.0001 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0049  0.0000  0.0024  0.0216  0.0036  0.0000  0.0017  0.1537 </r>
+        <r>  0.0000  0.0049  0.0000  0.0024  0.0217  0.0035  0.0000  0.0017  0.1539 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0076  0.0155  0.0252  0.0323  0.0618  0.0153  0.0127  0.0318  0.0087 </r>
+        <r>  0.0077  0.0155  0.0251  0.0323  0.0616  0.0152  0.0127  0.0317  0.0087 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0229  0.0000  0.0110  0.0202  0.0081  0.0000  0.0039  0.1434 </r>
+        <r>  0.0000  0.0229  0.0000  0.0110  0.0202  0.0080  0.0000  0.0039  0.1434 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0381  0.0017  0.0160  0.0036  0.0862  0.0551  0.0626  0.1146  0.0121 </r>
+        <r>  0.0380  0.0017  0.0161  0.0036  0.0860  0.0550  0.0626  0.1147  0.0121 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0244  0.0000  0.0117  0.0023  0.2191  0.0000  0.1051  0.0164 </r>
+        <r>  0.0000  0.0244  0.0000  0.0117  0.0023  0.2187  0.0000  0.1052  0.0165 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0447  0.0002  0.1000  0.0004  0.0565  0.0128  0.0023  0.0270  0.0080 </r>
+        <r>  0.0446  0.0002  0.1000  0.0004  0.0566  0.0131  0.0023  0.0268  0.0080 </r>
+       </set>
+      </set>
+      <set comment="kpoint 59">
+       <set comment="band 1">
+        <r>  0.3990  0.0021  0.0144  0.0043  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.3987  0.0021  0.0144  0.0043  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3738  0.0032  0.0221  0.0066  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.3738  0.0032  0.0221  0.0066  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0849  0.0205  0.1432  0.0427  0.0013  0.0044  0.0062  0.0091  0.0002 </r>
+        <r>  0.0849  0.0205  0.1433  0.0426  0.0013  0.0044  0.0062  0.0091  0.0002 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2175  0.0187  0.1094  0.0046  0.0117  0.0001  0.0063  0.0057 </r>
+        <r>  0.0000  0.2172  0.0187  0.1093  0.0042  0.0120  0.0001  0.0060  0.0060 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0938  0.0870  0.1647  0.0193  0.0034  0.0004  0.0017  0.0035 </r>
+        <r>  0.0000  0.0938  0.0869  0.1647  0.0196  0.0031  0.0004  0.0020  0.0032 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0000  0.0672  0.0879  0.1342  0.0253  0.0002  0.0031  0.0003  0.0036 </r>
+        <r>  0.0000  0.0671  0.0879  0.1341  0.0252  0.0002  0.0031  0.0003  0.0036 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.1933  0.0006  0.0952  0.0005  0.0201  0.0000  0.0096  0.0023 </r>
+        <r>  0.0000  0.1934  0.0006  0.0953  0.0005  0.0201  0.0000  0.0096  0.0022 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0638  0.0248  0.1733  0.0516  0.0004  0.0013  0.0018  0.0027  0.0001 </r>
+        <r>  0.0638  0.0248  0.1733  0.0516  0.0004  0.0013  0.0018  0.0027  0.0001 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0031  0.0109  0.0762  0.0227  0.0046  0.0155  0.0221  0.0324  0.0007 </r>
+        <r>  0.0031  0.0109  0.0762  0.0227  0.0046  0.0156  0.0221  0.0324  0.0006 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0053  0.0071  0.0108  0.0188  0.0230  0.1064  0.0488  0.0027 </r>
+        <r>  0.0000  0.0054  0.0071  0.0109  0.0179  0.0237  0.1063  0.0480  0.0034 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0157  0.0000  0.0076  0.0236  0.0043  0.0002  0.0017  0.1696 </r>
+        <r>  0.0000  0.0156  0.0000  0.0076  0.0244  0.0035  0.0002  0.0024  0.1689 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0156  0.0105  0.0737  0.0219  0.0059  0.0197  0.0280  0.0410  0.0008 </r>
+        <r>  0.0156  0.0105  0.0737  0.0219  0.0059  0.0197  0.0280  0.0410  0.0008 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0076  0.0101  0.0155  0.0210  0.0215  0.0970  0.0459  0.0028 </r>
+        <r>  0.0000  0.0076  0.0101  0.0155  0.0202  0.0224  0.0972  0.0452  0.0037 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0223  0.0000  0.0109  0.0223  0.0041  0.0001  0.0015  0.1604 </r>
+        <r>  0.0000  0.0223  0.0000  0.0109  0.0231  0.0032  0.0001  0.0023  0.1597 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0218  0.0081  0.0089  0.0979  0.0652  0.0684  0.0199  0.0091 </r>
+        <r>  0.0000  0.0218  0.0082  0.0088  0.0972  0.0660  0.0688  0.0190  0.0098 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0131  0.0037  0.0219  0.0374  0.1084  0.0315  0.0673  0.0159 </r>
+        <r>  0.0000  0.0131  0.0038  0.0219  0.0381  0.1078  0.0319  0.0678  0.0152 </r>
+       </set>
+      </set>
+      <set comment="kpoint 60">
+       <set comment="band 1">
+        <r>  0.4019  0.0019  0.0137  0.0062  0.0001  0.0002  0.0000  0.0001  0.0000 </r>
+        <r>  0.4017  0.0019  0.0136  0.0062  0.0001  0.0002  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3774  0.0023  0.0182  0.0069  0.0001  0.0004  0.0001  0.0002  0.0000 </r>
+        <r>  0.3775  0.0023  0.0182  0.0069  0.0001  0.0004  0.0001  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0287  0.0733  0.1215  0.0847  0.0053  0.0040  0.0018  0.0054  0.0009 </r>
+        <r>  0.0287  0.0732  0.1216  0.0846  0.0053  0.0040  0.0018  0.0054  0.0009 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2240  0.0761  0.0315  0.0118  0.0019  0.0007  0.0036  0.0056 </r>
+        <r>  0.0000  0.2240  0.0760  0.0315  0.0118  0.0019  0.0007  0.0036  0.0056 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0422  0.0210  0.0653  0.1638  0.0014  0.0108  0.0030  0.0008  0.0003 </r>
+        <r>  0.0423  0.0210  0.0652  0.1637  0.0014  0.0108  0.0030  0.0008  0.0003 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0469  0.0153  0.0547  0.2127  0.0039  0.0103  0.0028  0.0050  0.0009 </r>
+        <r>  0.0469  0.0152  0.0547  0.2129  0.0039  0.0103  0.0028  0.0050  0.0009 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2085  0.0708  0.0294  0.0188  0.0044  0.0029  0.0045  0.0067 </r>
+        <r>  0.0000  0.2085  0.0708  0.0293  0.0188  0.0044  0.0029  0.0045  0.0067 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0218  0.0830  0.1417  0.0757  0.0109  0.0080  0.0003  0.0096  0.0003 </r>
+        <r>  0.0218  0.0831  0.1416  0.0757  0.0109  0.0080  0.0003  0.0096  0.0003 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0087  0.0529  0.0252  0.0100  0.0141  0.0223  0.0325  0.0264 </r>
+        <r>  0.0000  0.0087  0.0529  0.0252  0.0100  0.0141  0.0223  0.0325  0.0264 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0099  0.0075  0.0271  0.0119  0.0155  0.0096  0.0158  0.0331  0.0345 </r>
+        <r>  0.0099  0.0075  0.0271  0.0119  0.0155  0.0096  0.0158  0.0331  0.0346 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0113  0.0038  0.0016  0.0033  0.0238  0.0746  0.0292  0.0608 </r>
+        <r>  0.0000  0.0113  0.0038  0.0016  0.0033  0.0237  0.0746  0.0292  0.0608 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0014  0.0164  0.0492  0.0056  0.0510  0.0010  0.0440  0.0108  0.0838 </r>
+        <r>  0.0014  0.0164  0.0492  0.0056  0.0509  0.0009  0.0441  0.0108  0.0839 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0215  0.0073  0.0030  0.0011  0.0261  0.0799  0.0282  0.0597 </r>
+        <r>  0.0000  0.0215  0.0073  0.0030  0.0011  0.0261  0.0799  0.0282  0.0598 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0039  0.0051  0.0257  0.0410  0.0185  0.0154  0.0020  0.0525  0.0617 </r>
+        <r>  0.0040  0.0051  0.0257  0.0410  0.0185  0.0155  0.0020  0.0525  0.0616 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0324  0.0071  0.0090  0.0067  0.0031  0.1483  0.0779  0.0208  0.0257 </r>
+        <r>  0.0323  0.0071  0.0090  0.0067  0.0031  0.1482  0.0780  0.0208  0.0257 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0306  0.0104  0.0043  0.0961  0.0555  0.0685  0.0057  0.0051 </r>
+        <r>  0.0000  0.0305  0.0104  0.0043  0.0965  0.0556  0.0688  0.0057  0.0052 </r>
+       </set>
+      </set>
+     </set>
+     <set comment="spin2">
+      <set comment="kpoint 1">
+       <set comment="band 1">
+        <r>  0.3945  0.0003  0.0017  0.0005  0.0000  0.0000  0.0001  0.0001  0.0000 </r>
+        <r>  0.3945  0.0002  0.0017  0.0005  0.0000  0.0000  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4703  0.0005  0.0033  0.0010  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.4703  0.0005  0.0033  0.0010  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0066  0.0333  0.2344  0.0699  0.0003  0.0009  0.0012  0.0018  0.0000 </r>
+        <r>  0.0066  0.0334  0.2341  0.0703  0.0002  0.0009  0.0012  0.0018  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.3062  0.0551  0.0237  0.0004  0.0010  0.0005  0.0001  0.0004 </r>
+        <r>  0.0000  0.3060  0.0552  0.0237  0.0007  0.0007  0.0005  0.0004  0.0002 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0408  0.0627  0.2814  0.0007  0.0003  0.0005  0.0006  0.0002 </r>
+        <r>  0.0000  0.0408  0.0628  0.2811  0.0004  0.0006  0.0005  0.0004  0.0004 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0097  0.0294  0.2032  0.0611  0.0012  0.0042  0.0060  0.0088  0.0002 </r>
+        <r>  0.0096  0.0292  0.2036  0.0608  0.0013  0.0042  0.0059  0.0088  0.0002 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.1832  0.0019  0.1342  0.0065  0.0084  0.0001  0.0033  0.0229 </r>
+        <r>  0.0000  0.1833  0.0019  0.1343  0.0057  0.0091  0.0001  0.0025  0.0236 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1042  0.0965  0.1188  0.0204  0.0025  0.0051  0.0068  0.0062 </r>
+        <r>  0.0000  0.1044  0.0960  0.1190  0.0211  0.0018  0.0052  0.0076  0.0054 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0211  0.0013  0.0092  0.0027  0.0077  0.0259  0.0364  0.0540  0.0011 </r>
+        <r>  0.0209  0.0013  0.0092  0.0027  0.0076  0.0258  0.0363  0.0536  0.0011 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0004  0.0034  0.0146  0.0511  0.0119  0.0604  0.0340  0.0454 </r>
+        <r>  0.0000  0.0004  0.0035  0.0146  0.0516  0.0107  0.0603  0.0351  0.0451 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0163  0.0022  0.0000  0.0017  0.0143  0.0381  0.0161  0.1328 </r>
+        <r>  0.0000  0.0163  0.0022  0.0000  0.0008  0.0155  0.0384  0.0150  0.1334 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.1136  0.0028  0.0194  0.0058  0.0001  0.0005  0.0007  0.0010  0.0000 </r>
+        <r>  0.1134  0.0028  0.0194  0.0058  0.0001  0.0005  0.0007  0.0010  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0162  0.0008  0.0055  0.0016  0.0027  0.0088  0.0126  0.0185  0.0004 </r>
+        <r>  0.0162  0.0008  0.0056  0.0017  0.0026  0.0089  0.0126  0.0184  0.0004 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0052  0.0000  0.0028  0.0008  0.2246  0.0002  0.1078  0.0013 </r>
+        <r>  0.0000  0.0052  0.0000  0.0028  0.0015  0.2240  0.0002  0.1085  0.0007 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0020  0.0024  0.0036  0.2236  0.0009  0.0782  0.0007  0.0314 </r>
+        <r>  0.0000  0.0020  0.0025  0.0035  0.2230  0.0016  0.0780  0.0001  0.0320 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0012  0.0018  0.0085  0.0158  0.0079  0.0669  0.0410  0.0700 </r>
+        <r>  0.0000  0.0012  0.0018  0.0086  0.0233  0.0003  0.0670  0.0487  0.0627 </r>
+       </set>
+      </set>
+      <set comment="kpoint 2">
+       <set comment="band 1">
+        <r>  0.3934  0.0003  0.0016  0.0035  0.0000  0.0001  0.0001  0.0001  0.0000 </r>
+        <r>  0.3935  0.0003  0.0017  0.0035  0.0000  0.0001  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4492  0.0006  0.0021  0.0131  0.0000  0.0003  0.0001  0.0000  0.0000 </r>
+        <r>  0.4493  0.0006  0.0021  0.0131  0.0000  0.0003  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0008  0.1133  0.1821  0.0569  0.0006  0.0008  0.0017  0.0015  0.0009 </r>
+        <r>  0.0008  0.1132  0.1821  0.0568  0.0006  0.0008  0.0017  0.0015  0.0008 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2588  0.0880  0.0363  0.0021  0.0019  0.0028  0.0000  0.0000 </r>
+        <r>  0.0000  0.2588  0.0877  0.0366  0.0020  0.0019  0.0029  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0266  0.0009  0.0775  0.2508  0.0021  0.0027  0.0010  0.0002  0.0018 </r>
+        <r>  0.0266  0.0010  0.0777  0.2507  0.0021  0.0027  0.0010  0.0002  0.0018 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0295  0.0025  0.0570  0.2139  0.0043  0.0101  0.0006  0.0011  0.0034 </r>
+        <r>  0.0295  0.0024  0.0573  0.2135  0.0042  0.0101  0.0006  0.0011  0.0034 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2075  0.0706  0.0291  0.0175  0.0042  0.0050  0.0064  0.0108 </r>
+        <r>  0.0000  0.2077  0.0703  0.0294  0.0175  0.0042  0.0051  0.0065  0.0107 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0037  0.0986  0.1757  0.0365  0.0109  0.0034  0.0054  0.0039  0.0044 </r>
+        <r>  0.0037  0.0986  0.1757  0.0366  0.0109  0.0034  0.0054  0.0039  0.0044 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0015  0.0099  0.0141  0.0081  0.0297  0.0165  0.0470  0.0072  0.0239 </r>
+        <r>  0.0014  0.0098  0.0141  0.0081  0.0294  0.0165  0.0471  0.0071  0.0241 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0031  0.0010  0.0004  0.0122  0.0226  0.0746  0.0377  0.0753 </r>
+        <r>  0.0000  0.0031  0.0011  0.0004  0.0121  0.0226  0.0746  0.0376  0.0751 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0160  0.0003  0.0022  0.0038  0.0052  0.0315  0.0041  0.0752  0.0577 </r>
+        <r>  0.0159  0.0003  0.0022  0.0038  0.0052  0.0313  0.0041  0.0750  0.0578 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0755  0.0051  0.0035  0.0314  0.0234  0.0364  0.0039  0.0398  0.0009 </r>
+        <r>  0.0752  0.0051  0.0035  0.0314  0.0231  0.0364  0.0040  0.0397  0.0010 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0138  0.0013  0.0011  0.0184  0.0223  0.0002  0.0205  0.0027  0.0360 </r>
+        <r>  0.0138  0.0013  0.0011  0.0185  0.0222  0.0002  0.0205  0.0027  0.0362 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0184  0.0005  0.0186  0.0254  0.0405  0.1187  0.0209  0.0562  0.0026 </r>
+        <r>  0.0184  0.0005  0.0186  0.0253  0.0405  0.1186  0.0208  0.0563  0.0026 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0234  0.0079  0.0033  0.1508  0.0560  0.0541  0.0210  0.0272 </r>
+        <r>  0.0000  0.0233  0.0079  0.0033  0.1508  0.0562  0.0541  0.0210  0.0272 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0072  0.0003  0.0074  0.0186  0.0045  0.0017  0.0027  0.1203  0.1103 </r>
+        <r>  0.0073  0.0003  0.0074  0.0186  0.0045  0.0016  0.0027  0.1204  0.1104 </r>
+       </set>
+      </set>
+      <set comment="kpoint 3">
+       <set comment="band 1">
+        <r>  0.3916  0.0010  0.0014  0.0102  0.0000  0.0001  0.0001  0.0002  0.0000 </r>
+        <r>  0.3916  0.0010  0.0014  0.0102  0.0000  0.0001  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4195  0.0027  0.0004  0.0256  0.0001  0.0005  0.0001  0.0001  0.0001 </r>
+        <r>  0.4195  0.0027  0.0004  0.0256  0.0001  0.0005  0.0001  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0090  0.1046  0.1726  0.0496  0.0004  0.0028  0.0037  0.0009  0.0017 </r>
+        <r>  0.0090  0.1044  0.1725  0.0495  0.0004  0.0028  0.0037  0.0009  0.0017 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2515  0.0855  0.0352  0.0038  0.0045  0.0074  0.0001  0.0003 </r>
+        <r>  0.0000  0.2514  0.0852  0.0355  0.0038  0.0045  0.0074  0.0001  0.0003 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0450  0.0010  0.0817  0.2029  0.0067  0.0049  0.0008  0.0002  0.0048 </r>
+        <r>  0.0450  0.0011  0.0821  0.2028  0.0067  0.0049  0.0008  0.0002  0.0048 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0453  0.0021  0.0562  0.1963  0.0052  0.0079  0.0001  0.0002  0.0028 </r>
+        <r>  0.0454  0.0021  0.0564  0.1959  0.0052  0.0079  0.0001  0.0002  0.0027 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2015  0.0686  0.0283  0.0200  0.0069  0.0067  0.0036  0.0051 </r>
+        <r>  0.0000  0.2017  0.0683  0.0285  0.0199  0.0069  0.0067  0.0036  0.0051 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0106  0.0891  0.1725  0.0271  0.0040  0.0177  0.0053  0.0033  0.0012 </r>
+        <r>  0.0105  0.0891  0.1726  0.0272  0.0040  0.0177  0.0053  0.0032  0.0012 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0054  0.0110  0.0038  0.0348  0.0324  0.0120  0.0404  0.0048  0.0280 </r>
+        <r>  0.0053  0.0110  0.0038  0.0348  0.0322  0.0120  0.0403  0.0047  0.0281 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0067  0.0023  0.0009  0.0145  0.0195  0.0701  0.0412  0.0816 </r>
+        <r>  0.0000  0.0067  0.0023  0.0009  0.0144  0.0195  0.0701  0.0411  0.0815 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0058  0.0012  0.0102  0.0075  0.0021  0.0335  0.0110  0.0892  0.0401 </r>
+        <r>  0.0058  0.0012  0.0102  0.0075  0.0021  0.0333  0.0110  0.0890  0.0402 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0436  0.0209  0.0097  0.0589  0.0267  0.0419  0.0043  0.0454  0.0038 </r>
+        <r>  0.0433  0.0209  0.0097  0.0589  0.0264  0.0419  0.0043  0.0453  0.0038 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0152  0.0007  0.0204  0.0804  0.0276  0.0478  0.0053  0.0189  0.0333 </r>
+        <r>  0.0153  0.0006  0.0204  0.0805  0.0273  0.0477  0.0055  0.0191  0.0334 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0009  0.0026  0.0131  0.0090  0.0405  0.0511  0.0342  0.0040  0.0265 </r>
+        <r>  0.0008  0.0027  0.0131  0.0089  0.0406  0.0510  0.0341  0.0039  0.0269 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0340  0.0115  0.0048  0.1401  0.0547  0.0544  0.0182  0.0230 </r>
+        <r>  0.0000  0.0339  0.0115  0.0048  0.1402  0.0549  0.0544  0.0182  0.0229 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0301  0.0006  0.0041  0.0029  0.0008  0.0044  0.0047  0.1500  0.0898 </r>
+        <r>  0.0302  0.0005  0.0041  0.0029  0.0008  0.0044  0.0047  0.1501  0.0896 </r>
+       </set>
+      </set>
+      <set comment="kpoint 4">
+       <set comment="band 1">
+        <r>  0.3914  0.0020  0.0009  0.0188  0.0000  0.0003  0.0001  0.0002  0.0001 </r>
+        <r>  0.3914  0.0020  0.0009  0.0188  0.0000  0.0003  0.0001  0.0002  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3978  0.0043  0.0000  0.0284  0.0001  0.0004  0.0001  0.0001  0.0001 </r>
+        <r>  0.3978  0.0043  0.0000  0.0284  0.0001  0.0004  0.0001  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0201  0.0979  0.1616  0.0458  0.0002  0.0046  0.0046  0.0007  0.0025 </r>
+        <r>  0.0201  0.0977  0.1616  0.0457  0.0002  0.0046  0.0046  0.0007  0.0025 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2428  0.0826  0.0340  0.0051  0.0062  0.0104  0.0002  0.0006 </r>
+        <r>  0.0000  0.2428  0.0822  0.0343  0.0051  0.0062  0.0104  0.0002  0.0005 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0568  0.0015  0.0481  0.1657  0.0129  0.0102  0.0003  0.0003  0.0077 </r>
+        <r>  0.0566  0.0015  0.0487  0.1660  0.0128  0.0101  0.0003  0.0003  0.0077 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0432  0.0010  0.1048  0.1852  0.0035  0.0040  0.0002  0.0001  0.0020 </r>
+        <r>  0.0434  0.0010  0.1049  0.1843  0.0036  0.0040  0.0002  0.0001  0.0020 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.1988  0.0678  0.0279  0.0192  0.0088  0.0095  0.0019  0.0022 </r>
+        <r>  0.0000  0.1992  0.0673  0.0281  0.0192  0.0088  0.0095  0.0019  0.0021 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0159  0.0818  0.1580  0.0242  0.0022  0.0252  0.0089  0.0025  0.0012 </r>
+        <r>  0.0159  0.0816  0.1581  0.0243  0.0022  0.0252  0.0089  0.0025  0.0012 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0090  0.0160  0.0020  0.0720  0.0309  0.0055  0.0342  0.0041  0.0274 </r>
+        <r>  0.0090  0.0160  0.0020  0.0719  0.0307  0.0055  0.0342  0.0040  0.0276 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0153  0.0052  0.0022  0.0158  0.0166  0.0652  0.0433  0.0850 </r>
+        <r>  0.0000  0.0153  0.0052  0.0021  0.0156  0.0166  0.0651  0.0431  0.0849 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0034  0.0031  0.0204  0.0170  0.0041  0.0279  0.0129  0.0692  0.0233 </r>
+        <r>  0.0034  0.0030  0.0205  0.0169  0.0041  0.0278  0.0128  0.0688  0.0232 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0036  0.0023  0.0060  0.0548  0.0050  0.0115  0.0013  0.1029  0.0816 </r>
+        <r>  0.0037  0.0023  0.0060  0.0550  0.0050  0.0114  0.0013  0.1030  0.0818 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0023  0.0358  0.0283  0.0658  0.0001  0.0414  0.0282  0.0095  0.0026 </r>
+        <r>  0.0023  0.0357  0.0283  0.0658  0.0001  0.0415  0.0282  0.0095  0.0025 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0271  0.0092  0.0038  0.0221  0.0123  0.0574  0.0481  0.0931 </r>
+        <r>  0.0000  0.0270  0.0092  0.0038  0.0218  0.0123  0.0574  0.0480  0.0931 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0163  0.0009  0.0086  0.0195  0.1101  0.0607  0.0035  0.1651  0.0074 </r>
+        <r>  0.0159  0.0009  0.0087  0.0194  0.1088  0.0606  0.0034  0.1648  0.0074 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0269  0.0091  0.0038  0.1659  0.0436  0.0311  0.0344  0.0493 </r>
+        <r>  0.0000  0.0269  0.0091  0.0038  0.1654  0.0436  0.0314  0.0345  0.0493 </r>
+       </set>
+      </set>
+      <set comment="kpoint 5">
+       <set comment="band 1">
+        <r>  0.3958  0.0026  0.0003  0.0235  0.0001  0.0005  0.0001  0.0000  0.0000 </r>
+        <r>  0.3959  0.0026  0.0003  0.0235  0.0001  0.0005  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3873  0.0051  0.0005  0.0262  0.0000  0.0002  0.0001  0.0003  0.0002 </r>
+        <r>  0.3872  0.0051  0.0005  0.0263  0.0000  0.0002  0.0001  0.0003  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0307  0.0954  0.1465  0.0516  0.0006  0.0049  0.0043  0.0010  0.0037 </r>
+        <r>  0.0308  0.0946  0.1469  0.0516  0.0006  0.0049  0.0043  0.0010  0.0036 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2386  0.0816  0.0336  0.0046  0.0059  0.0100  0.0001  0.0005 </r>
+        <r>  0.0000  0.2393  0.0807  0.0337  0.0046  0.0060  0.0100  0.0001  0.0005 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0478  0.0005  0.0760  0.1680  0.0091  0.0075  0.0002  0.0005  0.0048 </r>
+        <r>  0.0477  0.0005  0.0764  0.1680  0.0091  0.0075  0.0002  0.0005  0.0048 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0434  0.0012  0.0988  0.1632  0.0085  0.0075  0.0001  0.0004  0.0042 </r>
+        <r>  0.0435  0.0012  0.0993  0.1626  0.0085  0.0074  0.0001  0.0004  0.0042 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0199  0.0803  0.1506  0.0250  0.0016  0.0256  0.0105  0.0017  0.0016 </r>
+        <r>  0.0197  0.0816  0.1493  0.0249  0.0015  0.0258  0.0104  0.0017  0.0016 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1989  0.0669  0.0277  0.0192  0.0104  0.0122  0.0014  0.0015 </r>
+        <r>  0.0000  0.1978  0.0677  0.0282  0.0192  0.0102  0.0124  0.0014  0.0015 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0022  0.0033  0.0043  0.0609  0.0141  0.0075  0.0035  0.0334  0.0518 </r>
+        <r>  0.0023  0.0033  0.0043  0.0609  0.0141  0.0074  0.0035  0.0334  0.0520 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0125  0.0211  0.0087  0.0803  0.0258  0.0151  0.0371  0.0146  0.0287 </r>
+        <r>  0.0124  0.0212  0.0088  0.0807  0.0255  0.0150  0.0367  0.0142  0.0288 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0266  0.0091  0.0038  0.0065  0.0198  0.0721  0.0376  0.0760 </r>
+        <r>  0.0000  0.0267  0.0091  0.0038  0.0063  0.0198  0.0717  0.0372  0.0753 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0104  0.0196  0.0122  0.0573  0.0249  0.0147  0.0371  0.0483  0.0009 </r>
+        <r>  0.0103  0.0195  0.0124  0.0567  0.0247  0.0145  0.0369  0.0475  0.0010 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0030  0.0027  0.0202  0.0068  0.0006  0.0233  0.0109  0.1387  0.0480 </r>
+        <r>  0.0029  0.0024  0.0205  0.0068  0.0008  0.0229  0.0121  0.1349  0.0518 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0185  0.0061  0.0026  0.0383  0.0057  0.0453  0.0548  0.1112 </r>
+        <r>  0.0000  0.0184  0.0057  0.0027  0.0378  0.0063  0.0446  0.0593  0.1077 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0314  0.0107  0.0044  0.1610  0.0412  0.0294  0.0350  0.0508 </r>
+        <r>  0.0000  0.0315  0.0107  0.0044  0.1602  0.0415  0.0295  0.0352  0.0506 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0388  0.0004  0.0268  0.0427  0.0132  0.0894  0.0285  0.0509  0.0227 </r>
+        <r>  0.0386  0.0004  0.0266  0.0427  0.0132  0.0902  0.0287  0.0517  0.0230 </r>
+       </set>
+      </set>
+      <set comment="kpoint 6">
+       <set comment="band 1">
+        <r>  0.3905  0.0028  0.0008  0.0154  0.0001  0.0003  0.0001  0.0001  0.0000 </r>
+        <r>  0.3906  0.0028  0.0008  0.0154  0.0001  0.0003  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4040  0.0049  0.0002  0.0284  0.0000  0.0004  0.0001  0.0003  0.0002 </r>
+        <r>  0.4040  0.0049  0.0002  0.0284  0.0000  0.0004  0.0001  0.0003  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.2415  0.0819  0.0338  0.0028  0.0044  0.0079  0.0001  0.0005 </r>
+        <r>  0.0000  0.2410  0.0820  0.0341  0.0028  0.0045  0.0079  0.0001  0.0005 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0533  0.0351  0.0516  0.1795  0.0068  0.0031  0.0026  0.0002  0.0068 </r>
+        <r>  0.0534  0.0357  0.0514  0.1790  0.0067  0.0031  0.0026  0.0002  0.0068 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0113  0.0649  0.2089  0.0463  0.0013  0.0061  0.0013  0.0025  0.0007 </r>
+        <r>  0.0112  0.0647  0.2089  0.0464  0.0013  0.0061  0.0013  0.0025  0.0007 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0366  0.0730  0.0864  0.0804  0.0009  0.0193  0.0086  0.0010  0.0011 </r>
+        <r>  0.0366  0.0732  0.0865  0.0803  0.0008  0.0193  0.0086  0.0009  0.0011 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0272  0.0084  0.1310  0.1289  0.0096  0.0131  0.0004  0.0018  0.0044 </r>
+        <r>  0.0272  0.0083  0.1310  0.1288  0.0096  0.0131  0.0004  0.0018  0.0044 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2005  0.0681  0.0281  0.0195  0.0102  0.0123  0.0019  0.0023 </r>
+        <r>  0.0000  0.2006  0.0680  0.0283  0.0195  0.0102  0.0124  0.0019  0.0023 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0042  0.0028  0.0018  0.0382  0.0160  0.0103  0.0025  0.0320  0.0581 </r>
+        <r>  0.0043  0.0028  0.0018  0.0383  0.0160  0.0102  0.0025  0.0320  0.0583 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0121  0.0136  0.0102  0.0287  0.0203  0.0277  0.0491  0.0678  0.0012 </r>
+        <r>  0.0118  0.0136  0.0103  0.0287  0.0201  0.0276  0.0490  0.0674  0.0012 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0199  0.0067  0.0028  0.0194  0.0181  0.0678  0.0441  0.0869 </r>
+        <r>  0.0000  0.0199  0.0067  0.0028  0.0191  0.0182  0.0677  0.0438  0.0866 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0041  0.0210  0.0029  0.1596  0.0233  0.0063  0.0075  0.0080  0.0139 </r>
+        <r>  0.0041  0.0210  0.0029  0.1596  0.0231  0.0062  0.0075  0.0079  0.0139 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0437  0.0149  0.0061  0.0126  0.0389  0.0807  0.0068  0.0176 </r>
+        <r>  0.0000  0.0437  0.0149  0.0061  0.0127  0.0390  0.0807  0.0067  0.0176 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0091  0.0102  0.0379  0.0019  0.0003  0.0563  0.0320  0.0580  0.0260 </r>
+        <r>  0.0090  0.0102  0.0378  0.0019  0.0004  0.0563  0.0320  0.0584  0.0261 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0042  0.0014  0.0006  0.1923  0.0167  0.0030  0.0817  0.1335 </r>
+        <r>  0.0000  0.0041  0.0014  0.0006  0.1911  0.0168  0.0030  0.0817  0.1339 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0058  0.0011  0.0031  0.0131  0.0230  0.0176  0.0101  0.1263  0.0554 </r>
+        <r>  0.0059  0.0011  0.0032  0.0131  0.0229  0.0176  0.0103  0.1260  0.0555 </r>
+       </set>
+      </set>
+      <set comment="kpoint 7">
+       <set comment="band 1">
+        <r>  0.3910  0.0018  0.0013  0.0072  0.0000  0.0002  0.0001  0.0001  0.0000 </r>
+        <r>  0.3910  0.0018  0.0013  0.0072  0.0000  0.0002  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4297  0.0044  0.0005  0.0213  0.0001  0.0003  0.0001  0.0002  0.0001 </r>
+        <r>  0.4298  0.0044  0.0005  0.0213  0.0001  0.0003  0.0001  0.0002  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.2476  0.0840  0.0347  0.0011  0.0025  0.0049  0.0002  0.0007 </r>
+        <r>  0.0000  0.2472  0.0840  0.0350  0.0011  0.0026  0.0050  0.0002  0.0006 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0251  0.0041  0.0782  0.2278  0.0046  0.0021  0.0015  0.0003  0.0031 </r>
+        <r>  0.0252  0.0044  0.0783  0.2276  0.0046  0.0021  0.0015  0.0003  0.0031 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0158  0.1073  0.2086  0.0279  0.0004  0.0035  0.0029  0.0028  0.0021 </r>
+        <r>  0.0158  0.1073  0.2084  0.0277  0.0004  0.0035  0.0029  0.0028  0.0020 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0335  0.0768  0.0762  0.0975  0.0030  0.0153  0.0038  0.0022  0.0008 </r>
+        <r>  0.0334  0.0769  0.0763  0.0975  0.0030  0.0153  0.0038  0.0022  0.0008 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0183  0.0049  0.1250  0.1474  0.0075  0.0121  0.0002  0.0038  0.0052 </r>
+        <r>  0.0183  0.0048  0.1252  0.1473  0.0075  0.0121  0.0002  0.0038  0.0052 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2096  0.0712  0.0295  0.0166  0.0070  0.0086  0.0034  0.0053 </r>
+        <r>  0.0000  0.2097  0.0711  0.0296  0.0166  0.0070  0.0087  0.0034  0.0052 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0054  0.0021  0.0016  0.0184  0.0205  0.0088  0.0047  0.0243  0.0624 </r>
+        <r>  0.0054  0.0021  0.0016  0.0184  0.0205  0.0087  0.0047  0.0244  0.0625 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0095  0.0058  0.0028  0.0164  0.0212  0.0372  0.0541  0.0684  0.0007 </r>
+        <r>  0.0093  0.0058  0.0028  0.0163  0.0210  0.0371  0.0541  0.0681  0.0007 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0121  0.0041  0.0017  0.0191  0.0215  0.0726  0.0413  0.0820 </r>
+        <r>  0.0000  0.0120  0.0041  0.0017  0.0190  0.0217  0.0726  0.0411  0.0818 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0753  0.0090  0.0052  0.0922  0.0069  0.0209  0.0068  0.0114  0.0005 </r>
+        <r>  0.0752  0.0090  0.0052  0.0924  0.0067  0.0209  0.0068  0.0114  0.0005 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0250  0.0085  0.0035  0.1411  0.0545  0.0542  0.0200  0.0261 </r>
+        <r>  0.0000  0.0250  0.0085  0.0035  0.1412  0.0545  0.0541  0.0200  0.0261 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0005  0.0018  0.0049  0.0083  0.0348  0.0136  0.0137  0.0213  0.0508 </r>
+        <r>  0.0005  0.0018  0.0050  0.0082  0.0345  0.0136  0.0137  0.0214  0.0511 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0097  0.0205  0.0305  0.0137  0.0415  0.1113  0.0220  0.0531  0.0096 </r>
+        <r>  0.0095  0.0206  0.0305  0.0138  0.0415  0.1113  0.0219  0.0530  0.0096 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0137  0.0046  0.0019  0.0663  0.0022  0.0307  0.0692  0.1264 </r>
+        <r>  0.0000  0.0136  0.0046  0.0019  0.0658  0.0022  0.0307  0.0690  0.1260 </r>
+       </set>
+      </set>
+      <set comment="kpoint 8">
+       <set comment="band 1">
+        <r>  0.3932  0.0008  0.0016  0.0019  0.0000  0.0001  0.0001  0.0001  0.0000 </r>
+        <r>  0.3933  0.0008  0.0016  0.0019  0.0000  0.0001  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4603  0.0026  0.0020  0.0065  0.0000  0.0001  0.0000  0.0002  0.0000 </r>
+        <r>  0.4603  0.0026  0.0020  0.0065  0.0000  0.0001  0.0000  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0032  0.0039  0.0885  0.2543  0.0014  0.0012  0.0014  0.0005  0.0008 </r>
+        <r>  0.0032  0.0002  0.0900  0.2567  0.0012  0.0011  0.0018  0.0004  0.0007 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2522  0.0891  0.0356  0.0003  0.0009  0.0022  0.0002  0.0005 </r>
+        <r>  0.0000  0.2559  0.0877  0.0333  0.0005  0.0010  0.0018  0.0003  0.0006 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0119  0.1172  0.1835  0.0615  0.0002  0.0016  0.0010  0.0022  0.0009 </r>
+        <r>  0.0119  0.1172  0.1833  0.0613  0.0002  0.0016  0.0010  0.0022  0.0009 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0185  0.0888  0.1092  0.0848  0.0090  0.0093  0.0016  0.0040  0.0034 </r>
+        <r>  0.0185  0.0890  0.1092  0.0848  0.0089  0.0093  0.0016  0.0040  0.0034 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0059  0.0014  0.1107  0.1827  0.0030  0.0110  0.0017  0.0077  0.0067 </r>
+        <r>  0.0059  0.0014  0.1107  0.1826  0.0029  0.0110  0.0017  0.0077  0.0068 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2204  0.0748  0.0310  0.0098  0.0014  0.0039  0.0070  0.0126 </r>
+        <r>  0.0000  0.2205  0.0748  0.0311  0.0098  0.0014  0.0039  0.0070  0.0125 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0058  0.0006  0.0026  0.0120  0.0253  0.0072  0.0087  0.0208  0.0723 </r>
+        <r>  0.0058  0.0006  0.0026  0.0120  0.0253  0.0070  0.0088  0.0209  0.0725 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0036  0.0011  0.0045  0.0109  0.0264  0.0362  0.0604  0.0624  0.0014 </r>
+        <r>  0.0035  0.0011  0.0045  0.0109  0.0261  0.0362  0.0605  0.0621  0.0014 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0115  0.0039  0.0016  0.0111  0.0230  0.0749  0.0355  0.0720 </r>
+        <r>  0.0000  0.0114  0.0039  0.0016  0.0110  0.0231  0.0750  0.0352  0.0718 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.1149  0.0064  0.0034  0.0301  0.0042  0.0185  0.0052  0.0035  0.0006 </r>
+        <r>  0.1148  0.0064  0.0034  0.0302  0.0042  0.0185  0.0052  0.0035  0.0006 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0027  0.0001  0.0016  0.0052  0.0188  0.0061  0.0051  0.0191  0.0393 </r>
+        <r>  0.0027  0.0001  0.0017  0.0052  0.0188  0.0060  0.0051  0.0192  0.0394 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0067  0.0023  0.0010  0.1587  0.0596  0.0576  0.0224  0.0290 </r>
+        <r>  0.0000  0.0067  0.0023  0.0009  0.1587  0.0597  0.0574  0.0225  0.0291 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0100  0.0131  0.0229  0.0053  0.0512  0.1293  0.0184  0.0700  0.0052 </r>
+        <r>  0.0099  0.0132  0.0229  0.0053  0.0512  0.1293  0.0183  0.0699  0.0052 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0064  0.0021  0.0009  0.0550  0.0016  0.0199  0.0516  0.0935 </r>
+        <r>  0.0000  0.0063  0.0022  0.0009  0.0546  0.0016  0.0198  0.0514  0.0932 </r>
+       </set>
+      </set>
+      <set comment="kpoint 9">
+       <set comment="band 1">
+        <r>  0.3937  0.0015  0.0019  0.0030  0.0001  0.0000  0.0001  0.0001  0.0000 </r>
+        <r>  0.3937  0.0015  0.0020  0.0030  0.0001  0.0001  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4467  0.0039  0.0032  0.0081  0.0003  0.0000  0.0004  0.0001  0.0000 </r>
+        <r>  0.4468  0.0039  0.0032  0.0081  0.0003  0.0000  0.0004  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0039  0.0065  0.3184  0.0132  0.0012  0.0013  0.0001  0.0028  0.0002 </r>
+        <r>  0.0039  0.0062  0.3183  0.0137  0.0012  0.0013  0.0001  0.0028  0.0002 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2485  0.0000  0.1195  0.0005  0.0010  0.0000  0.0005  0.0036 </r>
+        <r>  0.0000  0.2486  0.0000  0.1190  0.0005  0.0011  0.0000  0.0005  0.0035 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0246  0.1112  0.0091  0.2316  0.0031  0.0001  0.0071  0.0002  0.0004 </r>
+        <r>  0.0246  0.1113  0.0092  0.2319  0.0031  0.0001  0.0072  0.0002  0.0004 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0252  0.0845  0.0122  0.1759  0.0193  0.0008  0.0022  0.0016  0.0027 </r>
+        <r>  0.0253  0.0843  0.0122  0.1757  0.0192  0.0008  0.0022  0.0016  0.0027 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0046  0.0011  0.2776  0.0023  0.0185  0.0006  0.0196  0.0013  0.0026 </r>
+        <r>  0.0046  0.0011  0.2774  0.0023  0.0184  0.0006  0.0196  0.0013  0.0026 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2242  0.0000  0.1077  0.0029  0.0085  0.0000  0.0041  0.0208 </r>
+        <r>  0.0000  0.2244  0.0000  0.1077  0.0029  0.0085  0.0000  0.0041  0.0207 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0029  0.0006  0.0492  0.0012  0.0200  0.0013  0.0837  0.0028  0.0028 </r>
+        <r>  0.0029  0.0006  0.0492  0.0012  0.0197  0.0013  0.0838  0.0028  0.0028 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0118  0.0008  0.0108  0.0017  0.0043  0.0581  0.0023  0.1204  0.0006 </r>
+        <r>  0.0117  0.0008  0.0109  0.0017  0.0043  0.0576  0.0023  0.1203  0.0006 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0184  0.0000  0.0089  0.0254  0.0012  0.0000  0.0005  0.1810 </r>
+        <r>  0.0000  0.0184  0.0000  0.0088  0.0256  0.0013  0.0000  0.0006  0.1813 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0945  0.0045  0.0207  0.0094  0.0566  0.0030  0.0177  0.0061  0.0079 </r>
+        <r>  0.0942  0.0045  0.0207  0.0094  0.0565  0.0029  0.0178  0.0061  0.0079 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0039  0.0000  0.0019  0.0002  0.2229  0.0000  0.1071  0.0011 </r>
+        <r>  0.0000  0.0038  0.0000  0.0018  0.0002  0.2229  0.0000  0.1072  0.0012 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0009  0.0001  0.0012  0.0003  0.0137  0.0017  0.0511  0.0034  0.0019 </r>
+        <r>  0.0009  0.0001  0.0012  0.0003  0.0136  0.0016  0.0510  0.0035  0.0019 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0178  0.0220  0.0008  0.0459  0.1566  0.0021  0.0570  0.0043  0.0221 </r>
+        <r>  0.0178  0.0220  0.0008  0.0458  0.1563  0.0021  0.0570  0.0043  0.0221 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0142  0.0120  0.0152  0.0115  0.0075  0.0800  0.0075  0.1171  0.0190 </r>
+        <r>  0.0144  0.0111  0.0153  0.0124  0.0024  0.0868  0.0075  0.1100  0.0241 </r>
+       </set>
+      </set>
+      <set comment="kpoint 10">
+       <set comment="band 1">
+        <r>  0.3932  0.0002  0.0021  0.0088  0.0002  0.0001  0.0001  0.0001  0.0001 </r>
+        <r>  0.3933  0.0002  0.0021  0.0088  0.0002  0.0001  0.0001  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4311  0.0000  0.0019  0.0186  0.0008  0.0002  0.0006  0.0000  0.0000 </r>
+        <r>  0.4312  0.0000  0.0019  0.0186  0.0008  0.0002  0.0006  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0010  0.0859  0.1878  0.0591  0.0007  0.0014  0.0013  0.0013  0.0015 </r>
+        <r>  0.0010  0.0859  0.1877  0.0590  0.0007  0.0014  0.0013  0.0013  0.0015 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0105  0.1851  0.0846  0.0667  0.0039  0.0038  0.0024  0.0002  0.0017 </r>
+        <r>  0.0105  0.1850  0.0845  0.0668  0.0039  0.0038  0.0024  0.0002  0.0017 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0244  0.0697  0.0614  0.1584  0.0103  0.0005  0.0050  0.0005  0.0017 </r>
+        <r>  0.0244  0.0698  0.0615  0.1585  0.0103  0.0005  0.0050  0.0005  0.0017 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0370  0.1027  0.0098  0.2035  0.0143  0.0013  0.0050  0.0001  0.0008 </r>
+        <r>  0.0370  0.1027  0.0098  0.2034  0.0143  0.0013  0.0050  0.0001  0.0008 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0095  0.1135  0.1424  0.0436  0.0094  0.0126  0.0042  0.0016  0.0120 </r>
+        <r>  0.0095  0.1138  0.1423  0.0436  0.0094  0.0125  0.0042  0.0016  0.0119 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0056  0.1223  0.1205  0.0501  0.0135  0.0048  0.0144  0.0009  0.0034 </r>
+        <r>  0.0055  0.1222  0.1205  0.0502  0.0134  0.0048  0.0144  0.0009  0.0034 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0006  0.0070  0.0454  0.0075  0.0201  0.0165  0.0813  0.0010  0.0013 </r>
+        <r>  0.0005  0.0070  0.0454  0.0075  0.0199  0.0164  0.0813  0.0010  0.0013 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0044  0.0031  0.0119  0.0079  0.0126  0.0313  0.0118  0.0611  0.0985 </r>
+        <r>  0.0043  0.0031  0.0119  0.0079  0.0126  0.0315  0.0118  0.0605  0.0985 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0160  0.0020  0.0089  0.0155  0.0071  0.0277  0.0026  0.0691  0.0571 </r>
+        <r>  0.0159  0.0019  0.0090  0.0155  0.0071  0.0274  0.0026  0.0691  0.0572 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0504  0.0069  0.0038  0.0334  0.0422  0.0392  0.0094  0.0379  0.0211 </r>
+        <r>  0.0501  0.0069  0.0038  0.0334  0.0419  0.0391  0.0095  0.0380  0.0212 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0123  0.0072  0.0267  0.0189  0.0111  0.1446  0.0043  0.0634  0.0123 </r>
+        <r>  0.0124  0.0072  0.0267  0.0189  0.0112  0.1448  0.0043  0.0634  0.0124 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0009  0.0007  0.0024  0.0049  0.0300  0.0182  0.0441  0.0003  0.0199 </r>
+        <r>  0.0009  0.0007  0.0024  0.0049  0.0299  0.0182  0.0441  0.0003  0.0201 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0045  0.0056  0.0041  0.0418  0.0788  0.0009  0.0094  0.1067  0.0413 </r>
+        <r>  0.0045  0.0057  0.0041  0.0418  0.0786  0.0009  0.0095  0.1068  0.0415 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0264  0.0159  0.0017  0.0349  0.0866  0.0016  0.0471  0.0366  0.0608 </r>
+        <r>  0.0265  0.0158  0.0017  0.0348  0.0864  0.0016  0.0472  0.0366  0.0607 </r>
+       </set>
+      </set>
+      <set comment="kpoint 11">
+       <set comment="band 1">
+        <r>  0.3939  0.0002  0.0019  0.0160  0.0004  0.0002  0.0002  0.0001  0.0002 </r>
+        <r>  0.3940  0.0002  0.0019  0.0160  0.0004  0.0002  0.0002  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4110  0.0027  0.0004  0.0232  0.0010  0.0003  0.0004  0.0001  0.0001 </r>
+        <r>  0.4110  0.0027  0.0004  0.0233  0.0010  0.0003  0.0004  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0087  0.0937  0.1679  0.0509  0.0001  0.0027  0.0034  0.0004  0.0015 </r>
+        <r>  0.0087  0.0939  0.1678  0.0507  0.0002  0.0027  0.0034  0.0004  0.0015 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0184  0.1482  0.0249  0.1275  0.0096  0.0024  0.0052  0.0002  0.0008 </r>
+        <r>  0.0184  0.1479  0.0249  0.1277  0.0096  0.0024  0.0052  0.0002  0.0007 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0236  0.0774  0.1431  0.0813  0.0032  0.0049  0.0035  0.0002  0.0020 </r>
+        <r>  0.0236  0.0775  0.1431  0.0813  0.0032  0.0048  0.0036  0.0002  0.0020 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0366  0.1100  0.0780  0.0889  0.0043  0.0131  0.0060  0.0010  0.0089 </r>
+        <r>  0.0366  0.1099  0.0780  0.0889  0.0043  0.0131  0.0060  0.0010  0.0089 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0168  0.1366  0.0440  0.1361  0.0261  0.0045  0.0023  0.0011  0.0016 </r>
+        <r>  0.0169  0.1371  0.0439  0.1359  0.0261  0.0046  0.0023  0.0011  0.0016 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0129  0.0869  0.1690  0.0346  0.0045  0.0212  0.0060  0.0015  0.0021 </r>
+        <r>  0.0128  0.0866  0.1690  0.0348  0.0045  0.0212  0.0060  0.0015  0.0021 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0035  0.0157  0.0041  0.0208  0.0323  0.0138  0.0924  0.0010  0.0025 </r>
+        <r>  0.0034  0.0156  0.0041  0.0207  0.0320  0.0138  0.0923  0.0011  0.0025 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0040  0.0024  0.0043  0.0374  0.0039  0.0081  0.0155  0.0283  0.1278 </r>
+        <r>  0.0039  0.0023  0.0043  0.0372  0.0039  0.0081  0.0155  0.0279  0.1280 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0032  0.0002  0.0240  0.0289  0.0057  0.0347  0.0006  0.0706  0.0108 </r>
+        <r>  0.0031  0.0001  0.0241  0.0289  0.0057  0.0346  0.0006  0.0702  0.0107 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0020  0.0037  0.0063  0.0500  0.0008  0.0106  0.0034  0.1088  0.0943 </r>
+        <r>  0.0020  0.0037  0.0063  0.0501  0.0008  0.0106  0.0034  0.1089  0.0946 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0224  0.0127  0.0318  0.0280  0.0282  0.0933  0.0036  0.0063  0.0016 </r>
+        <r>  0.0223  0.0127  0.0318  0.0281  0.0280  0.0932  0.0037  0.0063  0.0016 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0087  0.0121  0.0148  0.0184  0.0249  0.0776  0.0065  0.2096  0.0015 </r>
+        <r>  0.0087  0.0121  0.0149  0.0183  0.0252  0.0778  0.0064  0.2095  0.0015 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0473  0.0182  0.0104  0.0062  0.0586  0.0076  0.0091  0.0724  0.0704 </r>
+        <r>  0.0467  0.0182  0.0104  0.0061  0.0583  0.0077  0.0092  0.0721  0.0702 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0021  0.0010  0.0014  0.0126  0.0392  0.0159  0.0366  0.0076  0.0433 </r>
+        <r>  0.0021  0.0010  0.0014  0.0127  0.0389  0.0159  0.0365  0.0076  0.0437 </r>
+       </set>
+      </set>
+      <set comment="kpoint 12">
+       <set comment="band 1">
+        <r>  0.3996  0.0020  0.0012  0.0210  0.0005  0.0004  0.0003  0.0001  0.0002 </r>
+        <r>  0.3997  0.0020  0.0012  0.0210  0.0005  0.0004  0.0003  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3947  0.0063  0.0004  0.0208  0.0007  0.0002  0.0003  0.0002  0.0002 </r>
+        <r>  0.3947  0.0062  0.0004  0.0209  0.0007  0.0002  0.0003  0.0002  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0181  0.1384  0.0046  0.1533  0.0084  0.0006  0.0049  0.0001  0.0021 </r>
+        <r>  0.0181  0.1386  0.0045  0.1532  0.0084  0.0006  0.0050  0.0001  0.0021 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0166  0.0881  0.1605  0.0485  0.0000  0.0047  0.0037  0.0007  0.0011 </r>
+        <r>  0.0166  0.0877  0.1605  0.0486  0.0000  0.0047  0.0037  0.0007  0.0011 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0241  0.0741  0.1753  0.0544  0.0014  0.0087  0.0051  0.0002  0.0009 </r>
+        <r>  0.0241  0.0741  0.1754  0.0544  0.0014  0.0087  0.0051  0.0002  0.0009 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0349  0.1131  0.1058  0.0472  0.0008  0.0173  0.0056  0.0020  0.0079 </r>
+        <r>  0.0349  0.1131  0.1059  0.0472  0.0008  0.0173  0.0056  0.0020  0.0079 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0192  0.0783  0.1651  0.0326  0.0014  0.0270  0.0077  0.0024  0.0018 </r>
+        <r>  0.0192  0.0787  0.1651  0.0324  0.0014  0.0271  0.0077  0.0025  0.0019 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0154  0.1346  0.0157  0.1584  0.0331  0.0006  0.0059  0.0015  0.0011 </r>
+        <r>  0.0153  0.1344  0.0156  0.1586  0.0331  0.0006  0.0059  0.0016  0.0011 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0036  0.0281  0.0001  0.0377  0.0402  0.0030  0.0803  0.0043  0.0161 </r>
+        <r>  0.0035  0.0281  0.0001  0.0376  0.0398  0.0030  0.0800  0.0044  0.0160 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0054  0.0017  0.0041  0.0432  0.0083  0.0174  0.0105  0.0327  0.0543 </r>
+        <r>  0.0055  0.0016  0.0041  0.0433  0.0082  0.0173  0.0105  0.0327  0.0545 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0037  0.0003  0.0138  0.0467  0.0086  0.0215  0.0038  0.0822  0.0410 </r>
+        <r>  0.0036  0.0003  0.0140  0.0467  0.0086  0.0213  0.0039  0.0812  0.0408 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0034  0.0047  0.0112  0.0538  0.0012  0.0161  0.0152  0.0309  0.1148 </r>
+        <r>  0.0034  0.0047  0.0112  0.0536  0.0012  0.0161  0.0152  0.0306  0.1151 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0026  0.0011  0.0253  0.0094  0.0047  0.0272  0.0039  0.1525  0.0263 </r>
+        <r>  0.0026  0.0011  0.0252  0.0095  0.0048  0.0273  0.0039  0.1530  0.0262 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0011  0.0682  0.0034  0.0263  0.0137  0.0051  0.0885  0.0283  0.0426 </r>
+        <r>  0.0010  0.0677  0.0034  0.0265  0.0133  0.0050  0.0890  0.0283  0.0422 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0279  0.0021  0.0187  0.0244  0.0891  0.0819  0.0414  0.0668  0.0417 </r>
+        <r>  0.0282  0.0022  0.0188  0.0240  0.0869  0.0822  0.0417  0.0667  0.0418 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0308  0.0148  0.0091  0.0082  0.0965  0.0519  0.0303  0.0957  0.0767 </r>
+        <r>  0.0301  0.0149  0.0092  0.0082  0.0969  0.0516  0.0298  0.0955  0.0771 </r>
+       </set>
+      </set>
+      <set comment="kpoint 13">
+       <set comment="band 1">
+        <r>  0.3931  0.0072  0.0002  0.0142  0.0004  0.0004  0.0002  0.0001  0.0000 </r>
+        <r>  0.3932  0.0072  0.0002  0.0142  0.0004  0.0004  0.0002  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4046  0.0068  0.0009  0.0210  0.0005  0.0003  0.0004  0.0004  0.0003 </r>
+        <r>  0.4046  0.0068  0.0009  0.0211  0.0005  0.0003  0.0004  0.0004  0.0003 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0103  0.1307  0.0029  0.1750  0.0052  0.0002  0.0033  0.0000  0.0041 </r>
+        <r>  0.0103  0.1308  0.0028  0.1750  0.0051  0.0002  0.0033  0.0000  0.0040 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0235  0.0938  0.1503  0.0455  0.0004  0.0054  0.0041  0.0022  0.0010 </r>
+        <r>  0.0235  0.0937  0.1503  0.0455  0.0004  0.0054  0.0041  0.0022  0.0010 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0260  0.0819  0.1850  0.0560  0.0012  0.0087  0.0048  0.0002  0.0001 </r>
+        <r>  0.0260  0.0819  0.1849  0.0561  0.0012  0.0087  0.0048  0.0002  0.0001 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0274  0.0894  0.1331  0.0334  0.0000  0.0183  0.0064  0.0037  0.0054 </r>
+        <r>  0.0274  0.0894  0.1331  0.0333  0.0000  0.0183  0.0064  0.0037  0.0054 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0258  0.0836  0.1554  0.0392  0.0007  0.0224  0.0091  0.0030  0.0012 </r>
+        <r>  0.0257  0.0837  0.1554  0.0392  0.0007  0.0224  0.0091  0.0030  0.0012 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0087  0.1306  0.0061  0.1701  0.0296  0.0007  0.0064  0.0055  0.0024 </r>
+        <r>  0.0087  0.1306  0.0061  0.1702  0.0296  0.0007  0.0065  0.0055  0.0025 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0030  0.0069  0.0001  0.0387  0.0106  0.0082  0.0022  0.0256  0.0748 </r>
+        <r>  0.0030  0.0069  0.0001  0.0386  0.0106  0.0082  0.0022  0.0256  0.0749 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0082  0.0007  0.0089  0.0206  0.0041  0.0383  0.0166  0.1002  0.0263 </r>
+        <r>  0.0080  0.0007  0.0089  0.0206  0.0041  0.0382  0.0166  0.0997  0.0263 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0021  0.0363  0.0004  0.0514  0.0682  0.0032  0.0583  0.0032  0.0129 </r>
+        <r>  0.0020  0.0364  0.0004  0.0515  0.0674  0.0032  0.0578  0.0032  0.0127 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0090  0.0352  0.0043  0.0432  0.0629  0.0105  0.0873  0.0018  0.0203 </r>
+        <r>  0.0089  0.0348  0.0043  0.0433  0.0625  0.0106  0.0879  0.0018  0.0204 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0199  0.0241  0.0019  0.0405  0.0404  0.0037  0.1065  0.0128  0.0142 </r>
+        <r>  0.0199  0.0240  0.0019  0.0402  0.0404  0.0037  0.1062  0.0128  0.0139 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0121  0.0018  0.0223  0.0043  0.0309  0.0133  0.0067  0.1481  0.0668 </r>
+        <r>  0.0118  0.0017  0.0223  0.0042  0.0309  0.0134  0.0067  0.1477  0.0670 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0105  0.0045  0.0092  0.0215  0.0277  0.0137  0.0066  0.0318  0.2109 </r>
+        <r>  0.0106  0.0045  0.0092  0.0215  0.0275  0.0136  0.0066  0.0320  0.2113 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0033  0.0041  0.0125  0.0110  0.0146  0.0636  0.0019  0.0449  0.0474 </r>
+        <r>  0.0033  0.0041  0.0125  0.0111  0.0150  0.0639  0.0019  0.0450  0.0474 </r>
+       </set>
+      </set>
+      <set comment="kpoint 14">
+       <set comment="band 1">
+        <r>  0.3906  0.0072  0.0007  0.0069  0.0001  0.0003  0.0001  0.0001  0.0000 </r>
+        <r>  0.3907  0.0072  0.0007  0.0069  0.0001  0.0003  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4217  0.0126  0.0002  0.0140  0.0004  0.0004  0.0003  0.0004  0.0001 </r>
+        <r>  0.4217  0.0126  0.0002  0.0140  0.0004  0.0004  0.0003  0.0004  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0025  0.1212  0.0025  0.2038  0.0021  0.0000  0.0022  0.0000  0.0058 </r>
+        <r>  0.0025  0.1212  0.0025  0.2038  0.0021  0.0000  0.0022  0.0000  0.0058 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0285  0.1294  0.1424  0.0384  0.0008  0.0078  0.0042  0.0019  0.0007 </r>
+        <r>  0.0287  0.1287  0.1435  0.0379  0.0008  0.0077  0.0042  0.0019  0.0007 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0170  0.0672  0.1967  0.0592  0.0014  0.0027  0.0034  0.0036  0.0002 </r>
+        <r>  0.0169  0.0678  0.1955  0.0596  0.0014  0.0027  0.0034  0.0037  0.0002 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0311  0.0761  0.1413  0.0638  0.0008  0.0146  0.0074  0.0043  0.0002 </r>
+        <r>  0.0310  0.0761  0.1415  0.0638  0.0008  0.0146  0.0074  0.0043  0.0002 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0197  0.0860  0.1561  0.0273  0.0003  0.0184  0.0057  0.0045  0.0044 </r>
+        <r>  0.0196  0.0861  0.1561  0.0273  0.0003  0.0184  0.0057  0.0045  0.0043 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0015  0.1172  0.0010  0.1857  0.0177  0.0057  0.0023  0.0154  0.0043 </r>
+        <r>  0.0016  0.1172  0.0010  0.1859  0.0177  0.0057  0.0023  0.0155  0.0044 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0022  0.0146  0.0009  0.0336  0.0088  0.0043  0.0029  0.0121  0.0871 </r>
+        <r>  0.0022  0.0146  0.0009  0.0336  0.0088  0.0042  0.0029  0.0121  0.0871 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0056  0.0042  0.0017  0.0168  0.0111  0.0473  0.0068  0.1031  0.0153 </r>
+        <r>  0.0055  0.0042  0.0017  0.0167  0.0111  0.0472  0.0068  0.1025  0.0152 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0265  0.0210  0.0024  0.0214  0.1080  0.0061  0.0752  0.0022  0.0200 </r>
+        <r>  0.0273  0.0214  0.0023  0.0225  0.1034  0.0064  0.0788  0.0020  0.0189 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0252  0.0197  0.0033  0.0302  0.0625  0.0106  0.0940  0.0094  0.0185 </r>
+        <r>  0.0243  0.0191  0.0034  0.0291  0.0662  0.0104  0.0901  0.0096  0.0194 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0008  0.0661  0.0031  0.0305  0.0040  0.0161  0.0802  0.0008  0.0042 </r>
+        <r>  0.0008  0.0660  0.0031  0.0305  0.0040  0.0161  0.0802  0.0008  0.0042 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0017  0.0053  0.0026  0.0083  0.0221  0.0064  0.0202  0.0059  0.0810 </r>
+        <r>  0.0017  0.0052  0.0026  0.0082  0.0222  0.0063  0.0202  0.0059  0.0810 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0324  0.0014  0.0209  0.0004  0.1090  0.1010  0.0286  0.0559  0.0287 </r>
+        <r>  0.0323  0.0013  0.0208  0.0004  0.1084  0.1013  0.0286  0.0562  0.0289 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0284  0.0171  0.0250  0.0180  0.1270  0.0802  0.0024  0.0399  0.0283 </r>
+        <r>  0.0280  0.0172  0.0250  0.0181  0.1263  0.0802  0.0024  0.0397  0.0282 </r>
+       </set>
+      </set>
+      <set comment="kpoint 15">
+       <set comment="band 1">
+        <r>  0.3917  0.0056  0.0012  0.0019  0.0000  0.0002  0.0001  0.0001  0.0000 </r>
+        <r>  0.3918  0.0056  0.0012  0.0019  0.0000  0.0002  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4389  0.0171  0.0004  0.0039  0.0001  0.0003  0.0001  0.0004  0.0000 </r>
+        <r>  0.4389  0.0170  0.0004  0.0039  0.0001  0.0003  0.0001  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0015  0.0993  0.0026  0.2449  0.0003  0.0001  0.0021  0.0001  0.0057 </r>
+        <r>  0.0015  0.0993  0.0025  0.2449  0.0003  0.0001  0.0021  0.0001  0.0057 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0104  0.1140  0.1822  0.0487  0.0004  0.0025  0.0036  0.0012  0.0005 </r>
+        <r>  0.0104  0.1139  0.1823  0.0486  0.0004  0.0025  0.0036  0.0013  0.0005 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0213  0.1143  0.1959  0.0380  0.0009  0.0017  0.0029  0.0054  0.0005 </r>
+        <r>  0.0214  0.1142  0.1956  0.0379  0.0008  0.0017  0.0029  0.0055  0.0005 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0295  0.0993  0.0854  0.0768  0.0045  0.0097  0.0035  0.0062  0.0018 </r>
+        <r>  0.0294  0.0994  0.0855  0.0769  0.0045  0.0097  0.0035  0.0062  0.0018 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0122  0.0767  0.1808  0.0297  0.0008  0.0140  0.0029  0.0053  0.0066 </r>
+        <r>  0.0121  0.0768  0.1808  0.0297  0.0008  0.0140  0.0029  0.0053  0.0065 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0029  0.0962  0.0023  0.2116  0.0106  0.0081  0.0006  0.0134  0.0053 </r>
+        <r>  0.0029  0.0962  0.0022  0.2116  0.0105  0.0081  0.0006  0.0134  0.0053 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0014  0.0107  0.0021  0.0135  0.0123  0.0034  0.0066  0.0134  0.0963 </r>
+        <r>  0.0014  0.0106  0.0020  0.0134  0.0123  0.0033  0.0066  0.0134  0.0964 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0050  0.0012  0.0006  0.0175  0.0079  0.0522  0.0037  0.0980  0.0135 </r>
+        <r>  0.0048  0.0012  0.0006  0.0176  0.0079  0.0521  0.0036  0.0974  0.0135 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0037  0.0168  0.0014  0.0109  0.0570  0.0164  0.1347  0.0139  0.0033 </r>
+        <r>  0.0037  0.0168  0.0014  0.0108  0.0560  0.0163  0.1350  0.0140  0.0032 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0692  0.0377  0.0019  0.0013  0.0870  0.0039  0.0389  0.0019  0.0093 </r>
+        <r>  0.0691  0.0376  0.0019  0.0013  0.0872  0.0040  0.0387  0.0018  0.0093 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0118  0.0161  0.0034  0.0090  0.0602  0.0344  0.0107  0.0032  0.0498 </r>
+        <r>  0.0118  0.0161  0.0033  0.0091  0.0604  0.0344  0.0108  0.0032  0.0496 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0087  0.0163  0.0083  0.0089  0.0372  0.0395  0.0237  0.0235  0.0551 </r>
+        <r>  0.0087  0.0163  0.0083  0.0088  0.0371  0.0396  0.0235  0.0236  0.0555 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0135  0.0242  0.0330  0.0104  0.0359  0.1207  0.0154  0.0725  0.0028 </r>
+        <r>  0.0133  0.0242  0.0330  0.0104  0.0358  0.1207  0.0154  0.0724  0.0028 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0156  0.0076  0.0010  0.0122  0.1838  0.0114  0.0727  0.0005  0.0050 </r>
+        <r>  0.0154  0.0075  0.0010  0.0121  0.1826  0.0115  0.0725  0.0005  0.0050 </r>
+       </set>
+      </set>
+      <set comment="kpoint 16">
+       <set comment="band 1">
+        <r>  0.3961  0.0029  0.0027  0.0061  0.0007  0.0001  0.0002  0.0001  0.0001 </r>
+        <r>  0.3961  0.0029  0.0027  0.0061  0.0007  0.0001  0.0002  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4371  0.0036  0.0028  0.0074  0.0015  0.0000  0.0012  0.0000  0.0002 </r>
+        <r>  0.4371  0.0036  0.0028  0.0074  0.0016  0.0000  0.0012  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0081  0.0433  0.1767  0.0902  0.0035  0.0009  0.0006  0.0018  0.0005 </r>
+        <r>  0.0080  0.0433  0.1766  0.0902  0.0035  0.0009  0.0006  0.0018  0.0005 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2387  0.0000  0.1146  0.0005  0.0008  0.0000  0.0004  0.0039 </r>
+        <r>  0.0000  0.2385  0.0000  0.1145  0.0005  0.0008  0.0000  0.0004  0.0038 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0193  0.0464  0.1463  0.0966  0.0074  0.0002  0.0039  0.0005  0.0010 </r>
+        <r>  0.0193  0.0464  0.1463  0.0966  0.0074  0.0002  0.0039  0.0005  0.0010 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0351  0.0763  0.0652  0.1589  0.0010  0.0002  0.0292  0.0004  0.0001 </r>
+        <r>  0.0350  0.0763  0.0653  0.1589  0.0010  0.0002  0.0292  0.0004  0.0001 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0046  0.0338  0.1158  0.0703  0.0451  0.0005  0.0269  0.0010  0.0063 </r>
+        <r>  0.0046  0.0338  0.1157  0.0704  0.0449  0.0005  0.0269  0.0010  0.0063 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2357  0.0000  0.1132  0.0021  0.0094  0.0000  0.0045  0.0152 </r>
+        <r>  0.0000  0.2358  0.0000  0.1132  0.0021  0.0094  0.0000  0.0045  0.0150 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0035  0.0015  0.1602  0.0031  0.0076  0.0024  0.0500  0.0049  0.0011 </r>
+        <r>  0.0035  0.0015  0.1602  0.0031  0.0075  0.0024  0.0500  0.0049  0.0011 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0904  0.0074  0.0132  0.0155  0.0557  0.0001  0.0164  0.0002  0.0078 </r>
+        <r>  0.0901  0.0075  0.0134  0.0155  0.0557  0.0001  0.0164  0.0002  0.0078 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0019  0.0009  0.0291  0.0019  0.0100  0.0614  0.0032  0.1283  0.0014 </r>
+        <r>  0.0019  0.0009  0.0290  0.0018  0.0099  0.0615  0.0032  0.1277  0.0014 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0212  0.0000  0.0102  0.0175  0.0813  0.0000  0.0389  0.1239 </r>
+        <r>  0.0000  0.0212  0.0000  0.0102  0.0174  0.0814  0.0000  0.0392  0.1242 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0043  0.0000  0.0021  0.0094  0.1375  0.0000  0.0660  0.0669 </r>
+        <r>  0.0000  0.0042  0.0000  0.0020  0.0095  0.1374  0.0000  0.0660  0.0672 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0006  0.0002  0.0006  0.0004  0.0145  0.0024  0.0524  0.0049  0.0021 </r>
+        <r>  0.0006  0.0002  0.0006  0.0004  0.0144  0.0023  0.0523  0.0049  0.0020 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0080  0.0000  0.0038  0.0224  0.0509  0.0000  0.0245  0.1590 </r>
+        <r>  0.0000  0.0080  0.0000  0.0038  0.0224  0.0511  0.0000  0.0246  0.1590 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0213  0.0148  0.0114  0.0308  0.0147  0.0516  0.0014  0.1074  0.0021 </r>
+        <r>  0.0215  0.0148  0.0115  0.0308  0.0147  0.0516  0.0014  0.1073  0.0021 </r>
+       </set>
+      </set>
+      <set comment="kpoint 17">
+       <set comment="band 1">
+        <r>  0.3995  0.0004  0.0030  0.0105  0.0012  0.0001  0.0003  0.0001  0.0002 </r>
+        <r>  0.3995  0.0004  0.0031  0.0105  0.0011  0.0001  0.0003  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4288  0.0009  0.0018  0.0126  0.0021  0.0001  0.0012  0.0000  0.0002 </r>
+        <r>  0.4289  0.0009  0.0017  0.0127  0.0021  0.0001  0.0012  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0127  0.0893  0.0489  0.1542  0.0056  0.0011  0.0013  0.0002  0.0000 </r>
+        <r>  0.0127  0.0895  0.0488  0.1541  0.0055  0.0011  0.0013  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0034  0.1466  0.1028  0.0761  0.0016  0.0001  0.0029  0.0004  0.0014 </r>
+        <r>  0.0034  0.1463  0.1028  0.0762  0.0016  0.0001  0.0029  0.0004  0.0014 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0146  0.0916  0.1706  0.0535  0.0013  0.0028  0.0015  0.0001  0.0022 </r>
+        <r>  0.0146  0.0916  0.1707  0.0534  0.0013  0.0028  0.0015  0.0001  0.0021 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0163  0.0496  0.1673  0.0329  0.0055  0.0092  0.0319  0.0017  0.0086 </r>
+        <r>  0.0162  0.0495  0.1673  0.0330  0.0055  0.0092  0.0319  0.0017  0.0085 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0109  0.1574  0.0167  0.0575  0.0373  0.0058  0.0209  0.0002  0.0025 </r>
+        <r>  0.0110  0.1580  0.0167  0.0571  0.0370  0.0057  0.0209  0.0002  0.0026 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0219  0.1407  0.0008  0.2084  0.0169  0.0015  0.0054  0.0015  0.0031 </r>
+        <r>  0.0219  0.1403  0.0008  0.2087  0.0170  0.0015  0.0055  0.0015  0.0031 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0004  0.0171  0.1481  0.0197  0.0038  0.0209  0.0506  0.0007  0.0020 </r>
+        <r>  0.0004  0.0171  0.1481  0.0196  0.0038  0.0209  0.0505  0.0008  0.0020 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0443  0.0064  0.0044  0.0487  0.0300  0.0218  0.0095  0.0353  0.0456 </r>
+        <r>  0.0440  0.0064  0.0044  0.0486  0.0298  0.0220  0.0095  0.0349  0.0458 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0031  0.0005  0.0228  0.0339  0.0047  0.0699  0.0011  0.0271  0.0457 </r>
+        <r>  0.0031  0.0005  0.0229  0.0340  0.0047  0.0698  0.0011  0.0268  0.0454 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0017  0.0018  0.0230  0.0024  0.0027  0.0969  0.0013  0.1080  0.0217 </r>
+        <r>  0.0017  0.0018  0.0232  0.0024  0.0027  0.0963  0.0014  0.1083  0.0213 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0060  0.0054  0.0043  0.0233  0.0180  0.0266  0.0064  0.0103  0.1107 </r>
+        <r>  0.0060  0.0054  0.0043  0.0233  0.0182  0.0269  0.0064  0.0100  0.1118 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0337  0.0082  0.0084  0.0007  0.0492  0.0460  0.0053  0.1699  0.0245 </r>
+        <r>  0.0338  0.0081  0.0084  0.0008  0.0492  0.0463  0.0052  0.1699  0.0243 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0359  0.0057  0.0042  0.0201  0.0312  0.0094  0.0011  0.1164  0.0559 </r>
+        <r>  0.0354  0.0057  0.0042  0.0201  0.0308  0.0093  0.0012  0.1162  0.0554 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0020  0.0028  0.0018  0.0040  0.0305  0.0359  0.0341  0.0004  0.0295 </r>
+        <r>  0.0020  0.0028  0.0018  0.0040  0.0305  0.0360  0.0339  0.0003  0.0301 </r>
+       </set>
+      </set>
+      <set comment="kpoint 18">
+       <set comment="band 1">
+        <r>  0.4057  0.0011  0.0029  0.0126  0.0015  0.0002  0.0005  0.0002  0.0003 </r>
+        <r>  0.4058  0.0011  0.0029  0.0126  0.0015  0.0002  0.0005  0.0002  0.0003 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4126  0.0064  0.0005  0.0133  0.0018  0.0002  0.0008  0.0001  0.0002 </r>
+        <r>  0.4126  0.0064  0.0005  0.0133  0.0018  0.0002  0.0008  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0080  0.1140  0.0036  0.1771  0.0043  0.0005  0.0019  0.0001  0.0011 </r>
+        <r>  0.0080  0.1141  0.0036  0.1770  0.0043  0.0005  0.0019  0.0001  0.0011 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0107  0.0999  0.1515  0.0540  0.0002  0.0014  0.0041  0.0004  0.0007 </r>
+        <r>  0.0107  0.0997  0.1515  0.0540  0.0002  0.0014  0.0041  0.0004  0.0007 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0198  0.0918  0.1711  0.0445  0.0007  0.0051  0.0039  0.0004  0.0014 </r>
+        <r>  0.0198  0.0919  0.1711  0.0445  0.0007  0.0051  0.0039  0.0004  0.0014 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0283  0.1157  0.1367  0.0430  0.0003  0.0173  0.0057  0.0039  0.0066 </r>
+        <r>  0.0283  0.1157  0.1366  0.0430  0.0003  0.0173  0.0057  0.0039  0.0065 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0152  0.1009  0.1525  0.0400  0.0103  0.0157  0.0109  0.0018  0.0012 </r>
+        <r>  0.0152  0.1012  0.1525  0.0399  0.0102  0.0157  0.0109  0.0018  0.0013 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0088  0.1462  0.0016  0.1466  0.0495  0.0046  0.0027  0.0012  0.0003 </r>
+        <r>  0.0088  0.1460  0.0015  0.1468  0.0493  0.0046  0.0028  0.0012  0.0003 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0055  0.0016  0.0254  0.0766  0.0115  0.0118  0.0878  0.0049  0.0078 </r>
+        <r>  0.0055  0.0017  0.0255  0.0765  0.0115  0.0118  0.0877  0.0049  0.0078 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0022  0.0044  0.0006  0.0513  0.0052  0.0129  0.0001  0.0304  0.0749 </r>
+        <r>  0.0022  0.0044  0.0006  0.0513  0.0052  0.0128  0.0001  0.0303  0.0752 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0037  0.0008  0.0138  0.0340  0.0062  0.0450  0.0033  0.0536  0.0374 </r>
+        <r>  0.0036  0.0008  0.0139  0.0338  0.0062  0.0449  0.0033  0.0531  0.0373 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0087  0.0055  0.0084  0.0553  0.0252  0.0147  0.0209  0.0298  0.0716 </r>
+        <r>  0.0087  0.0055  0.0084  0.0553  0.0252  0.0149  0.0209  0.0294  0.0715 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0048  0.0031  0.0274  0.0108  0.0234  0.0187  0.0088  0.1374  0.0124 </r>
+        <r>  0.0045  0.0031  0.0274  0.0110  0.0236  0.0188  0.0089  0.1367  0.0126 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0400  0.0160  0.0102  0.0063  0.0228  0.1092  0.0020  0.1540  0.0159 </r>
+        <r>  0.0393  0.0160  0.0104  0.0063  0.0227  0.1089  0.0021  0.1546  0.0156 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0505  0.0155  0.0245  0.0282  0.0836  0.0714  0.0299  0.0356  0.0411 </r>
+        <r>  0.0511  0.0156  0.0245  0.0280  0.0825  0.0715  0.0298  0.0359  0.0415 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0480  0.0266  0.0032  0.0038  0.0829  0.0122  0.0286  0.0374  0.1342 </r>
+        <r>  0.0477  0.0262  0.0032  0.0039  0.0829  0.0125  0.0293  0.0371  0.1338 </r>
+       </set>
+      </set>
+      <set comment="kpoint 19">
+       <set comment="band 1">
+        <r>  0.4015  0.0109  0.0002  0.0111  0.0010  0.0005  0.0004  0.0001  0.0001 </r>
+        <r>  0.4016  0.0109  0.0002  0.0111  0.0010  0.0005  0.0004  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4105  0.0086  0.0021  0.0093  0.0015  0.0002  0.0006  0.0003  0.0003 </r>
+        <r>  0.4104  0.0085  0.0021  0.0093  0.0015  0.0002  0.0006  0.0003  0.0003 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0017  0.1135  0.0016  0.1891  0.0019  0.0001  0.0021  0.0001  0.0038 </r>
+        <r>  0.0017  0.1135  0.0016  0.1890  0.0019  0.0001  0.0021  0.0001  0.0038 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0196  0.0894  0.1476  0.0527  0.0004  0.0028  0.0046  0.0017  0.0003 </r>
+        <r>  0.0196  0.0892  0.1476  0.0527  0.0004  0.0028  0.0047  0.0017  0.0002 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0218  0.0773  0.1842  0.0425  0.0007  0.0072  0.0055  0.0011  0.0008 </r>
+        <r>  0.0218  0.0773  0.1841  0.0425  0.0007  0.0072  0.0055  0.0011  0.0008 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0323  0.1148  0.1299  0.0423  0.0002  0.0150  0.0055  0.0066  0.0024 </r>
+        <r>  0.0323  0.1148  0.1299  0.0423  0.0002  0.0150  0.0055  0.0066  0.0024 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0227  0.0860  0.1757  0.0413  0.0018  0.0214  0.0073  0.0065  0.0004 </r>
+        <r>  0.0227  0.0861  0.1757  0.0412  0.0018  0.0214  0.0073  0.0065  0.0004 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0024  0.1137  0.0015  0.2091  0.0205  0.0044  0.0021  0.0120  0.0090 </r>
+        <r>  0.0024  0.1136  0.0015  0.2092  0.0205  0.0044  0.0021  0.0121  0.0091 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0007  0.0498  0.0002  0.0163  0.0283  0.0000  0.0525  0.0087  0.0493 </r>
+        <r>  0.0007  0.0499  0.0002  0.0163  0.0282  0.0000  0.0524  0.0087  0.0493 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0030  0.0067  0.0004  0.0608  0.0303  0.0157  0.0305  0.0069  0.0457 </r>
+        <r>  0.0030  0.0065  0.0004  0.0608  0.0300  0.0157  0.0303  0.0069  0.0458 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0050  0.0070  0.0021  0.0173  0.0126  0.0392  0.0043  0.0969  0.0219 </r>
+        <r>  0.0048  0.0070  0.0021  0.0172  0.0127  0.0391  0.0044  0.0964  0.0218 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0396  0.0013  0.0023  0.0287  0.0915  0.0045  0.0719  0.0046  0.0058 </r>
+        <r>  0.0397  0.0013  0.0022  0.0287  0.0913  0.0045  0.0722  0.0046  0.0058 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0102  0.0506  0.0259  0.0300  0.0054  0.0134  0.0831  0.0408  0.0450 </r>
+        <r>  0.0101  0.0505  0.0259  0.0296  0.0052  0.0134  0.0834  0.0405  0.0447 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0015  0.0160  0.0131  0.0068  0.0406  0.0083  0.0200  0.0531  0.0176 </r>
+        <r>  0.0014  0.0159  0.0132  0.0067  0.0402  0.0082  0.0199  0.0531  0.0177 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0121  0.0191  0.0030  0.0296  0.0098  0.0012  0.0151  0.0168  0.2611 </r>
+        <r>  0.0121  0.0187  0.0031  0.0300  0.0098  0.0012  0.0147  0.0168  0.2617 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0066  0.0096  0.0055  0.0081  0.0506  0.0897  0.0033  0.1607  0.0140 </r>
+        <r>  0.0068  0.0097  0.0056  0.0080  0.0501  0.0910  0.0034  0.1595  0.0141 </r>
+       </set>
+      </set>
+      <set comment="kpoint 20">
+       <set comment="band 1">
+        <r>  0.3931  0.0144  0.0002  0.0056  0.0004  0.0003  0.0002  0.0001  0.0001 </r>
+        <r>  0.3931  0.0144  0.0002  0.0056  0.0004  0.0003  0.0002  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4137  0.0190  0.0010  0.0050  0.0010  0.0004  0.0005  0.0004  0.0001 </r>
+        <r>  0.4137  0.0190  0.0010  0.0050  0.0010  0.0004  0.0005  0.0004  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0021  0.1021  0.0051  0.2056  0.0003  0.0000  0.0025  0.0003  0.0071 </r>
+        <r>  0.0021  0.1021  0.0051  0.2056  0.0003  0.0000  0.0025  0.0003  0.0070 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0249  0.0908  0.1380  0.0544  0.0014  0.0037  0.0043  0.0042  0.0000 </r>
+        <r>  0.0249  0.0906  0.1380  0.0544  0.0014  0.0037  0.0043  0.0042  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0217  0.0737  0.1991  0.0545  0.0006  0.0064  0.0041  0.0013  0.0007 </r>
+        <r>  0.0217  0.0737  0.1989  0.0546  0.0006  0.0065  0.0041  0.0013  0.0007 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0276  0.0964  0.1305  0.0279  0.0006  0.0129  0.0079  0.0107  0.0009 </r>
+        <r>  0.0276  0.0965  0.1305  0.0279  0.0006  0.0129  0.0079  0.0108  0.0009 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0299  0.0852  0.1625  0.0527  0.0007  0.0139  0.0079  0.0094  0.0011 </r>
+        <r>  0.0299  0.0853  0.1625  0.0526  0.0007  0.0139  0.0080  0.0094  0.0011 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0025  0.0891  0.0039  0.2243  0.0104  0.0082  0.0007  0.0113  0.0138 </r>
+        <r>  0.0025  0.0891  0.0039  0.2244  0.0103  0.0082  0.0007  0.0113  0.0139 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0007  0.0335  0.0008  0.0268  0.0112  0.0045  0.0097  0.0104  0.0905 </r>
+        <r>  0.0007  0.0335  0.0008  0.0267  0.0113  0.0044  0.0097  0.0104  0.0906 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0025  0.0012  0.0009  0.0231  0.0056  0.0560  0.0004  0.0956  0.0106 </r>
+        <r>  0.0024  0.0013  0.0009  0.0232  0.0056  0.0559  0.0004  0.0951  0.0106 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0011  0.0759  0.0012  0.0133  0.1157  0.0012  0.0231  0.0067  0.0165 </r>
+        <r>  0.0011  0.0761  0.0012  0.0133  0.1148  0.0012  0.0228  0.0067  0.0163 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0479  0.0018  0.0006  0.0091  0.0404  0.0025  0.1278  0.0006  0.0055 </r>
+        <r>  0.0479  0.0019  0.0006  0.0090  0.0404  0.0025  0.1282  0.0006  0.0055 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0066  0.0491  0.0048  0.0259  0.0739  0.0109  0.1323  0.0062  0.0050 </r>
+        <r>  0.0065  0.0486  0.0048  0.0258  0.0736  0.0109  0.1320  0.0063  0.0050 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0054  0.0129  0.0131  0.0035  0.0772  0.0654  0.0024  0.0374  0.0402 </r>
+        <r>  0.0055  0.0130  0.0132  0.0035  0.0772  0.0655  0.0024  0.0371  0.0404 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0109  0.0103  0.0051  0.0033  0.0396  0.0154  0.0029  0.0111  0.0788 </r>
+        <r>  0.0109  0.0103  0.0051  0.0033  0.0396  0.0154  0.0029  0.0112  0.0785 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0143  0.0146  0.0284  0.0112  0.0423  0.0796  0.0102  0.0805  0.0556 </r>
+        <r>  0.0142  0.0147  0.0283  0.0112  0.0421  0.0800  0.0102  0.0806  0.0560 </r>
+       </set>
+      </set>
+      <set comment="kpoint 21">
+       <set comment="band 1">
+        <r>  0.3910  0.0138  0.0007  0.0017  0.0001  0.0002  0.0001  0.0001  0.0000 </r>
+        <r>  0.3911  0.0138  0.0007  0.0017  0.0001  0.0002  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4139  0.0286  0.0001  0.0012  0.0003  0.0004  0.0002  0.0004  0.0000 </r>
+        <r>  0.4139  0.0286  0.0001  0.0012  0.0003  0.0004  0.0002  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0091  0.0838  0.0105  0.2290  0.0001  0.0002  0.0035  0.0006  0.0095 </r>
+        <r>  0.0091  0.0838  0.0105  0.2290  0.0001  0.0002  0.0035  0.0006  0.0095 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0182  0.0881  0.1787  0.0597  0.0003  0.0030  0.0044  0.0029  0.0012 </r>
+        <r>  0.0182  0.0879  0.1790  0.0597  0.0003  0.0030  0.0044  0.0028  0.0012 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0265  0.1022  0.1444  0.0490  0.0029  0.0032  0.0030  0.0067  0.0001 </r>
+        <r>  0.0265  0.1023  0.1440  0.0491  0.0028  0.0032  0.0030  0.0067  0.0001 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0336  0.0890  0.1392  0.0549  0.0007  0.0071  0.0052  0.0118  0.0043 </r>
+        <r>  0.0335  0.0890  0.1394  0.0549  0.0007  0.0071  0.0052  0.0118  0.0042 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0210  0.0848  0.1499  0.0253  0.0014  0.0132  0.0071  0.0106  0.0007 </r>
+        <r>  0.0210  0.0849  0.1498  0.0253  0.0015  0.0132  0.0072  0.0106  0.0007 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0077  0.0617  0.0141  0.2295  0.0134  0.0051  0.0059  0.0020  0.0127 </r>
+        <r>  0.0077  0.0617  0.0141  0.2296  0.0133  0.0052  0.0060  0.0020  0.0128 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0031  0.0386  0.0020  0.0056  0.0142  0.0067  0.0077  0.0149  0.0872 </r>
+        <r>  0.0031  0.0385  0.0020  0.0056  0.0143  0.0066  0.0077  0.0149  0.0873 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0052  0.0030  0.0046  0.0033  0.0061  0.0607  0.0007  0.0963  0.0122 </r>
+        <r>  0.0051  0.0030  0.0047  0.0033  0.0061  0.0606  0.0007  0.0959  0.0122 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0052  0.0229  0.0030  0.0221  0.0804  0.0092  0.1226  0.0065  0.0007 </r>
+        <r>  0.0051  0.0231  0.0030  0.0219  0.0794  0.0092  0.1224  0.0066  0.0007 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0301  0.0889  0.0019  0.0100  0.0910  0.0068  0.0218  0.0064  0.0168 </r>
+        <r>  0.0301  0.0887  0.0019  0.0100  0.0912  0.0069  0.0217  0.0064  0.0167 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0002  0.0511  0.0048  0.0368  0.0070  0.0261  0.0863  0.0011  0.0090 </r>
+        <r>  0.0002  0.0511  0.0048  0.0368  0.0070  0.0262  0.0864  0.0011  0.0090 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0141  0.0122  0.0082  0.0053  0.0364  0.0238  0.0482  0.0175  0.0703 </r>
+        <r>  0.0140  0.0120  0.0082  0.0052  0.0365  0.0239  0.0478  0.0176  0.0699 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0064  0.0078  0.0215  0.0032  0.0910  0.0347  0.0016  0.0640  0.0367 </r>
+        <r>  0.0065  0.0078  0.0216  0.0031  0.0907  0.0344  0.0017  0.0637  0.0373 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0137  0.0061  0.0167  0.0003  0.0751  0.0808  0.0174  0.0431  0.0437 </r>
+        <r>  0.0136  0.0062  0.0166  0.0003  0.0749  0.0814  0.0176  0.0432  0.0436 </r>
+       </set>
+      </set>
+      <set comment="kpoint 22">
+       <set comment="band 1">
+        <r>  0.4084  0.0019  0.0040  0.0040  0.0021  0.0001  0.0005  0.0001  0.0003 </r>
+        <r>  0.4084  0.0019  0.0040  0.0040  0.0021  0.0001  0.0005  0.0001  0.0003 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4361  0.0024  0.0025  0.0049  0.0026  0.0000  0.0018  0.0000  0.0004 </r>
+        <r>  0.4362  0.0023  0.0025  0.0049  0.0026  0.0000  0.0018  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0105  0.0874  0.0175  0.1821  0.0026  0.0001  0.0007  0.0003  0.0004 </r>
+        <r>  0.0105  0.0875  0.0175  0.1821  0.0026  0.0001  0.0007  0.0003  0.0004 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2358  0.0000  0.1132  0.0003  0.0006  0.0000  0.0003  0.0023 </r>
+        <r>  0.0000  0.2356  0.0000  0.1132  0.0003  0.0006  0.0000  0.0003  0.0022 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0070  0.0042  0.2986  0.0088  0.0016  0.0002  0.0012  0.0005  0.0002 </r>
+        <r>  0.0070  0.0042  0.2986  0.0087  0.0016  0.0002  0.0012  0.0005  0.0002 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0033  0.0003  0.1125  0.0006  0.0285  0.0005  0.0742  0.0011  0.0040 </r>
+        <r>  0.0032  0.0003  0.1125  0.0006  0.0284  0.0005  0.0742  0.0011  0.0040 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2503  0.0000  0.1202  0.0010  0.0109  0.0000  0.0053  0.0073 </r>
+        <r>  0.0000  0.2503  0.0000  0.1202  0.0010  0.0109  0.0000  0.0052  0.0072 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0155  0.0253  0.1873  0.0527  0.0126  0.0013  0.0134  0.0027  0.0018 </r>
+        <r>  0.0155  0.0253  0.1873  0.0526  0.0125  0.0013  0.0134  0.0027  0.0018 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0102  0.0981  0.0616  0.2043  0.0133  0.0001  0.0186  0.0003  0.0019 </r>
+        <r>  0.0102  0.0981  0.0616  0.2043  0.0133  0.0001  0.0186  0.0003  0.0019 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0780  0.0118  0.0128  0.0246  0.0518  0.0025  0.0148  0.0052  0.0073 </r>
+        <r>  0.0776  0.0119  0.0129  0.0247  0.0517  0.0025  0.0149  0.0052  0.0072 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0088  0.0000  0.0042  0.0034  0.1994  0.0000  0.0961  0.0239 </r>
+        <r>  0.0000  0.0088  0.0000  0.0042  0.0034  0.1998  0.0000  0.0960  0.0239 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0138  0.0099  0.0319  0.0206  0.0169  0.0265  0.0051  0.0551  0.0024 </r>
+        <r>  0.0138  0.0099  0.0319  0.0206  0.0168  0.0260  0.0052  0.0544  0.0024 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0007  0.0000  0.0003  0.0217  0.0831  0.0000  0.0401  0.1538 </r>
+        <r>  0.0000  0.0006  0.0000  0.0003  0.0221  0.0832  0.0000  0.0399  0.1569 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0344  0.0038  0.0027  0.0079  0.0067  0.0623  0.0010  0.1294  0.0010 </r>
+        <r>  0.0345  0.0038  0.0028  0.0080  0.0067  0.0623  0.0010  0.1295  0.0009 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0182  0.0000  0.0087  0.0171  0.0026  0.0000  0.0013  0.1228 </r>
+        <r>  0.0000  0.0183  0.0000  0.0087  0.0168  0.0027  0.0000  0.0014  0.1205 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0002  0.0064  0.0000  0.0041  0.0292  0.0385  0.0000  0.0257  0.2472 </r>
+        <r>  0.0002  0.0066  0.0000  0.0038  0.0381  0.0405  0.0000  0.0234  0.2377 </r>
+       </set>
+      </set>
+      <set comment="kpoint 23">
+       <set comment="band 1">
+        <r>  0.4144  0.0007  0.0043  0.0034  0.0026  0.0001  0.0006  0.0001  0.0004 </r>
+        <r>  0.4144  0.0007  0.0043  0.0034  0.0026  0.0001  0.0006  0.0001  0.0004 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4276  0.0047  0.0018  0.0076  0.0025  0.0001  0.0016  0.0000  0.0003 </r>
+        <r>  0.4277  0.0047  0.0018  0.0076  0.0025  0.0001  0.0016  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0051  0.0995  0.0021  0.1892  0.0015  0.0002  0.0005  0.0001  0.0005 </r>
+        <r>  0.0051  0.0996  0.0021  0.1892  0.0015  0.0002  0.0005  0.0002  0.0005 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0026  0.1188  0.1374  0.0668  0.0005  0.0001  0.0021  0.0003  0.0006 </r>
+        <r>  0.0026  0.1186  0.1373  0.0668  0.0005  0.0001  0.0021  0.0003  0.0006 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0117  0.1007  0.1793  0.0423  0.0006  0.0018  0.0013  0.0003  0.0011 </r>
+        <r>  0.0117  0.1007  0.1793  0.0422  0.0006  0.0018  0.0013  0.0003  0.0011 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0062  0.0160  0.1440  0.0080  0.0241  0.0028  0.0561  0.0026  0.0056 </r>
+        <r>  0.0062  0.0160  0.1440  0.0081  0.0240  0.0028  0.0561  0.0027  0.0055 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0159  0.1850  0.0098  0.0799  0.0101  0.0118  0.0185  0.0037  0.0009 </r>
+        <r>  0.0159  0.1852  0.0098  0.0799  0.0100  0.0118  0.0185  0.0037  0.0009 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0013  0.0476  0.1943  0.0212  0.0035  0.0140  0.0260  0.0033  0.0022 </r>
+        <r>  0.0013  0.0476  0.1942  0.0213  0.0035  0.0140  0.0260  0.0033  0.0022 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0041  0.1315  0.0019  0.2659  0.0158  0.0009  0.0020  0.0038  0.0016 </r>
+        <r>  0.0041  0.1315  0.0019  0.2658  0.0158  0.0009  0.0020  0.0038  0.0016 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0010  0.0143  0.0003  0.0505  0.0078  0.0102  0.0015  0.0264  0.0762 </r>
+        <r>  0.0009  0.0144  0.0003  0.0505  0.0078  0.0101  0.0015  0.0263  0.0765 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0382  0.0020  0.0085  0.0209  0.0221  0.1277  0.0059  0.0019  0.0188 </r>
+        <r>  0.0381  0.0020  0.0085  0.0209  0.0219  0.1277  0.0059  0.0019  0.0188 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0320  0.0128  0.0033  0.0082  0.0233  0.0374  0.0094  0.1451  0.0097 </r>
+        <r>  0.0315  0.0128  0.0033  0.0081  0.0230  0.0375  0.0095  0.1443  0.0096 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0596  0.0178  0.0321  0.0106  0.0684  0.1072  0.0155  0.0388  0.0002 </r>
+        <r>  0.0592  0.0178  0.0322  0.0107  0.0691  0.1075  0.0157  0.0390  0.0002 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0329  0.0021  0.0015  0.0137  0.1012  0.0348  0.0376  0.0271  0.0123 </r>
+        <r>  0.0333  0.0020  0.0015  0.0136  0.1006  0.0346  0.0377  0.0273  0.0126 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0100  0.0053  0.0094  0.0015  0.0107  0.0329  0.0015  0.0807  0.0695 </r>
+        <r>  0.0099  0.0054  0.0094  0.0014  0.0105  0.0325  0.0015  0.0795  0.0696 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0088  0.0057  0.0152  0.0080  0.0221  0.0189  0.0076  0.0903  0.1292 </r>
+        <r>  0.0088  0.0056  0.0152  0.0080  0.0219  0.0191  0.0078  0.0902  0.1299 </r>
+       </set>
+      </set>
+      <set comment="kpoint 24">
+       <set comment="band 1">
+        <r>  0.4127  0.0077  0.0034  0.0017  0.0023  0.0002  0.0006  0.0002  0.0003 </r>
+        <r>  0.4127  0.0077  0.0034  0.0018  0.0023  0.0002  0.0006  0.0002  0.0003 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4133  0.0130  0.0007  0.0067  0.0017  0.0003  0.0009  0.0001  0.0003 </r>
+        <r>  0.4134  0.0130  0.0007  0.0067  0.0017  0.0003  0.0009  0.0001  0.0003 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0012  0.1020  0.0023  0.1942  0.0005  0.0001  0.0014  0.0003  0.0032 </r>
+        <r>  0.0012  0.1021  0.0023  0.1942  0.0005  0.0001  0.0015  0.0003  0.0032 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0124  0.0950  0.1448  0.0616  0.0005  0.0008  0.0037  0.0012  0.0001 </r>
+        <r>  0.0124  0.0948  0.1447  0.0617  0.0005  0.0008  0.0037  0.0012  0.0001 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0186  0.0895  0.1784  0.0424  0.0007  0.0034  0.0040  0.0013  0.0008 </r>
+        <r>  0.0186  0.0895  0.1784  0.0423  0.0007  0.0034  0.0040  0.0013  0.0008 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0252  0.1012  0.1477  0.0479  0.0033  0.0121  0.0045  0.0110  0.0018 </r>
+        <r>  0.0252  0.1012  0.1477  0.0479  0.0033  0.0122  0.0045  0.0111  0.0017 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0180  0.0995  0.1312  0.0536  0.0131  0.0085  0.0210  0.0038  0.0005 </r>
+        <r>  0.0180  0.0997  0.1312  0.0535  0.0129  0.0085  0.0210  0.0038  0.0005 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0020  0.0164  0.0383  0.0303  0.0276  0.0099  0.0713  0.0122  0.0098 </r>
+        <r>  0.0020  0.0163  0.0383  0.0304  0.0274  0.0099  0.0712  0.0122  0.0097 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0033  0.1219  0.0068  0.2362  0.0093  0.0049  0.0051  0.0033  0.0110 </r>
+        <r>  0.0033  0.1220  0.0068  0.2362  0.0093  0.0049  0.0051  0.0033  0.0110 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0008  0.0304  0.0018  0.0309  0.0229  0.0150  0.0016  0.0143  0.0843 </r>
+        <r>  0.0008  0.0303  0.0018  0.0309  0.0229  0.0148  0.0016  0.0142  0.0845 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0013  0.0066  0.0007  0.0171  0.0033  0.0458  0.0001  0.0893  0.0177 </r>
+        <r>  0.0012  0.0066  0.0008  0.0172  0.0033  0.0458  0.0001  0.0887  0.0176 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0365  0.0306  0.0046  0.0004  0.0702  0.0045  0.0653  0.0039  0.0280 </r>
+        <r>  0.0364  0.0307  0.0046  0.0004  0.0700  0.0045  0.0656  0.0038  0.0280 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0483  0.0276  0.0194  0.0111  0.0191  0.1595  0.0096  0.0544  0.0196 </r>
+        <r>  0.0488  0.0278  0.0201  0.0112  0.0175  0.1626  0.0094  0.0525  0.0205 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0089  0.0002  0.0209  0.0095  0.0748  0.0427  0.0038  0.0388  0.0148 </r>
+        <r>  0.0082  0.0001  0.0203  0.0093  0.0758  0.0399  0.0041  0.0403  0.0144 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0412  0.0393  0.0305  0.0096  0.0653  0.1315  0.0201  0.0195  0.0487 </r>
+        <r>  0.0409  0.0390  0.0304  0.0097  0.0657  0.1313  0.0203  0.0194  0.0478 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0095  0.0121  0.0128  0.0089  0.0214  0.0154  0.0000  0.1133  0.1260 </r>
+        <r>  0.0098  0.0123  0.0130  0.0089  0.0212  0.0152  0.0000  0.1132  0.1274 </r>
+       </set>
+      </set>
+      <set comment="kpoint 25">
+       <set comment="band 1">
+        <r>  0.4007  0.0206  0.0003  0.0033  0.0008  0.0002  0.0004  0.0003  0.0002 </r>
+        <r>  0.4008  0.0205  0.0003  0.0033  0.0008  0.0002  0.0004  0.0003  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4032  0.0196  0.0017  0.0011  0.0013  0.0004  0.0004  0.0001  0.0001 </r>
+        <r>  0.4031  0.0197  0.0017  0.0011  0.0013  0.0004  0.0004  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0076  0.0919  0.0143  0.1952  0.0002  0.0000  0.0032  0.0009  0.0069 </r>
+        <r>  0.0076  0.0919  0.0143  0.1952  0.0001  0.0000  0.0032  0.0009  0.0069 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0215  0.0876  0.1293  0.0691  0.0015  0.0016  0.0042  0.0031  0.0002 </r>
+        <r>  0.0216  0.0874  0.1293  0.0691  0.0015  0.0016  0.0042  0.0031  0.0002 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0207  0.0729  0.1937  0.0444  0.0008  0.0048  0.0049  0.0024  0.0009 </r>
+        <r>  0.0207  0.0729  0.1936  0.0444  0.0008  0.0048  0.0049  0.0024  0.0009 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0296  0.0990  0.1161  0.0475  0.0021  0.0096  0.0068  0.0141  0.0004 </r>
+        <r>  0.0296  0.0990  0.1161  0.0475  0.0022  0.0096  0.0068  0.0141  0.0004 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0266  0.0786  0.1638  0.0592  0.0009  0.0109  0.0070  0.0154  0.0049 </r>
+        <r>  0.0266  0.0787  0.1638  0.0591  0.0009  0.0109  0.0070  0.0154  0.0048 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0088  0.0725  0.0191  0.2358  0.0152  0.0035  0.0036  0.0005  0.0196 </r>
+        <r>  0.0088  0.0725  0.0190  0.2360  0.0151  0.0035  0.0037  0.0006  0.0196 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0048  0.0557  0.0004  0.0078  0.0266  0.0001  0.0796  0.0102  0.0307 </r>
+        <r>  0.0047  0.0557  0.0004  0.0078  0.0263  0.0001  0.0794  0.0102  0.0307 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0020  0.0458  0.0023  0.0138  0.0454  0.0192  0.0086  0.0081  0.0577 </r>
+        <r>  0.0020  0.0457  0.0023  0.0138  0.0453  0.0191  0.0086  0.0081  0.0578 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0045  0.0041  0.0058  0.0043  0.0033  0.0535  0.0021  0.0870  0.0128 </r>
+        <r>  0.0044  0.0042  0.0059  0.0043  0.0033  0.0534  0.0021  0.0865  0.0128 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0055  0.0415  0.0056  0.0097  0.0076  0.0308  0.0290  0.0225  0.0601 </r>
+        <r>  0.0055  0.0415  0.0056  0.0097  0.0077  0.0310  0.0290  0.0223  0.0602 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0197  0.0185  0.0131  0.0188  0.0997  0.0435  0.0337  0.0430  0.0004 </r>
+        <r>  0.0199  0.0186  0.0132  0.0186  0.0990  0.0438  0.0342  0.0428  0.0004 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0057  0.0658  0.0175  0.0310  0.0368  0.0133  0.0987  0.0215  0.0100 </r>
+        <r>  0.0057  0.0657  0.0174  0.0309  0.0366  0.0135  0.0986  0.0215  0.0102 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0233  0.0195  0.0107  0.0058  0.1586  0.0614  0.0105  0.0182  0.0517 </r>
+        <r>  0.0238  0.0193  0.0105  0.0057  0.1556  0.0591  0.0108  0.0188  0.0526 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0295  0.0005  0.0215  0.0044  0.1005  0.1822  0.0279  0.0288  0.0235 </r>
+        <r>  0.0283  0.0005  0.0217  0.0044  0.1030  0.1839  0.0272  0.0283  0.0226 </r>
+       </set>
+      </set>
+      <set comment="kpoint 26">
+       <set comment="band 1">
+        <r>  0.3931  0.0229  0.0002  0.0013  0.0001  0.0003  0.0001  0.0002  0.0001 </r>
+        <r>  0.3932  0.0228  0.0002  0.0013  0.0001  0.0003  0.0001  0.0002  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3961  0.0300  0.0006  0.0002  0.0004  0.0004  0.0002  0.0003  0.0000 </r>
+        <r>  0.3961  0.0300  0.0006  0.0002  0.0004  0.0004  0.0002  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0168  0.0755  0.0354  0.1947  0.0005  0.0004  0.0055  0.0026  0.0096 </r>
+        <r>  0.0168  0.0755  0.0353  0.1947  0.0005  0.0004  0.0055  0.0026  0.0096 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0195  0.0703  0.1548  0.0953  0.0016  0.0027  0.0049  0.0024  0.0011 </r>
+        <r>  0.0209  0.0654  0.1625  0.0945  0.0016  0.0026  0.0050  0.0022  0.0011 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0290  0.0977  0.1378  0.0479  0.0022  0.0031  0.0020  0.0048  0.0022 </r>
+        <r>  0.0276  0.1025  0.1301  0.0488  0.0022  0.0032  0.0019  0.0049  0.0022 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0267  0.0865  0.1365  0.0145  0.0017  0.0095  0.0079  0.0181  0.0005 </r>
+        <r>  0.0267  0.0865  0.1367  0.0145  0.0017  0.0095  0.0079  0.0182  0.0005 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0332  0.0804  0.1099  0.0868  0.0007  0.0055  0.0076  0.0123  0.0105 </r>
+        <r>  0.0331  0.0806  0.1098  0.0866  0.0007  0.0055  0.0076  0.0123  0.0104 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0099  0.0498  0.0521  0.2015  0.0153  0.0042  0.0083  0.0012  0.0113 </r>
+        <r>  0.0099  0.0497  0.0520  0.2017  0.0152  0.0043  0.0084  0.0012  0.0114 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0056  0.0668  0.0030  0.0065  0.0155  0.0084  0.0108  0.0131  0.0806 </r>
+        <r>  0.0056  0.0668  0.0030  0.0064  0.0156  0.0083  0.0108  0.0131  0.0807 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0025  0.0129  0.0145  0.0004  0.0052  0.0605  0.0002  0.0786  0.0091 </r>
+        <r>  0.0025  0.0129  0.0146  0.0005  0.0052  0.0603  0.0002  0.0782  0.0091 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0056  0.0788  0.0017  0.0096  0.0398  0.0059  0.0608  0.0157  0.0188 </r>
+        <r>  0.0056  0.0790  0.0017  0.0096  0.0392  0.0059  0.0603  0.0157  0.0187 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0012  0.0180  0.0026  0.0165  0.0560  0.0535  0.0437  0.0172  0.0494 </r>
+        <r>  0.0011  0.0177  0.0026  0.0168  0.0552  0.0537  0.0430  0.0170  0.0495 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0066  0.0245  0.0106  0.0279  0.0606  0.0063  0.0950  0.0242  0.0025 </r>
+        <r>  0.0066  0.0245  0.0106  0.0274  0.0609  0.0062  0.0959  0.0243  0.0026 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0025  0.0491  0.0174  0.0215  0.0099  0.0529  0.0233  0.0566  0.0180 </r>
+        <r>  0.0026  0.0489  0.0175  0.0215  0.0097  0.0528  0.0233  0.0565  0.0180 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0252  0.0020  0.0073  0.0134  0.2822  0.0041  0.0389  0.0107  0.0098 </r>
+        <r>  0.0252  0.0021  0.0072  0.0134  0.2819  0.0040  0.0391  0.0109  0.0100 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0256  0.0183  0.0174  0.0021  0.0091  0.1462  0.0050  0.0256  0.0472 </r>
+        <r>  0.0255  0.0183  0.0174  0.0021  0.0091  0.1464  0.0050  0.0256  0.0467 </r>
+       </set>
+      </set>
+      <set comment="kpoint 27">
+       <set comment="band 1">
+        <r>  0.4157  0.0005  0.0046  0.0011  0.0029  0.0000  0.0006  0.0001  0.0004 </r>
+        <r>  0.4156  0.0005  0.0046  0.0011  0.0029  0.0000  0.0006  0.0001  0.0004 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4328  0.0032  0.0030  0.0066  0.0027  0.0000  0.0020  0.0000  0.0004 </r>
+        <r>  0.4329  0.0032  0.0029  0.0066  0.0027  0.0000  0.0020  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0103  0.0921  0.0003  0.1918  0.0014  0.0001  0.0003  0.0002  0.0002 </r>
+        <r>  0.0103  0.0921  0.0003  0.1918  0.0014  0.0001  0.0003  0.0002  0.0002 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2347  0.0000  0.1127  0.0003  0.0005  0.0000  0.0002  0.0018 </r>
+        <r>  0.0000  0.2345  0.0000  0.1126  0.0002  0.0005  0.0000  0.0002  0.0017 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0043  0.0003  0.3158  0.0006  0.0009  0.0001  0.0008  0.0002  0.0001 </r>
+        <r>  0.0043  0.0003  0.3158  0.0005  0.0009  0.0001  0.0008  0.0002  0.0001 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0027  0.0002  0.1014  0.0004  0.0302  0.0005  0.0765  0.0011  0.0042 </r>
+        <r>  0.0026  0.0002  0.1014  0.0004  0.0300  0.0005  0.0765  0.0011  0.0042 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2530  0.0000  0.1215  0.0004  0.0124  0.0000  0.0060  0.0028 </r>
+        <r>  0.0000  0.2531  0.0000  0.1215  0.0004  0.0124  0.0000  0.0060  0.0027 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0075  0.0003  0.2571  0.0005  0.0054  0.0004  0.0244  0.0008  0.0008 </r>
+        <r>  0.0075  0.0003  0.2570  0.0005  0.0053  0.0004  0.0244  0.0008  0.0008 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0053  0.1330  0.0027  0.2770  0.0116  0.0008  0.0014  0.0018  0.0016 </r>
+        <r>  0.0054  0.1330  0.0027  0.2770  0.0116  0.0009  0.0014  0.0018  0.0016 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0396  0.0177  0.0175  0.0369  0.0340  0.0078  0.0092  0.0161  0.0048 </r>
+        <r>  0.0395  0.0178  0.0175  0.0370  0.0340  0.0077  0.0092  0.0161  0.0048 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0101  0.0000  0.0049  0.0042  0.1988  0.0000  0.0955  0.0303 </r>
+        <r>  0.0000  0.0102  0.0000  0.0049  0.0043  0.1993  0.0000  0.0957  0.0307 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.1095  0.0093  0.0186  0.0194  0.0572  0.0062  0.0169  0.0131  0.0080 </r>
+        <r>  0.1090  0.0093  0.0186  0.0194  0.0568  0.0062  0.0170  0.0129  0.0080 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0034  0.0000  0.0017  0.0100  0.1149  0.0000  0.0553  0.0709 </r>
+        <r>  0.0000  0.0034  0.0000  0.0016  0.0099  0.1147  0.0000  0.0550  0.0707 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0074  0.0029  0.0085  0.0060  0.0115  0.0586  0.0003  0.1219  0.0016 </r>
+        <r>  0.0075  0.0028  0.0085  0.0059  0.0114  0.0581  0.0004  0.1210  0.0016 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0063  0.0000  0.0030  0.0365  0.0014  0.0000  0.0007  0.2593 </r>
+        <r>  0.0000  0.0062  0.0000  0.0030  0.0365  0.0014  0.0000  0.0007  0.2598 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0314  0.0073  0.0060  0.0153  0.0633  0.0750  0.0187  0.1563  0.0089 </r>
+        <r>  0.0309  0.0074  0.0060  0.0154  0.0631  0.0747  0.0189  0.1555  0.0088 </r>
+       </set>
+      </set>
+      <set comment="kpoint 28">
+       <set comment="band 1">
+        <r>  0.4072  0.0060  0.0037  0.0017  0.0022  0.0000  0.0005  0.0001  0.0002 </r>
+        <r>  0.4072  0.0060  0.0037  0.0017  0.0022  0.0000  0.0005  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4278  0.0094  0.0024  0.0043  0.0022  0.0001  0.0014  0.0000  0.0004 </r>
+        <r>  0.4279  0.0094  0.0024  0.0043  0.0022  0.0001  0.0014  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0109  0.0926  0.0061  0.1899  0.0018  0.0001  0.0012  0.0005  0.0023 </r>
+        <r>  0.0109  0.0927  0.0061  0.1898  0.0017  0.0001  0.0012  0.0005  0.0023 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0051  0.1198  0.1240  0.0757  0.0008  0.0000  0.0019  0.0006  0.0006 </r>
+        <r>  0.0051  0.1195  0.1240  0.0758  0.0008  0.0000  0.0019  0.0006  0.0006 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0101  0.0943  0.1901  0.0406  0.0008  0.0010  0.0015  0.0013  0.0009 </r>
+        <r>  0.0101  0.0943  0.1901  0.0405  0.0008  0.0010  0.0015  0.0013  0.0009 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0073  0.0222  0.1621  0.0101  0.0238  0.0021  0.0449  0.0056  0.0037 </r>
+        <r>  0.0073  0.0222  0.1620  0.0102  0.0237  0.0021  0.0449  0.0057  0.0036 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0141  0.1512  0.0028  0.0882  0.0113  0.0084  0.0289  0.0057  0.0013 </r>
+        <r>  0.0141  0.1514  0.0028  0.0880  0.0112  0.0084  0.0289  0.0057  0.0013 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0093  0.0505  0.1081  0.1124  0.0130  0.0041  0.0113  0.0107  0.0129 </r>
+        <r>  0.0093  0.0504  0.1081  0.1125  0.0129  0.0041  0.0113  0.0107  0.0128 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0090  0.1086  0.0659  0.1654  0.0073  0.0011  0.0214  0.0037  0.0025 </r>
+        <r>  0.0090  0.1086  0.0658  0.1653  0.0073  0.0011  0.0215  0.0036  0.0026 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0120  0.0631  0.0088  0.0122  0.0508  0.0313  0.0048  0.0023  0.0253 </r>
+        <r>  0.0119  0.0631  0.0088  0.0122  0.0507  0.0311  0.0048  0.0023  0.0254 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0287  0.0052  0.0121  0.0010  0.0143  0.0454  0.0033  0.1169  0.0344 </r>
+        <r>  0.0283  0.0052  0.0122  0.0010  0.0140  0.0461  0.0033  0.1160  0.0351 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0033  0.0011  0.0141  0.0077  0.0126  0.0789  0.0047  0.0563  0.0374 </r>
+        <r>  0.0033  0.0011  0.0141  0.0077  0.0126  0.0782  0.0046  0.0568  0.0371 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0517  0.0134  0.0202  0.0209  0.0082  0.0021  0.0105  0.0106  0.1258 </r>
+        <r>  0.0515  0.0132  0.0201  0.0210  0.0082  0.0016  0.0107  0.0104  0.1267 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0040  0.0224  0.0023  0.0007  0.0008  0.2099  0.0039  0.0054  0.0236 </r>
+        <r>  0.0042  0.0223  0.0024  0.0007  0.0008  0.2097  0.0039  0.0055  0.0223 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0265  0.0194  0.0091  0.0073  0.0034  0.1076  0.0025  0.0784  0.0771 </r>
+        <r>  0.0264  0.0195  0.0091  0.0073  0.0034  0.1082  0.0026  0.0780  0.0773 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0336  0.0016  0.0020  0.0233  0.0418  0.0167  0.0040  0.1022  0.1282 </r>
+        <r>  0.0326  0.0016  0.0020  0.0231  0.0425  0.0167  0.0041  0.1013  0.1285 </r>
+       </set>
+      </set>
+      <set comment="kpoint 29">
+       <set comment="band 1">
+        <r>  0.3977  0.0152  0.0023  0.0013  0.0011  0.0001  0.0003  0.0002  0.0000 </r>
+        <r>  0.3977  0.0151  0.0024  0.0013  0.0011  0.0001  0.0003  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4122  0.0214  0.0009  0.0018  0.0012  0.0003  0.0006  0.0001  0.0003 </r>
+        <r>  0.4123  0.0214  0.0009  0.0018  0.0012  0.0003  0.0006  0.0001  0.0003 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0104  0.0894  0.0428  0.1688  0.0011  0.0000  0.0036  0.0019  0.0057 </r>
+        <r>  0.0104  0.0894  0.0428  0.1687  0.0011  0.0000  0.0036  0.0020  0.0056 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0189  0.0960  0.0981  0.0975  0.0027  0.0003  0.0033  0.0013  0.0008 </r>
+        <r>  0.0190  0.0957  0.0981  0.0976  0.0027  0.0003  0.0033  0.0013  0.0008 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0172  0.0824  0.1910  0.0424  0.0009  0.0022  0.0038  0.0028  0.0011 </r>
+        <r>  0.0172  0.0824  0.1909  0.0424  0.0009  0.0022  0.0038  0.0028  0.0011 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0240  0.0927  0.1207  0.0577  0.0053  0.0083  0.0042  0.0149  0.0012 </r>
+        <r>  0.0240  0.0927  0.1207  0.0577  0.0054  0.0083  0.0042  0.0149  0.0012 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0303  0.0916  0.0857  0.1241  0.0001  0.0045  0.0122  0.0084  0.0143 </r>
+        <r>  0.0302  0.0918  0.0857  0.1237  0.0001  0.0045  0.0123  0.0084  0.0142 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0072  0.0606  0.0811  0.1708  0.0301  0.0020  0.0030  0.0029  0.0084 </r>
+        <r>  0.0073  0.0604  0.0810  0.1712  0.0299  0.0020  0.0031  0.0029  0.0084 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0034  0.0416  0.0163  0.0034  0.0231  0.0047  0.0872  0.0141  0.0058 </r>
+        <r>  0.0034  0.0415  0.0163  0.0033  0.0229  0.0047  0.0871  0.0140  0.0058 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0004  0.0656  0.0044  0.0087  0.0334  0.0258  0.0015  0.0090  0.0563 </r>
+        <r>  0.0004  0.0655  0.0044  0.0087  0.0333  0.0257  0.0015  0.0089  0.0565 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0030  0.0306  0.0104  0.0004  0.0251  0.0222  0.0113  0.0354  0.0660 </r>
+        <r>  0.0030  0.0308  0.0106  0.0003  0.0250  0.0222  0.0113  0.0347  0.0661 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0090  0.0132  0.0222  0.0001  0.0133  0.0285  0.0014  0.1114  0.0049 </r>
+        <r>  0.0088  0.0130  0.0221  0.0001  0.0133  0.0287  0.0014  0.1113  0.0050 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0048  0.0383  0.0237  0.0114  0.0196  0.0568  0.0069  0.0605  0.0601 </r>
+        <r>  0.0048  0.0384  0.0235  0.0113  0.0195  0.0554  0.0070  0.0609  0.0607 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0349  0.0082  0.0093  0.0106  0.0086  0.1913  0.0080  0.0058  0.0602 </r>
+        <r>  0.0347  0.0080  0.0095  0.0108  0.0086  0.1920  0.0079  0.0057  0.0596 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0432  0.0266  0.0172  0.0111  0.0089  0.1734  0.0079  0.0274  0.0530 </r>
+        <r>  0.0430  0.0267  0.0172  0.0111  0.0090  0.1736  0.0081  0.0274  0.0528 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0187  0.0246  0.0020  0.0171  0.1422  0.0107  0.0080  0.0007  0.0111 </r>
+        <r>  0.0187  0.0247  0.0021  0.0169  0.1409  0.0107  0.0084  0.0007  0.0109 </r>
+       </set>
+      </set>
+      <set comment="kpoint 30">
+       <set comment="band 1">
+        <r>  0.3990  0.0030  0.0033  0.0062  0.0014  0.0000  0.0003  0.0001  0.0002 </r>
+        <r>  0.3991  0.0030  0.0033  0.0062  0.0014  0.0000  0.0003  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4352  0.0036  0.0034  0.0075  0.0022  0.0000  0.0015  0.0000  0.0003 </r>
+        <r>  0.4353  0.0036  0.0034  0.0075  0.0022  0.0000  0.0015  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0206  0.0820  0.0289  0.1708  0.0055  0.0004  0.0014  0.0008  0.0008 </r>
+        <r>  0.0206  0.0820  0.0289  0.1708  0.0055  0.0004  0.0014  0.0008  0.0008 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2362  0.0000  0.1134  0.0004  0.0006  0.0000  0.0003  0.0031 </r>
+        <r>  0.0000  0.2360  0.0000  0.1134  0.0004  0.0006  0.0000  0.0003  0.0031 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0054  0.0076  0.2901  0.0158  0.0010  0.0004  0.0016  0.0008  0.0001 </r>
+        <r>  0.0054  0.0076  0.2901  0.0158  0.0010  0.0004  0.0016  0.0008  0.0001 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0038  0.0006  0.1382  0.0013  0.0274  0.0006  0.0657  0.0011  0.0039 </r>
+        <r>  0.0038  0.0007  0.1382  0.0014  0.0273  0.0006  0.0657  0.0012  0.0038 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0281  0.1100  0.0010  0.2297  0.0265  0.0006  0.0023  0.0012  0.0037 </r>
+        <r>  0.0282  0.1104  0.0009  0.2293  0.0265  0.0006  0.0023  0.0012  0.0037 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2389  0.0000  0.1144  0.0011  0.0120  0.0000  0.0057  0.0079 </r>
+        <r>  0.0000  0.2386  0.0000  0.1149  0.0011  0.0120  0.0000  0.0058  0.0079 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0073  0.0005  0.1953  0.0010  0.0050  0.0021  0.0388  0.0043  0.0007 </r>
+        <r>  0.0073  0.0005  0.1953  0.0010  0.0050  0.0021  0.0388  0.0043  0.0007 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0744  0.0059  0.0365  0.0124  0.0592  0.0070  0.0153  0.0147  0.0083 </r>
+        <r>  0.0741  0.0059  0.0365  0.0124  0.0591  0.0070  0.0155  0.0145  0.0083 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0149  0.0000  0.0072  0.0097  0.1524  0.0000  0.0732  0.0689 </r>
+        <r>  0.0000  0.0149  0.0000  0.0071  0.0097  0.1526  0.0000  0.0732  0.0690 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0077  0.0103  0.0211  0.0215  0.0002  0.0494  0.0041  0.1030  0.0000 </r>
+        <r>  0.0076  0.0103  0.0213  0.0215  0.0002  0.0492  0.0041  0.1024  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0150  0.0000  0.0072  0.0180  0.0646  0.0000  0.0310  0.1282 </r>
+        <r>  0.0000  0.0150  0.0000  0.0072  0.0181  0.0646  0.0000  0.0311  0.1285 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0050  0.0000  0.0024  0.0159  0.0953  0.0000  0.0459  0.1127 </r>
+        <r>  0.0000  0.0049  0.0000  0.0024  0.0158  0.0952  0.0000  0.0457  0.1126 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0689  0.0165  0.0017  0.0345  0.0122  0.0134  0.0267  0.0277  0.0017 </r>
+        <r>  0.0684  0.0165  0.0017  0.0343  0.0119  0.0133  0.0267  0.0278  0.0017 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0147  0.0016  0.0046  0.0034  0.0227  0.0228  0.0279  0.0475  0.0032 </r>
+        <r>  0.0145  0.0016  0.0046  0.0034  0.0226  0.0226  0.0277  0.0469  0.0032 </r>
+       </set>
+      </set>
+      <set comment="kpoint 31">
+       <set comment="band 1">
+        <r>  0.3941  0.0083  0.0025  0.0032  0.0008  0.0000  0.0002  0.0001  0.0000 </r>
+        <r>  0.3942  0.0083  0.0025  0.0032  0.0008  0.0000  0.0002  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4288  0.0150  0.0024  0.0031  0.0013  0.0001  0.0009  0.0000  0.0003 </r>
+        <r>  0.4289  0.0150  0.0023  0.0031  0.0013  0.0001  0.0009  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0057  0.0895  0.1118  0.1179  0.0014  0.0002  0.0020  0.0027  0.0040 </r>
+        <r>  0.0056  0.0895  0.1117  0.1178  0.0014  0.0002  0.0020  0.0028  0.0039 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0166  0.1672  0.0382  0.1156  0.0042  0.0006  0.0017  0.0010  0.0010 </r>
+        <r>  0.0167  0.1668  0.0383  0.1159  0.0041  0.0006  0.0017  0.0010  0.0010 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0141  0.0441  0.1787  0.0768  0.0030  0.0003  0.0034  0.0012  0.0020 </r>
+        <r>  0.0141  0.0444  0.1787  0.0766  0.0031  0.0003  0.0034  0.0011  0.0020 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0343  0.0994  0.0032  0.2185  0.0093  0.0011  0.0081  0.0004  0.0106 </r>
+        <r>  0.0346  0.0984  0.0034  0.2195  0.0091  0.0011  0.0081  0.0004  0.0105 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0122  0.0585  0.1735  0.0400  0.0130  0.0045  0.0106  0.0109  0.0031 </r>
+        <r>  0.0119  0.0596  0.1733  0.0387  0.0132  0.0045  0.0107  0.0109  0.0030 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0050  0.1126  0.0479  0.0817  0.0274  0.0038  0.0287  0.0017  0.0021 </r>
+        <r>  0.0050  0.1124  0.0479  0.0820  0.0272  0.0038  0.0287  0.0016  0.0021 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0003  0.0313  0.0911  0.0112  0.0064  0.0017  0.0568  0.0187  0.0083 </r>
+        <r>  0.0003  0.0313  0.0911  0.0112  0.0063  0.0018  0.0568  0.0186  0.0082 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0019  0.0038  0.0148  0.0089  0.0186  0.0350  0.0114  0.0555  0.0612 </r>
+        <r>  0.0017  0.0039  0.0148  0.0089  0.0182  0.0358  0.0115  0.0544  0.0616 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0581  0.0391  0.0062  0.0007  0.0531  0.0493  0.0121  0.0290  0.0063 </r>
+        <r>  0.0579  0.0391  0.0063  0.0007  0.0532  0.0485  0.0120  0.0295  0.0061 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0043  0.0290  0.0175  0.0023  0.0246  0.0754  0.0018  0.0607  0.0798 </r>
+        <r>  0.0041  0.0286  0.0174  0.0024  0.0248  0.0749  0.0018  0.0610  0.0800 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0062  0.0399  0.0244  0.0018  0.0135  0.0758  0.0015  0.0707  0.0084 </r>
+        <r>  0.0063  0.0400  0.0245  0.0018  0.0135  0.0761  0.0016  0.0706  0.0085 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0011  0.0060  0.0045  0.0001  0.0070  0.0063  0.0394  0.0193  0.0436 </r>
+        <r>  0.0011  0.0061  0.0045  0.0001  0.0069  0.0064  0.0394  0.0192  0.0430 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0386  0.0105  0.0002  0.0126  0.0041  0.1306  0.0100  0.0057  0.1330 </r>
+        <r>  0.0384  0.0103  0.0002  0.0126  0.0041  0.1300  0.0099  0.0056  0.1337 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0070  0.0120  0.0086  0.0047  0.0033  0.1363  0.0008  0.0168  0.0692 </r>
+        <r>  0.0070  0.0121  0.0087  0.0048  0.0033  0.1368  0.0008  0.0168  0.0690 </r>
+       </set>
+      </set>
+      <set comment="kpoint 32">
+       <set comment="band 1">
+        <r>  0.3924  0.0025  0.0023  0.0053  0.0004  0.0000  0.0001  0.0001  0.0001 </r>
+        <r>  0.3924  0.0025  0.0023  0.0053  0.0004  0.0000  0.0001  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4404  0.0048  0.0032  0.0099  0.0010  0.0000  0.0008  0.0000  0.0001 </r>
+        <r>  0.4405  0.0048  0.0032  0.0099  0.0010  0.0000  0.0008  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0060  0.0128  0.2850  0.0268  0.0024  0.0016  0.0001  0.0032  0.0003 </r>
+        <r>  0.0060  0.0129  0.2850  0.0267  0.0024  0.0016  0.0001  0.0033  0.0003 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2429  0.0000  0.1166  0.0006  0.0007  0.0000  0.0004  0.0044 </r>
+        <r>  0.0000  0.2426  0.0000  0.1166  0.0006  0.0007  0.0000  0.0004  0.0043 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0225  0.0790  0.0458  0.1646  0.0088  0.0001  0.0058  0.0001  0.0012 </r>
+        <r>  0.0225  0.0791  0.0458  0.1647  0.0088  0.0001  0.0058  0.0001  0.0012 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0334  0.1038  0.0002  0.2163  0.0141  0.0004  0.0039  0.0008  0.0020 </r>
+        <r>  0.0335  0.1039  0.0002  0.2162  0.0141  0.0004  0.0039  0.0007  0.0020 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0045  0.0004  0.2342  0.0009  0.0244  0.0004  0.0328  0.0009  0.0034 </r>
+        <r>  0.0044  0.0004  0.2341  0.0008  0.0243  0.0004  0.0327  0.0009  0.0034 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2284  0.0000  0.1097  0.0017  0.0101  0.0000  0.0049  0.0121 </r>
+        <r>  0.0000  0.2285  0.0000  0.1097  0.0017  0.0101  0.0000  0.0049  0.0120 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0053  0.0003  0.0842  0.0006  0.0144  0.0027  0.0654  0.0057  0.0020 </r>
+        <r>  0.0053  0.0003  0.0842  0.0006  0.0142  0.0027  0.0654  0.0057  0.0020 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0136  0.0017  0.0232  0.0036  0.0259  0.0503  0.0130  0.1051  0.0037 </r>
+        <r>  0.0134  0.0017  0.0231  0.0035  0.0259  0.0503  0.0130  0.1044  0.0036 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0158  0.0000  0.0076  0.0238  0.0382  0.0000  0.0183  0.1688 </r>
+        <r>  0.0000  0.0157  0.0000  0.0075  0.0238  0.0382  0.0000  0.0184  0.1690 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0841  0.0082  0.0247  0.0170  0.0379  0.0061  0.0122  0.0128  0.0053 </r>
+        <r>  0.0839  0.0082  0.0248  0.0171  0.0378  0.0062  0.0122  0.0128  0.0053 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0089  0.0000  0.0043  0.0035  0.1843  0.0000  0.0884  0.0247 </r>
+        <r>  0.0000  0.0089  0.0000  0.0043  0.0035  0.1842  0.0000  0.0885  0.0248 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0001  0.0002  0.0037  0.0004  0.0175  0.0066  0.0526  0.0139  0.0025 </r>
+        <r>  0.0001  0.0002  0.0037  0.0004  0.0173  0.0067  0.0526  0.0138  0.0024 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0115  0.0301  0.0007  0.0626  0.1501  0.0025  0.0562  0.0052  0.0211 </r>
+        <r>  0.0115  0.0300  0.0007  0.0625  0.1498  0.0025  0.0564  0.0051  0.0211 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0089  0.0000  0.0042  0.0201  0.0643  0.0000  0.0309  0.1428 </r>
+        <r>  0.0000  0.0088  0.0000  0.0042  0.0201  0.0640  0.0000  0.0307  0.1429 </r>
+       </set>
+      </set>
+      <set comment="kpoint 33">
+       <set comment="band 1">
+        <r>  0.3937  0.0006  0.0044  0.0013  0.0000  0.0001  0.0001  0.0001  0.0000 </r>
+        <r>  0.3937  0.0006  0.0045  0.0013  0.0000  0.0001  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4363  0.0020  0.0137  0.0041  0.0000  0.0001  0.0001  0.0001  0.0000 </r>
+        <r>  0.4364  0.0020  0.0137  0.0041  0.0000  0.0001  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0007  0.0882  0.2878  0.0044  0.0013  0.0010  0.0004  0.0004 </r>
+        <r>  0.0000  0.0007  0.0870  0.2887  0.0046  0.0012  0.0009  0.0006  0.0002 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.3383  0.0277  0.0107  0.0008  0.0027  0.0003  0.0018  0.0019 </r>
+        <r>  0.0000  0.3387  0.0273  0.0105  0.0007  0.0028  0.0003  0.0017  0.0020 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0425  0.0291  0.2007  0.0602  0.0005  0.0016  0.0023  0.0034  0.0001 </r>
+        <r>  0.0425  0.0286  0.2022  0.0594  0.0005  0.0016  0.0023  0.0034  0.0001 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0001  0.1474  0.0044  0.1565  0.0096  0.0180  0.0005  0.0089  0.0118 </r>
+        <r>  0.0001  0.1463  0.0066  0.1556  0.0055  0.0220  0.0003  0.0049  0.0157 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0025  0.1358  0.0696  0.1008  0.0241  0.0028  0.0060  0.0034  0.0100 </r>
+        <r>  0.0024  0.1179  0.1113  0.0768  0.0282  0.0001  0.0026  0.0095  0.0058 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0350  0.0216  0.2082  0.0434  0.0028  0.0025  0.0010  0.0049  0.0006 </r>
+        <r>  0.0350  0.0406  0.1641  0.0683  0.0026  0.0011  0.0046  0.0028  0.0007 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0136  0.0018  0.0126  0.0038  0.0062  0.0208  0.0294  0.0435  0.0009 </r>
+        <r>  0.0135  0.0018  0.0127  0.0038  0.0061  0.0208  0.0294  0.0432  0.0009 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0072  0.0004  0.0041  0.0198  0.0148  0.0115  0.0013  0.1676 </r>
+        <r>  0.0000  0.0072  0.0004  0.0042  0.0338  0.0008  0.0118  0.0155  0.1533 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0033  0.0032  0.0053  0.0382  0.0154  0.0913  0.0524  0.0180 </r>
+        <r>  0.0000  0.0034  0.0032  0.0053  0.0239  0.0293  0.0911  0.0382  0.0325 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0577  0.0052  0.0365  0.0109  0.0008  0.0026  0.0036  0.0054  0.0001 </r>
+        <r>  0.0576  0.0052  0.0366  0.0109  0.0008  0.0026  0.0036  0.0053  0.0001 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0421  0.0048  0.0338  0.0101  0.0045  0.0146  0.0207  0.0308  0.0006 </r>
+        <r>  0.0419  0.0048  0.0338  0.0100  0.0042  0.0148  0.0209  0.0304  0.0006 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0229  0.0001  0.0117  0.0007  0.2059  0.0004  0.0978  0.0030 </r>
+        <r>  0.0000  0.0229  0.0001  0.0117  0.0025  0.2041  0.0004  0.0997  0.0012 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0083  0.0106  0.0158  0.2047  0.0007  0.0723  0.0020  0.0280 </r>
+        <r>  0.0000  0.0083  0.0105  0.0158  0.2029  0.0026  0.0720  0.0002  0.0298 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0163  0.0012  0.0009  0.0161  0.0513  0.0360  0.0001  0.1555 </r>
+        <r>  0.0000  0.0163  0.0012  0.0009  0.0181  0.0497  0.0360  0.0020  0.1538 </r>
+       </set>
+      </set>
+      <set comment="kpoint 34">
+       <set comment="band 1">
+        <r>  0.3936  0.0003  0.0042  0.0055  0.0000  0.0001  0.0001  0.0002  0.0000 </r>
+        <r>  0.3937  0.0003  0.0043  0.0055  0.0000  0.0001  0.0001  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4249  0.0004  0.0093  0.0131  0.0001  0.0006  0.0002  0.0000  0.0000 </r>
+        <r>  0.4250  0.0004  0.0093  0.0131  0.0001  0.0006  0.0002  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0027  0.1061  0.1561  0.0711  0.0021  0.0001  0.0017  0.0023  0.0009 </r>
+        <r>  0.0027  0.1060  0.1561  0.0710  0.0021  0.0001  0.0017  0.0023  0.0009 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2576  0.0877  0.0360  0.0057  0.0032  0.0040  0.0003  0.0003 </r>
+        <r>  0.0000  0.2575  0.0872  0.0365  0.0056  0.0033  0.0041  0.0003  0.0003 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0512  0.0012  0.0626  0.2243  0.0028  0.0067  0.0010  0.0005  0.0027 </r>
+        <r>  0.0512  0.0012  0.0632  0.2241  0.0028  0.0067  0.0010  0.0005  0.0027 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0394  0.0027  0.0706  0.1958  0.0034  0.0115  0.0017  0.0000  0.0013 </r>
+        <r>  0.0395  0.0026  0.0714  0.1948  0.0034  0.0115  0.0017  0.0000  0.0012 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2014  0.0688  0.0280  0.0212  0.0040  0.0031  0.0070  0.0112 </r>
+        <r>  0.0000  0.2016  0.0679  0.0288  0.0212  0.0040  0.0031  0.0070  0.0111 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0025  0.1019  0.1610  0.0531  0.0167  0.0016  0.0058  0.0058  0.0070 </r>
+        <r>  0.0025  0.1019  0.1609  0.0531  0.0166  0.0016  0.0058  0.0057  0.0069 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0042  0.0160  0.0246  0.0117  0.0161  0.0143  0.0397  0.0159  0.0068 </r>
+        <r>  0.0042  0.0160  0.0247  0.0117  0.0160  0.0143  0.0397  0.0157  0.0068 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0014  0.0005  0.0002  0.0096  0.0227  0.0760  0.0369  0.0748 </r>
+        <r>  0.0000  0.0014  0.0005  0.0002  0.0095  0.0227  0.0760  0.0368  0.0747 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0160  0.0027  0.0144  0.0189  0.0176  0.0183  0.0022  0.0506  0.0830 </r>
+        <r>  0.0159  0.0027  0.0143  0.0189  0.0175  0.0179  0.0022  0.0508  0.0833 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0425  0.0018  0.0157  0.0074  0.0347  0.0881  0.0092  0.0621  0.0130 </r>
+        <r>  0.0422  0.0018  0.0157  0.0074  0.0345  0.0884  0.0092  0.0618  0.0130 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0037  0.0011  0.0019  0.0103  0.0226  0.0054  0.0315  0.0101  0.0168 </r>
+        <r>  0.0037  0.0011  0.0018  0.0103  0.0225  0.0053  0.0314  0.0100  0.0170 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0207  0.0002  0.0304  0.0741  0.0258  0.0735  0.0113  0.0239  0.0061 </r>
+        <r>  0.0206  0.0002  0.0304  0.0740  0.0257  0.0734  0.0113  0.0241  0.0061 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0323  0.0110  0.0046  0.1467  0.0534  0.0503  0.0210  0.0272 </r>
+        <r>  0.0000  0.0323  0.0109  0.0045  0.1467  0.0536  0.0503  0.0210  0.0272 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0317  0.0004  0.0027  0.0038  0.0009  0.0033  0.0097  0.1282  0.1061 </r>
+        <r>  0.0319  0.0004  0.0028  0.0038  0.0009  0.0034  0.0097  0.1284  0.1061 </r>
+       </set>
+      </set>
+      <set comment="kpoint 35">
+       <set comment="band 1">
+        <r>  0.3943  0.0006  0.0035  0.0124  0.0001  0.0002  0.0001  0.0004  0.0001 </r>
+        <r>  0.3943  0.0006  0.0035  0.0124  0.0001  0.0002  0.0001  0.0004  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4136  0.0008  0.0028  0.0206  0.0003  0.0011  0.0002  0.0001  0.0000 </r>
+        <r>  0.4137  0.0008  0.0028  0.0206  0.0003  0.0011  0.0002  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0010  0.1003  0.1576  0.0581  0.0010  0.0009  0.0027  0.0008  0.0012 </r>
+        <r>  0.0010  0.1003  0.1576  0.0580  0.0010  0.0009  0.0027  0.0008  0.0012 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2393  0.0814  0.0334  0.0080  0.0054  0.0077  0.0008  0.0012 </r>
+        <r>  0.0000  0.2391  0.0810  0.0339  0.0080  0.0055  0.0077  0.0008  0.0012 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0539  0.0024  0.0469  0.1776  0.0076  0.0114  0.0002  0.0000  0.0042 </r>
+        <r>  0.0538  0.0026  0.0473  0.1775  0.0076  0.0113  0.0002  0.0000  0.0042 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0518  0.0001  0.0945  0.2064  0.0032  0.0061  0.0010  0.0001  0.0029 </r>
+        <r>  0.0519  0.0001  0.0951  0.2054  0.0033  0.0061  0.0010  0.0001  0.0028 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2155  0.0735  0.0301  0.0198  0.0056  0.0042  0.0038  0.0053 </r>
+        <r>  0.0000  0.2157  0.0728  0.0307  0.0197  0.0056  0.0042  0.0038  0.0053 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0046  0.1030  0.1728  0.0461  0.0082  0.0068  0.0066  0.0023  0.0042 </r>
+        <r>  0.0046  0.1030  0.1728  0.0462  0.0081  0.0069  0.0066  0.0023  0.0042 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0028  0.0183  0.0217  0.0186  0.0227  0.0212  0.0454  0.0125  0.0138 </r>
+        <r>  0.0027  0.0183  0.0217  0.0185  0.0226  0.0212  0.0454  0.0123  0.0138 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0018  0.0006  0.0003  0.0112  0.0197  0.0707  0.0391  0.0783 </r>
+        <r>  0.0000  0.0018  0.0006  0.0003  0.0111  0.0197  0.0707  0.0389  0.0782 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0184  0.0028  0.0072  0.0644  0.0053  0.0161  0.0024  0.0486  0.0323 </r>
+        <r>  0.0183  0.0028  0.0073  0.0644  0.0052  0.0159  0.0025  0.0486  0.0324 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0263  0.0062  0.0183  0.0086  0.0450  0.0867  0.0046  0.0338  0.0084 </r>
+        <r>  0.0261  0.0062  0.0184  0.0086  0.0448  0.0868  0.0047  0.0336  0.0084 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0060  0.0004  0.0088  0.0272  0.0073  0.0231  0.0008  0.1182  0.0990 </r>
+        <r>  0.0061  0.0003  0.0089  0.0273  0.0074  0.0229  0.0008  0.1183  0.0993 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0030  0.0018  0.0001  0.0148  0.0337  0.0031  0.0366  0.0039  0.0398 </r>
+        <r>  0.0030  0.0018  0.0001  0.0149  0.0334  0.0031  0.0365  0.0038  0.0401 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0358  0.0122  0.0050  0.1387  0.0522  0.0499  0.0189  0.0241 </r>
+        <r>  0.0000  0.0357  0.0121  0.0050  0.1386  0.0524  0.0500  0.0189  0.0240 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0369  0.0005  0.0207  0.0673  0.0170  0.0518  0.0137  0.1005  0.0294 </r>
+        <r>  0.0370  0.0005  0.0207  0.0669  0.0169  0.0519  0.0136  0.1007  0.0293 </r>
+       </set>
+      </set>
+      <set comment="kpoint 36">
+       <set comment="band 1">
+        <r>  0.3984  0.0012  0.0021  0.0194  0.0001  0.0006  0.0001  0.0004  0.0001 </r>
+        <r>  0.3984  0.0011  0.0021  0.0194  0.0001  0.0006  0.0001  0.0004  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3997  0.0030  0.0002  0.0222  0.0003  0.0010  0.0002  0.0004  0.0001 </r>
+        <r>  0.3997  0.0030  0.0002  0.0222  0.0003  0.0010  0.0002  0.0004  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0099  0.0948  0.1539  0.0492  0.0002  0.0027  0.0030  0.0002  0.0014 </r>
+        <r>  0.0099  0.0948  0.1539  0.0491  0.0002  0.0027  0.0030  0.0002  0.0014 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2323  0.0789  0.0325  0.0062  0.0048  0.0071  0.0006  0.0010 </r>
+        <r>  0.0000  0.2321  0.0787  0.0328  0.0062  0.0048  0.0072  0.0006  0.0010 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0509  0.0013  0.0602  0.1776  0.0073  0.0089  0.0001  0.0002  0.0039 </r>
+        <r>  0.0509  0.0014  0.0603  0.1775  0.0072  0.0088  0.0001  0.0002  0.0039 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0487  0.0009  0.0977  0.1806  0.0078  0.0070  0.0005  0.0001  0.0058 </r>
+        <r>  0.0487  0.0008  0.0982  0.1801  0.0079  0.0069  0.0005  0.0001  0.0057 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2151  0.0733  0.0301  0.0204  0.0095  0.0106  0.0020  0.0024 </r>
+        <r>  0.0000  0.2154  0.0728  0.0305  0.0204  0.0096  0.0106  0.0021  0.0024 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0139  0.0935  0.1666  0.0356  0.0021  0.0220  0.0100  0.0019  0.0028 </r>
+        <r>  0.0139  0.0935  0.1666  0.0357  0.0021  0.0220  0.0101  0.0019  0.0028 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0010  0.0106  0.0058  0.0504  0.0201  0.0021  0.0234  0.0448  0.0347 </r>
+        <r>  0.0009  0.0105  0.0059  0.0500  0.0201  0.0020  0.0233  0.0444  0.0350 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0102  0.0099  0.0120  0.0385  0.0164  0.0259  0.0208  0.0203  0.0340 </r>
+        <r>  0.0102  0.0099  0.0119  0.0389  0.0162  0.0259  0.0208  0.0204  0.0340 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0094  0.0032  0.0013  0.0127  0.0162  0.0641  0.0405  0.0806 </r>
+        <r>  0.0000  0.0094  0.0032  0.0013  0.0126  0.0163  0.0639  0.0405  0.0801 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0155  0.0231  0.0143  0.0511  0.0090  0.0614  0.0144  0.0255  0.0190 </r>
+        <r>  0.0155  0.0231  0.0145  0.0506  0.0089  0.0608  0.0143  0.0258  0.0191 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0009  0.0077  0.0279  0.0333  0.0060  0.0291  0.0048  0.1043  0.0545 </r>
+        <r>  0.0009  0.0076  0.0278  0.0338  0.0061  0.0296  0.0049  0.1036  0.0547 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0248  0.0084  0.0035  0.0374  0.0087  0.0456  0.0527  0.0993 </r>
+        <r>  0.0000  0.0246  0.0084  0.0034  0.0367  0.0088  0.0456  0.0527  0.0992 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0456  0.0029  0.0012  0.0282  0.1281  0.0283  0.0293  0.1586  0.0034 </r>
+        <r>  0.0448  0.0028  0.0012  0.0280  0.1267  0.0283  0.0291  0.1581  0.0033 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0380  0.0128  0.0056  0.1298  0.0365  0.0293  0.0243  0.0337 </r>
+        <r>  0.0000  0.0379  0.0127  0.0058  0.1267  0.0375  0.0295  0.0249  0.0350 </r>
+       </set>
+      </set>
+      <set comment="kpoint 37">
+       <set comment="band 1">
+        <r>  0.3990  0.0026  0.0004  0.0178  0.0003  0.0010  0.0002  0.0002  0.0000 </r>
+        <r>  0.3991  0.0026  0.0004  0.0177  0.0003  0.0010  0.0002  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3991  0.0041  0.0011  0.0235  0.0001  0.0006  0.0002  0.0008  0.0002 </r>
+        <r>  0.3991  0.0041  0.0011  0.0236  0.0001  0.0006  0.0002  0.0008  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0218  0.0914  0.1447  0.0468  0.0005  0.0049  0.0028  0.0007  0.0017 </r>
+        <r>  0.0219  0.0914  0.1447  0.0466  0.0005  0.0049  0.0028  0.0007  0.0017 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2341  0.0796  0.0328  0.0031  0.0036  0.0060  0.0002  0.0005 </r>
+        <r>  0.0000  0.2340  0.0794  0.0330  0.0031  0.0036  0.0061  0.0002  0.0005 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0393  0.0001  0.0764  0.1883  0.0061  0.0053  0.0001  0.0005  0.0033 </r>
+        <r>  0.0392  0.0001  0.0765  0.1884  0.0060  0.0053  0.0001  0.0005  0.0033 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0371  0.0015  0.1007  0.1683  0.0102  0.0083  0.0003  0.0014  0.0080 </r>
+        <r>  0.0371  0.0015  0.1011  0.1680  0.0102  0.0083  0.0003  0.0014  0.0080 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2097  0.0714  0.0295  0.0205  0.0117  0.0146  0.0016  0.0019 </r>
+        <r>  0.0000  0.2100  0.0710  0.0296  0.0205  0.0117  0.0146  0.0016  0.0018 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0223  0.0910  0.1600  0.0360  0.0011  0.0240  0.0109  0.0025  0.0029 </r>
+        <r>  0.0222  0.0908  0.1600  0.0362  0.0011  0.0240  0.0110  0.0025  0.0029 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0049  0.0016  0.0031  0.0276  0.0103  0.0139  0.0007  0.0483  0.0526 </r>
+        <r>  0.0049  0.0016  0.0031  0.0276  0.0103  0.0138  0.0007  0.0482  0.0528 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0069  0.0234  0.0091  0.0775  0.0301  0.0126  0.0402  0.0171  0.0132 </r>
+        <r>  0.0067  0.0234  0.0091  0.0777  0.0297  0.0126  0.0400  0.0168  0.0132 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0237  0.0081  0.0033  0.0033  0.0210  0.0708  0.0312  0.0644 </r>
+        <r>  0.0000  0.0238  0.0081  0.0033  0.0032  0.0210  0.0705  0.0310  0.0640 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0100  0.0204  0.0101  0.0647  0.0213  0.0216  0.0444  0.0386  0.0036 </r>
+        <r>  0.0099  0.0203  0.0102  0.0642  0.0211  0.0215  0.0445  0.0384  0.0037 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0196  0.0066  0.0027  0.0473  0.0073  0.0435  0.0598  0.1114 </r>
+        <r>  0.0000  0.0193  0.0066  0.0027  0.0469  0.0074  0.0438  0.0594  0.1113 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0212  0.0004  0.0306  0.0549  0.0025  0.0496  0.0188  0.0745  0.0283 </r>
+        <r>  0.0210  0.0003  0.0304  0.0552  0.0024  0.0497  0.0189  0.0745  0.0284 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0247  0.0084  0.0035  0.1879  0.0512  0.0416  0.0415  0.0611 </r>
+        <r>  0.0000  0.0248  0.0084  0.0035  0.1874  0.0515  0.0417  0.0418  0.0612 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0750  0.0021  0.0109  0.0087  0.0006  0.0325  0.0294  0.0788  0.0752 </r>
+        <r>  0.0748  0.0020  0.0110  0.0087  0.0006  0.0328  0.0295  0.0792  0.0757 </r>
+       </set>
+      </set>
+      <set comment="kpoint 38">
+       <set comment="band 1">
+        <r>  0.3930  0.0033  0.0018  0.0108  0.0001  0.0007  0.0001  0.0001  0.0000 </r>
+        <r>  0.3931  0.0033  0.0018  0.0107  0.0001  0.0007  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4191  0.0046  0.0006  0.0207  0.0002  0.0008  0.0002  0.0008  0.0002 </r>
+        <r>  0.4191  0.0045  0.0006  0.0207  0.0002  0.0008  0.0002  0.0008  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0312  0.0648  0.1057  0.1097  0.0035  0.0058  0.0022  0.0007  0.0029 </r>
+        <r>  0.0313  0.0638  0.1066  0.1097  0.0035  0.0057  0.0022  0.0007  0.0029 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2375  0.0813  0.0336  0.0009  0.0023  0.0046  0.0002  0.0007 </r>
+        <r>  0.0000  0.2387  0.0804  0.0333  0.0009  0.0023  0.0046  0.0002  0.0006 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0166  0.0257  0.1224  0.1491  0.0021  0.0027  0.0004  0.0024  0.0009 </r>
+        <r>  0.0165  0.0254  0.1224  0.1495  0.0021  0.0027  0.0004  0.0024  0.0009 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0287  0.0958  0.1628  0.0418  0.0014  0.0175  0.0076  0.0040  0.0041 </r>
+        <r>  0.0289  0.0959  0.1639  0.0410  0.0013  0.0174  0.0076  0.0040  0.0041 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0212  0.0021  0.0891  0.1700  0.0105  0.0133  0.0003  0.0044  0.0124 </r>
+        <r>  0.0210  0.0020  0.0881  0.1706  0.0104  0.0134  0.0003  0.0045  0.0124 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2136  0.0725  0.0300  0.0169  0.0098  0.0129  0.0020  0.0029 </r>
+        <r>  0.0000  0.2136  0.0725  0.0301  0.0170  0.0097  0.0129  0.0020  0.0029 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0086  0.0013  0.0100  0.0233  0.0117  0.0128  0.0008  0.0406  0.0480 </r>
+        <r>  0.0086  0.0013  0.0101  0.0233  0.0117  0.0127  0.0008  0.0405  0.0481 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0160  0.0095  0.0035  0.0435  0.0291  0.0307  0.0575  0.0462  0.0056 </r>
+        <r>  0.0158  0.0095  0.0036  0.0435  0.0287  0.0306  0.0575  0.0460  0.0056 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0234  0.0079  0.0033  0.0349  0.0247  0.0704  0.0412  0.0797 </r>
+        <r>  0.0000  0.0234  0.0079  0.0032  0.0348  0.0250  0.0703  0.0408  0.0794 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0316  0.0151  0.0052  0.1100  0.0186  0.0186  0.0045  0.0230  0.0003 </r>
+        <r>  0.0317  0.0150  0.0053  0.1101  0.0184  0.0185  0.0044  0.0230  0.0003 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0292  0.0099  0.0041  0.0827  0.0506  0.0696  0.0100  0.0149 </r>
+        <r>  0.0000  0.0293  0.0099  0.0041  0.0828  0.0507  0.0695  0.0100  0.0149 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0055  0.0018  0.0008  0.1236  0.0024  0.0118  0.0827  0.1440 </r>
+        <r>  0.0000  0.0053  0.0019  0.0007  0.1227  0.0024  0.0118  0.0826  0.1444 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0412  0.0102  0.0162  0.0075  0.0062  0.0385  0.0511  0.0149  0.0356 </r>
+        <r>  0.0409  0.0101  0.0161  0.0074  0.0064  0.0386  0.0516  0.0149  0.0359 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0357  0.0032  0.0035  0.0086  0.0477  0.0165  0.0523  0.0114  0.0441 </r>
+        <r>  0.0353  0.0031  0.0035  0.0085  0.0477  0.0166  0.0519  0.0114  0.0436 </r>
+       </set>
+      </set>
+      <set comment="kpoint 39">
+       <set comment="band 1">
+        <r>  0.3946  0.0022  0.0049  0.0045  0.0002  0.0001  0.0001  0.0002  0.0000 </r>
+        <r>  0.3947  0.0022  0.0049  0.0045  0.0002  0.0001  0.0001  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4188  0.0036  0.0121  0.0074  0.0004  0.0001  0.0006  0.0001  0.0001 </r>
+        <r>  0.4188  0.0036  0.0121  0.0074  0.0004  0.0001  0.0006  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0224  0.0195  0.2465  0.0406  0.0040  0.0011  0.0006  0.0024  0.0006 </r>
+        <r>  0.0224  0.0195  0.2464  0.0407  0.0040  0.0011  0.0006  0.0024  0.0006 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2411  0.0000  0.1158  0.0006  0.0035  0.0000  0.0017  0.0042 </r>
+        <r>  0.0000  0.2409  0.0000  0.1157  0.0006  0.0034  0.0000  0.0017  0.0041 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0241  0.0729  0.0556  0.1517  0.0156  0.0006  0.0062  0.0012  0.0022 </r>
+        <r>  0.0241  0.0729  0.0558  0.1518  0.0155  0.0006  0.0063  0.0012  0.0022 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0371  0.0971  0.0207  0.2021  0.0082  0.0011  0.0059  0.0022  0.0011 </r>
+        <r>  0.0371  0.0970  0.0208  0.2020  0.0082  0.0011  0.0059  0.0022  0.0011 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0213  0.0105  0.2577  0.0190  0.0211  0.0015  0.0061  0.0028  0.0029 </r>
+        <r>  0.0213  0.0086  0.2574  0.0210  0.0210  0.0013  0.0061  0.0030  0.0029 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2150  0.0000  0.1046  0.0022  0.0212  0.0000  0.0103  0.0162 </r>
+        <r>  0.0000  0.2170  0.0000  0.1026  0.0022  0.0213  0.0000  0.0100  0.0161 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0073  0.0011  0.0241  0.0022  0.0229  0.0008  0.0875  0.0017  0.0032 </r>
+        <r>  0.0072  0.0011  0.0242  0.0022  0.0228  0.0008  0.0875  0.0016  0.0032 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0035  0.0044  0.0182  0.0092  0.0075  0.0498  0.0168  0.1037  0.0011 </r>
+        <r>  0.0035  0.0044  0.0183  0.0092  0.0075  0.0497  0.0168  0.1035  0.0010 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0170  0.0000  0.0081  0.0262  0.0029  0.0000  0.0014  0.1861 </r>
+        <r>  0.0000  0.0170  0.0000  0.0082  0.0263  0.0030  0.0000  0.0015  0.1865 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0608  0.0055  0.0757  0.0114  0.0469  0.0021  0.0199  0.0045  0.0066 </r>
+        <r>  0.0605  0.0055  0.0757  0.0114  0.0468  0.0022  0.0201  0.0045  0.0066 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0257  0.0000  0.0123  0.0005  0.1905  0.0000  0.0916  0.0038 </r>
+        <r>  0.0000  0.0256  0.0000  0.0123  0.0005  0.1907  0.0000  0.0915  0.0039 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0014  0.0002  0.0051  0.0004  0.0158  0.0106  0.0439  0.0219  0.0022 </r>
+        <r>  0.0014  0.0002  0.0050  0.0004  0.0157  0.0104  0.0437  0.0218  0.0022 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0053  0.0254  0.0060  0.0529  0.0672  0.0365  0.0121  0.0759  0.0094 </r>
+        <r>  0.0054  0.0254  0.0060  0.0530  0.0670  0.0364  0.0122  0.0759  0.0094 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0084  0.0000  0.0040  0.0247  0.0524  0.0000  0.0251  0.1756 </r>
+        <r>  0.0000  0.0084  0.0000  0.0040  0.0247  0.0526  0.0000  0.0252  0.1757 </r>
+       </set>
+      </set>
+      <set comment="kpoint 40">
+       <set comment="band 1">
+        <r>  0.3969  0.0004  0.0051  0.0098  0.0005  0.0001  0.0002  0.0003  0.0001 </r>
+        <r>  0.3970  0.0004  0.0051  0.0097  0.0005  0.0001  0.0002  0.0003  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4165  0.0001  0.0081  0.0121  0.0009  0.0004  0.0007  0.0000  0.0001 </r>
+        <r>  0.4166  0.0001  0.0080  0.0121  0.0009  0.0004  0.0008  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0032  0.0868  0.1532  0.0773  0.0019  0.0002  0.0011  0.0015  0.0010 </r>
+        <r>  0.0032  0.0868  0.1531  0.0771  0.0019  0.0002  0.0011  0.0015  0.0010 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0172  0.1537  0.0055  0.1409  0.0101  0.0022  0.0038  0.0007  0.0002 </r>
+        <r>  0.0172  0.1535  0.0055  0.1411  0.0101  0.0022  0.0038  0.0007  0.0002 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0242  0.0970  0.1482  0.0658  0.0048  0.0051  0.0013  0.0004  0.0044 </r>
+        <r>  0.0242  0.0970  0.1483  0.0658  0.0048  0.0051  0.0013  0.0004  0.0043 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0316  0.1013  0.1170  0.0666  0.0014  0.0156  0.0050  0.0008  0.0078 </r>
+        <r>  0.0316  0.1012  0.1170  0.0666  0.0014  0.0156  0.0050  0.0008  0.0078 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0247  0.1214  0.0184  0.1899  0.0210  0.0030  0.0022  0.0049  0.0032 </r>
+        <r>  0.0247  0.1216  0.0184  0.1898  0.0210  0.0029  0.0022  0.0049  0.0031 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0014  0.1028  0.1295  0.0468  0.0226  0.0042  0.0237  0.0039  0.0020 </r>
+        <r>  0.0014  0.1027  0.1294  0.0469  0.0224  0.0042  0.0237  0.0039  0.0020 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0035  0.0192  0.0532  0.0211  0.0162  0.0030  0.0751  0.0020  0.0050 </r>
+        <r>  0.0034  0.0192  0.0533  0.0211  0.0161  0.0030  0.0751  0.0019  0.0050 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0005  0.0088  0.0133  0.0041  0.0050  0.0365  0.0125  0.0578  0.0784 </r>
+        <r>  0.0005  0.0089  0.0135  0.0041  0.0051  0.0368  0.0124  0.0571  0.0787 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0372  0.0049  0.0252  0.0262  0.0180  0.0370  0.0092  0.0519  0.0208 </r>
+        <r>  0.0370  0.0049  0.0251  0.0262  0.0178  0.0368  0.0093  0.0522  0.0209 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0112  0.0008  0.0099  0.0202  0.0300  0.0830  0.0019  0.0044  0.0362 </r>
+        <r>  0.0111  0.0008  0.0099  0.0203  0.0299  0.0830  0.0019  0.0043  0.0361 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0024  0.0021  0.0110  0.0325  0.0098  0.0190  0.0009  0.1015  0.1227 </r>
+        <r>  0.0025  0.0020  0.0111  0.0326  0.0100  0.0188  0.0009  0.1017  0.1232 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0243  0.0109  0.0198  0.0083  0.0442  0.0581  0.0111  0.1169  0.0041 </r>
+        <r>  0.0244  0.0109  0.0197  0.0083  0.0445  0.0586  0.0110  0.1166  0.0042 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0032  0.0013  0.0075  0.0009  0.0391  0.0467  0.0383  0.0114  0.0140 </r>
+        <r>  0.0032  0.0012  0.0076  0.0009  0.0387  0.0466  0.0383  0.0116  0.0141 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0109  0.0301  0.0036  0.0062  0.0000  0.0745  0.0016  0.0192  0.1002 </r>
+        <r>  0.0110  0.0302  0.0036  0.0062  0.0000  0.0746  0.0016  0.0191  0.1000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 41">
+       <set comment="band 1">
+        <r>  0.4016  0.0001  0.0045  0.0146  0.0006  0.0004  0.0003  0.0003  0.0002 </r>
+        <r>  0.4017  0.0001  0.0045  0.0146  0.0006  0.0004  0.0003  0.0003  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4111  0.0018  0.0023  0.0146  0.0012  0.0007  0.0006  0.0002  0.0001 </r>
+        <r>  0.4112  0.0018  0.0023  0.0146  0.0012  0.0007  0.0006  0.0002  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0014  0.0943  0.1515  0.0606  0.0006  0.0006  0.0023  0.0002  0.0007 </r>
+        <r>  0.0014  0.0944  0.1514  0.0604  0.0006  0.0006  0.0023  0.0002  0.0007 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0162  0.1266  0.0025  0.1644  0.0085  0.0010  0.0033  0.0005  0.0004 </r>
+        <r>  0.0162  0.1264  0.0026  0.1647  0.0085  0.0010  0.0033  0.0005  0.0004 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0252  0.0988  0.1796  0.0489  0.0021  0.0095  0.0031  0.0001  0.0009 </r>
+        <r>  0.0252  0.0988  0.1796  0.0489  0.0021  0.0095  0.0031  0.0001  0.0009 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0327  0.1124  0.1135  0.0421  0.0004  0.0168  0.0019  0.0024  0.0104 </r>
+        <r>  0.0327  0.1123  0.1135  0.0421  0.0004  0.0167  0.0019  0.0025  0.0103 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0206  0.1279  0.0083  0.1925  0.0329  0.0001  0.0041  0.0035  0.0001 </r>
+        <r>  0.0206  0.1281  0.0082  0.1924  0.0328  0.0001  0.0041  0.0036  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0058  0.1001  0.1529  0.0491  0.0127  0.0068  0.0195  0.0003  0.0014 </r>
+        <r>  0.0058  0.0999  0.1529  0.0493  0.0126  0.0068  0.0195  0.0003  0.0014 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0012  0.0243  0.0376  0.0148  0.0213  0.0139  0.0858  0.0016  0.0059 </r>
+        <r>  0.0011  0.0243  0.0376  0.0147  0.0212  0.0139  0.0857  0.0017  0.0058 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0036  0.0009  0.0049  0.0444  0.0054  0.0115  0.0003  0.0494  0.0583 </r>
+        <r>  0.0036  0.0009  0.0049  0.0445  0.0054  0.0114  0.0003  0.0493  0.0586 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0054  0.0034  0.0134  0.0123  0.0094  0.0301  0.0137  0.0533  0.0884 </r>
+        <r>  0.0054  0.0034  0.0134  0.0124  0.0094  0.0303  0.0137  0.0529  0.0882 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0367  0.0056  0.0051  0.0276  0.0303  0.0976  0.0048  0.0269  0.0004 </r>
+        <r>  0.0366  0.0056  0.0051  0.0277  0.0301  0.0975  0.0048  0.0270  0.0004 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0012  0.0011  0.0205  0.0380  0.0154  0.0154  0.0037  0.1068  0.0735 </r>
+        <r>  0.0012  0.0011  0.0206  0.0380  0.0156  0.0152  0.0037  0.1063  0.0741 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0201  0.0050  0.0027  0.0284  0.0232  0.0093  0.0037  0.1686  0.0635 </r>
+        <r>  0.0197  0.0050  0.0027  0.0283  0.0229  0.0092  0.0037  0.1685  0.0628 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0011  0.0184  0.0077  0.0009  0.0228  0.0919  0.0041  0.0256  0.1069 </r>
+        <r>  0.0011  0.0182  0.0079  0.0009  0.0230  0.0923  0.0040  0.0254  0.1080 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0197  0.0403  0.0114  0.0051  0.0840  0.0340  0.0263  0.0601  0.0398 </r>
+        <r>  0.0199  0.0402  0.0114  0.0051  0.0839  0.0346  0.0267  0.0601  0.0387 </r>
+       </set>
+      </set>
+      <set comment="kpoint 42">
+       <set comment="band 1">
+        <r>  0.4085  0.0029  0.0014  0.0145  0.0008  0.0011  0.0004  0.0002  0.0001 </r>
+        <r>  0.4086  0.0029  0.0014  0.0145  0.0008  0.0011  0.0004  0.0002  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4029  0.0053  0.0018  0.0148  0.0010  0.0004  0.0004  0.0006  0.0003 </r>
+        <r>  0.4029  0.0053  0.0018  0.0149  0.0010  0.0004  0.0004  0.0006  0.0003 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0125  0.1001  0.1358  0.0551  0.0011  0.0013  0.0040  0.0004  0.0010 </r>
+        <r>  0.0126  0.1004  0.1357  0.0546  0.0011  0.0013  0.0040  0.0005  0.0009 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0072  0.1143  0.0148  0.1750  0.0039  0.0012  0.0010  0.0001  0.0014 </r>
+        <r>  0.0071  0.1139  0.0148  0.1754  0.0039  0.0012  0.0011  0.0001  0.0014 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0275  0.0996  0.1663  0.0488  0.0005  0.0107  0.0026  0.0014  0.0011 </r>
+        <r>  0.0275  0.0996  0.1663  0.0489  0.0005  0.0108  0.0026  0.0014  0.0011 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0281  0.0935  0.1442  0.0403  0.0008  0.0149  0.0058  0.0024  0.0070 </r>
+        <r>  0.0281  0.0935  0.1443  0.0403  0.0008  0.0149  0.0058  0.0024  0.0070 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0075  0.1263  0.0172  0.1634  0.0325  0.0002  0.0054  0.0109  0.0059 </r>
+        <r>  0.0076  0.1269  0.0171  0.1630  0.0324  0.0002  0.0054  0.0110  0.0059 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0163  0.0980  0.1631  0.0549  0.0013  0.0224  0.0103  0.0016  0.0010 </r>
+        <r>  0.0162  0.0975  0.1631  0.0554  0.0013  0.0225  0.0104  0.0016  0.0010 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0050  0.0191  0.0005  0.0355  0.0120  0.0103  0.0020  0.0383  0.0567 </r>
+        <r>  0.0051  0.0191  0.0005  0.0354  0.0120  0.0102  0.0020  0.0383  0.0567 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0053  0.0203  0.0025  0.0310  0.0354  0.0147  0.0899  0.0007  0.0053 </r>
+        <r>  0.0052  0.0202  0.0024  0.0310  0.0350  0.0147  0.0897  0.0008  0.0053 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0029  0.0026  0.0066  0.0493  0.0202  0.0116  0.0242  0.0471  0.0405 </r>
+        <r>  0.0029  0.0026  0.0066  0.0493  0.0203  0.0117  0.0243  0.0467  0.0404 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0052  0.0029  0.0190  0.0440  0.0068  0.0450  0.0050  0.0385  0.0684 </r>
+        <r>  0.0051  0.0029  0.0191  0.0437  0.0067  0.0450  0.0050  0.0381  0.0683 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0381  0.0129  0.0075  0.0251  0.1213  0.0151  0.0465  0.0453  0.0348 </r>
+        <r>  0.0373  0.0124  0.0073  0.0257  0.1214  0.0151  0.0477  0.0436  0.0342 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0229  0.0450  0.0063  0.0181  0.0062  0.0340  0.0369  0.1195  0.0199 </r>
+        <r>  0.0233  0.0454  0.0065  0.0177  0.0056  0.0339  0.0362  0.1211  0.0202 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0167  0.0013  0.0157  0.0067  0.0449  0.0152  0.0336  0.0838  0.1355 </r>
+        <r>  0.0175  0.0011  0.0152  0.0064  0.0417  0.0170  0.0346  0.0806  0.1348 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0371  0.0195  0.0137  0.0147  0.1240  0.0714  0.0435  0.0394  0.0444 </r>
+        <r>  0.0354  0.0193  0.0144  0.0149  0.1251  0.0698  0.0419  0.0418  0.0458 </r>
+       </set>
+      </set>
+      <set comment="kpoint 43">
+       <set comment="band 1">
+        <r>  0.3984  0.0076  0.0004  0.0090  0.0005  0.0009  0.0002  0.0002  0.0000 </r>
+        <r>  0.3985  0.0076  0.0004  0.0090  0.0005  0.0009  0.0002  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4176  0.0089  0.0015  0.0121  0.0008  0.0007  0.0004  0.0008  0.0002 </r>
+        <r>  0.4176  0.0089  0.0015  0.0121  0.0008  0.0007  0.0004  0.0008  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0109  0.1101  0.0567  0.1356  0.0021  0.0007  0.0036  0.0007  0.0034 </r>
+        <r>  0.0110  0.1103  0.0567  0.1353  0.0021  0.0007  0.0036  0.0007  0.0034 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0115  0.0990  0.0880  0.1095  0.0003  0.0031  0.0004  0.0013  0.0008 </r>
+        <r>  0.0114  0.0987  0.0880  0.1098  0.0003  0.0031  0.0004  0.0013  0.0008 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0212  0.0981  0.1716  0.0540  0.0003  0.0055  0.0027  0.0019  0.0002 </r>
+        <r>  0.0212  0.0981  0.1716  0.0541  0.0003  0.0055  0.0027  0.0019  0.0002 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0221  0.0780  0.1537  0.0438  0.0005  0.0166  0.0074  0.0032  0.0076 </r>
+        <r>  0.0221  0.0780  0.1538  0.0437  0.0005  0.0166  0.0074  0.0032  0.0075 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0255  0.1004  0.1660  0.0415  0.0020  0.0131  0.0095  0.0128  0.0034 </r>
+        <r>  0.0254  0.1009  0.1659  0.0412  0.0020  0.0131  0.0095  0.0128  0.0034 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0008  0.0797  0.0095  0.1199  0.0209  0.0179  0.0048  0.0215  0.0186 </r>
+        <r>  0.0008  0.0793  0.0096  0.1203  0.0209  0.0179  0.0049  0.0215  0.0187 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0040  0.0633  0.0013  0.1057  0.0048  0.0059  0.0005  0.0152  0.0459 </r>
+        <r>  0.0040  0.0634  0.0013  0.1057  0.0048  0.0058  0.0005  0.0151  0.0458 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0111  0.0071  0.0027  0.0233  0.0022  0.0353  0.0659  0.0519  0.0312 </r>
+        <r>  0.0109  0.0072  0.0027  0.0231  0.0023  0.0353  0.0658  0.0515  0.0310 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0072  0.0325  0.0007  0.0515  0.1176  0.0011  0.0073  0.0094  0.0224 </r>
+        <r>  0.0072  0.0325  0.0007  0.0517  0.1168  0.0011  0.0071  0.0094  0.0224 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0271  0.0082  0.0041  0.0136  0.0388  0.0157  0.0820  0.0244  0.0032 </r>
+        <r>  0.0271  0.0082  0.0041  0.0137  0.0387  0.0156  0.0822  0.0241  0.0032 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0133  0.0473  0.0067  0.0181  0.0442  0.0177  0.1227  0.0136  0.0194 </r>
+        <r>  0.0132  0.0469  0.0067  0.0179  0.0438  0.0178  0.1225  0.0136  0.0192 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0019  0.0098  0.0038  0.0192  0.0993  0.0125  0.0110  0.0840  0.1085 </r>
+        <r>  0.0019  0.0099  0.0039  0.0192  0.0990  0.0126  0.0111  0.0841  0.1083 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0760  0.0078  0.0433  0.0020  0.0338  0.0852  0.0192  0.0125  0.0005 </r>
+        <r>  0.0756  0.0078  0.0431  0.0021  0.0332  0.0852  0.0191  0.0122  0.0005 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0026  0.0117  0.0025  0.0069  0.0422  0.0756  0.0010  0.0674  0.1199 </r>
+        <r>  0.0023  0.0118  0.0025  0.0068  0.0427  0.0766  0.0009  0.0672  0.1205 </r>
+       </set>
+      </set>
+      <set comment="kpoint 44">
+       <set comment="band 1">
+        <r>  0.4019  0.0027  0.0064  0.0057  0.0011  0.0001  0.0003  0.0002  0.0002 </r>
+        <r>  0.4019  0.0027  0.0064  0.0057  0.0011  0.0001  0.0003  0.0002  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4185  0.0019  0.0102  0.0040  0.0015  0.0000  0.0013  0.0000  0.0002 </r>
+        <r>  0.4186  0.0019  0.0102  0.0040  0.0015  0.0000  0.0013  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0138  0.0754  0.0608  0.1571  0.0040  0.0004  0.0011  0.0009  0.0006 </r>
+        <r>  0.0137  0.0755  0.0608  0.1572  0.0040  0.0005  0.0011  0.0009  0.0006 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2342  0.0000  0.1125  0.0005  0.0030  0.0000  0.0015  0.0033 </r>
+        <r>  0.0000  0.2341  0.0000  0.1124  0.0005  0.0030  0.0000  0.0015  0.0032 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0255  0.0166  0.2329  0.0345  0.0084  0.0005  0.0022  0.0010  0.0012 </r>
+        <r>  0.0255  0.0165  0.2330  0.0345  0.0084  0.0005  0.0022  0.0010  0.0012 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0271  0.0102  0.2286  0.0214  0.0070  0.0010  0.0316  0.0021  0.0010 </r>
+        <r>  0.0271  0.0103  0.2285  0.0213  0.0070  0.0010  0.0316  0.0021  0.0010 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2275  0.0000  0.1091  0.0017  0.0243  0.0000  0.0117  0.0118 </r>
+        <r>  0.0000  0.2274  0.0000  0.1093  0.0016  0.0243  0.0000  0.0116  0.0117 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0219  0.0960  0.0140  0.2002  0.0391  0.0020  0.0022  0.0042  0.0055 </r>
+        <r>  0.0220  0.0962  0.0139  0.2001  0.0389  0.0020  0.0022  0.0042  0.0055 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0128  0.0066  0.0735  0.0138  0.0140  0.0009  0.0732  0.0020  0.0020 </r>
+        <r>  0.0127  0.0066  0.0736  0.0138  0.0139  0.0009  0.0732  0.0019  0.0020 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0143  0.0148  0.0441  0.0308  0.0064  0.0146  0.0073  0.0303  0.0009 </r>
+        <r>  0.0142  0.0148  0.0443  0.0309  0.0064  0.0144  0.0073  0.0300  0.0009 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0105  0.0063  0.0419  0.0132  0.0297  0.0463  0.0135  0.0971  0.0043 </r>
+        <r>  0.0103  0.0064  0.0417  0.0131  0.0298  0.0467  0.0136  0.0965  0.0041 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0274  0.0000  0.0131  0.0157  0.0568  0.0000  0.0270  0.1109 </r>
+        <r>  0.0000  0.0273  0.0000  0.0132  0.0155  0.0567  0.0000  0.0275  0.1108 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0171  0.0000  0.0082  0.0206  0.0065  0.0000  0.0031  0.1468 </r>
+        <r>  0.0000  0.0170  0.0000  0.0082  0.0210  0.0065  0.0000  0.0031  0.1489 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0030  0.0000  0.0014  0.0141  0.1906  0.0000  0.0917  0.1000 </r>
+        <r>  0.0000  0.0030  0.0000  0.0014  0.0139  0.1909  0.0000  0.0917  0.0988 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0653  0.0029  0.0161  0.0060  0.0383  0.0413  0.0083  0.0858  0.0054 </r>
+        <r>  0.0654  0.0029  0.0162  0.0060  0.0381  0.0413  0.0083  0.0860  0.0054 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0019  0.0007  0.0037  0.0014  0.0122  0.0043  0.0460  0.0090  0.0017 </r>
+        <r>  0.0019  0.0007  0.0037  0.0014  0.0121  0.0042  0.0458  0.0089  0.0017 </r>
+       </set>
+      </set>
+      <set comment="kpoint 45">
+       <set comment="band 1">
+        <r>  0.4085  0.0002  0.0070  0.0076  0.0016  0.0002  0.0005  0.0003  0.0003 </r>
+        <r>  0.4084  0.0002  0.0070  0.0076  0.0016  0.0002  0.0005  0.0002  0.0003 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4196  0.0008  0.0066  0.0061  0.0020  0.0003  0.0013  0.0001  0.0002 </r>
+        <r>  0.4197  0.0008  0.0066  0.0061  0.0020  0.0003  0.0013  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0067  0.0910  0.0286  0.1747  0.0025  0.0006  0.0006  0.0005  0.0001 </r>
+        <r>  0.0067  0.0912  0.0285  0.1746  0.0025  0.0006  0.0006  0.0005  0.0001 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0029  0.1277  0.1112  0.0748  0.0032  0.0003  0.0023  0.0008  0.0007 </r>
+        <r>  0.0029  0.1274  0.1112  0.0749  0.0031  0.0003  0.0023  0.0008  0.0006 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0227  0.1080  0.1610  0.0459  0.0032  0.0046  0.0007  0.0005  0.0030 </r>
+        <r>  0.0227  0.1080  0.1610  0.0459  0.0032  0.0046  0.0007  0.0005  0.0029 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0255  0.1005  0.1577  0.0372  0.0021  0.0161  0.0071  0.0039  0.0066 </r>
+        <r>  0.0255  0.1004  0.1577  0.0372  0.0022  0.0161  0.0071  0.0039  0.0066 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0008  0.0858  0.0505  0.0339  0.0274  0.0082  0.0576  0.0021  0.0009 </r>
+        <r>  0.0008  0.0860  0.0504  0.0337  0.0271  0.0082  0.0575  0.0021  0.0009 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0167  0.1232  0.0024  0.2283  0.0253  0.0003  0.0009  0.0095  0.0005 </r>
+        <r>  0.0168  0.1230  0.0024  0.2284  0.0253  0.0003  0.0009  0.0095  0.0005 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0039  0.0589  0.1277  0.0467  0.0080  0.0024  0.0430  0.0005  0.0045 </r>
+        <r>  0.0039  0.0590  0.1277  0.0467  0.0080  0.0024  0.0429  0.0005  0.0045 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0031  0.0077  0.0044  0.0418  0.0039  0.0124  0.0002  0.0454  0.0636 </r>
+        <r>  0.0031  0.0077  0.0044  0.0419  0.0039  0.0123  0.0002  0.0453  0.0639 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0406  0.0085  0.0134  0.0037  0.0408  0.0938  0.0104  0.0396  0.0215 </r>
+        <r>  0.0403  0.0085  0.0134  0.0037  0.0405  0.0941  0.0105  0.0393  0.0215 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0039  0.0085  0.0142  0.0029  0.0001  0.0348  0.0052  0.0553  0.0479 </r>
+        <r>  0.0039  0.0085  0.0142  0.0029  0.0000  0.0348  0.0053  0.0551  0.0478 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0120  0.0093  0.0034  0.0079  0.0027  0.1141  0.0010  0.0006  0.1185 </r>
+        <r>  0.0122  0.0093  0.0035  0.0083  0.0030  0.1141  0.0009  0.0007  0.1197 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0120  0.0001  0.0116  0.0531  0.0923  0.0132  0.0180  0.0204  0.0281 </r>
+        <r>  0.0116  0.0001  0.0117  0.0528  0.0924  0.0132  0.0182  0.0204  0.0274 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0336  0.0151  0.0310  0.0142  0.0356  0.0581  0.0080  0.1658  0.0072 </r>
+        <r>  0.0340  0.0151  0.0310  0.0140  0.0352  0.0580  0.0079  0.1664  0.0072 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0399  0.0137  0.0019  0.0052  0.0893  0.0422  0.0406  0.0872  0.0902 </r>
+        <r>  0.0404  0.0136  0.0019  0.0051  0.0878  0.0418  0.0411  0.0846  0.0914 </r>
+       </set>
+      </set>
+      <set comment="kpoint 46">
+       <set comment="band 1">
+        <r>  0.4144  0.0022  0.0060  0.0074  0.0017  0.0005  0.0006  0.0003  0.0003 </r>
+        <r>  0.4144  0.0022  0.0060  0.0074  0.0017  0.0005  0.0006  0.0003  0.0003 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4143  0.0061  0.0021  0.0066  0.0018  0.0005  0.0008  0.0003  0.0002 </r>
+        <r>  0.4144  0.0061  0.0021  0.0067  0.0018  0.0005  0.0008  0.0003  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0020  0.1135  0.0024  0.1843  0.0019  0.0005  0.0015  0.0006  0.0017 </r>
+        <r>  0.0020  0.1139  0.0023  0.1839  0.0019  0.0005  0.0015  0.0006  0.0017 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0027  0.0932  0.1445  0.0643  0.0004  0.0002  0.0022  0.0001  0.0002 </r>
+        <r>  0.0027  0.0927  0.1445  0.0647  0.0004  0.0002  0.0022  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0250  0.0969  0.1789  0.0485  0.0023  0.0064  0.0032  0.0009  0.0015 </r>
+        <r>  0.0250  0.0968  0.1789  0.0485  0.0023  0.0064  0.0032  0.0008  0.0015 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0309  0.1137  0.1336  0.0409  0.0015  0.0147  0.0016  0.0070  0.0037 </r>
+        <r>  0.0308  0.1136  0.1336  0.0409  0.0015  0.0147  0.0016  0.0070  0.0036 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0046  0.0840  0.0975  0.0328  0.0289  0.0038  0.0464  0.0000  0.0008 </r>
+        <r>  0.0046  0.0844  0.0974  0.0324  0.0286  0.0038  0.0463  0.0000  0.0008 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0024  0.0852  0.0012  0.1881  0.0189  0.0045  0.0066  0.0214  0.0165 </r>
+        <r>  0.0024  0.0848  0.0012  0.1885  0.0190  0.0045  0.0066  0.0215  0.0166 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0014  0.0761  0.0982  0.0227  0.0131  0.0106  0.0492  0.0047  0.0054 </r>
+        <r>  0.0014  0.0760  0.0983  0.0228  0.0131  0.0106  0.0491  0.0047  0.0053 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0023  0.0355  0.0014  0.1019  0.0017  0.0172  0.0015  0.0217  0.0536 </r>
+        <r>  0.0023  0.0356  0.0014  0.1018  0.0017  0.0171  0.0015  0.0216  0.0538 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0280  0.0012  0.0090  0.0337  0.0261  0.0994  0.0123  0.0043  0.0344 </r>
+        <r>  0.0279  0.0012  0.0090  0.0336  0.0258  0.0996  0.0123  0.0042  0.0345 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0426  0.0124  0.0030  0.0187  0.0899  0.0252  0.0491  0.0463  0.0040 </r>
+        <r>  0.0424  0.0124  0.0030  0.0186  0.0898  0.0254  0.0494  0.0459  0.0039 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0338  0.0045  0.0106  0.0024  0.0968  0.0081  0.0205  0.0873  0.0076 </r>
+        <r>  0.0335  0.0044  0.0106  0.0024  0.0966  0.0080  0.0208  0.0864  0.0075 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0198  0.0081  0.0056  0.0052  0.0039  0.0693  0.0002  0.0348  0.0524 </r>
+        <r>  0.0197  0.0081  0.0056  0.0052  0.0038  0.0695  0.0002  0.0347  0.0524 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0032  0.0044  0.0039  0.0064  0.0158  0.0250  0.0013  0.1074  0.1405 </r>
+        <r>  0.0031  0.0043  0.0039  0.0064  0.0154  0.0244  0.0013  0.1049  0.1384 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0044  0.0024  0.0037  0.0021  0.0073  0.0357  0.0058  0.0902  0.1580 </r>
+        <r>  0.0044  0.0024  0.0038  0.0020  0.0076  0.0360  0.0058  0.0917  0.1611 </r>
+       </set>
+      </set>
+      <set comment="kpoint 47">
+       <set comment="band 1">
+        <r>  0.4069  0.0108  0.0004  0.0062  0.0009  0.0011  0.0005  0.0002  0.0001 </r>
+        <r>  0.4070  0.0108  0.0004  0.0062  0.0010  0.0011  0.0005  0.0002  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4135  0.0121  0.0034  0.0038  0.0015  0.0004  0.0005  0.0006  0.0002 </r>
+        <r>  0.4135  0.0120  0.0034  0.0039  0.0015  0.0004  0.0005  0.0006  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0023  0.1080  0.0556  0.1411  0.0005  0.0002  0.0034  0.0009  0.0038 </r>
+        <r>  0.0023  0.1082  0.0556  0.1408  0.0005  0.0002  0.0034  0.0010  0.0037 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0105  0.0848  0.0912  0.1154  0.0003  0.0010  0.0008  0.0010  0.0007 </r>
+        <r>  0.0105  0.0846  0.0912  0.1157  0.0003  0.0010  0.0008  0.0009  0.0007 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0239  0.0875  0.1841  0.0579  0.0008  0.0060  0.0025  0.0033  0.0003 </r>
+        <r>  0.0239  0.0875  0.1841  0.0579  0.0008  0.0060  0.0025  0.0033  0.0003 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0291  0.1018  0.1320  0.0327  0.0020  0.0121  0.0064  0.0079  0.0026 </r>
+        <r>  0.0291  0.1018  0.1321  0.0327  0.0021  0.0121  0.0064  0.0079  0.0025 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0202  0.1198  0.1040  0.0844  0.0055  0.0030  0.0058  0.0227  0.0080 </r>
+        <r>  0.0201  0.1204  0.1040  0.0836  0.0054  0.0030  0.0057  0.0227  0.0080 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0012  0.0398  0.0797  0.1295  0.0157  0.0227  0.0066  0.0072  0.0199 </r>
+        <r>  0.0012  0.0392  0.0797  0.1304  0.0157  0.0227  0.0066  0.0071  0.0201 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0013  0.0785  0.0026  0.0976  0.0018  0.0057  0.0122  0.0176  0.0517 </r>
+        <r>  0.0012  0.0785  0.0026  0.0976  0.0018  0.0056  0.0122  0.0175  0.0517 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0016  0.0285  0.0039  0.0242  0.0524  0.0128  0.0723  0.0018  0.0097 </r>
+        <r>  0.0016  0.0284  0.0039  0.0242  0.0520  0.0128  0.0721  0.0018  0.0097 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0050  0.0148  0.0006  0.0173  0.0181  0.0374  0.0123  0.0740  0.0381 </r>
+        <r>  0.0048  0.0149  0.0006  0.0174  0.0183  0.0374  0.0124  0.0733  0.0378 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0394  0.0138  0.0031  0.0007  0.0725  0.0053  0.0658  0.0059  0.0144 </r>
+        <r>  0.0395  0.0137  0.0031  0.0006  0.0722  0.0053  0.0662  0.0059  0.0145 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0126  0.0025  0.0104  0.0060  0.0993  0.0419  0.0046  0.0289  0.0247 </r>
+        <r>  0.0129  0.0026  0.0105  0.0059  0.0986  0.0426  0.0047  0.0285  0.0250 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0258  0.0517  0.0194  0.0254  0.0027  0.0885  0.0407  0.0455  0.0053 </r>
+        <r>  0.0255  0.0516  0.0193  0.0252  0.0027  0.0884  0.0409  0.0455  0.0054 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0084  0.0019  0.0038  0.0122  0.0008  0.0448  0.0121  0.0754  0.1864 </r>
+        <r>  0.0083  0.0018  0.0038  0.0122  0.0008  0.0447  0.0121  0.0751  0.1863 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0355  0.0160  0.0103  0.0178  0.1335  0.0909  0.0628  0.0532  0.0466 </r>
+        <r>  0.0348  0.0157  0.0103  0.0177  0.1322  0.0908  0.0623  0.0533  0.0463 </r>
+       </set>
+      </set>
+      <set comment="kpoint 48">
+       <set comment="band 1">
+        <r>  0.4148  0.0008  0.0086  0.0017  0.0024  0.0001  0.0006  0.0002  0.0003 </r>
+        <r>  0.4148  0.0008  0.0086  0.0017  0.0024  0.0001  0.0006  0.0002  0.0003 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4207  0.0016  0.0087  0.0033  0.0022  0.0000  0.0017  0.0000  0.0003 </r>
+        <r>  0.4208  0.0016  0.0087  0.0033  0.0022  0.0000  0.0017  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0028  0.0913  0.0115  0.1902  0.0006  0.0003  0.0003  0.0007  0.0001 </r>
+        <r>  0.0028  0.0914  0.0115  0.1902  0.0006  0.0003  0.0003  0.0007  0.0001 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2323  0.0000  0.1116  0.0003  0.0027  0.0000  0.0013  0.0020 </r>
+        <r>  0.0000  0.2322  0.0000  0.1115  0.0003  0.0027  0.0000  0.0013  0.0019 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0239  0.0028  0.2798  0.0059  0.0062  0.0001  0.0011  0.0003  0.0009 </r>
+        <r>  0.0238  0.0028  0.2798  0.0059  0.0062  0.0001  0.0011  0.0003  0.0009 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0139  0.0002  0.2020  0.0005  0.0205  0.0006  0.0506  0.0013  0.0029 </r>
+        <r>  0.0139  0.0002  0.2018  0.0005  0.0204  0.0006  0.0506  0.0013  0.0029 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2384  0.0000  0.1145  0.0005  0.0280  0.0000  0.0135  0.0032 </r>
+        <r>  0.0000  0.2385  0.0000  0.1145  0.0004  0.0280  0.0000  0.0134  0.0031 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0227  0.0007  0.1296  0.0014  0.0169  0.0001  0.0502  0.0002  0.0024 </r>
+        <r>  0.0227  0.0007  0.1296  0.0014  0.0168  0.0001  0.0501  0.0002  0.0024 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0036  0.1270  0.0019  0.2645  0.0103  0.0038  0.0025  0.0080  0.0015 </r>
+        <r>  0.0036  0.1270  0.0019  0.2644  0.0103  0.0038  0.0025  0.0080  0.0014 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0014  0.0266  0.0009  0.0555  0.0057  0.0291  0.0028  0.0606  0.0008 </r>
+        <r>  0.0013  0.0267  0.0009  0.0556  0.0057  0.0290  0.0028  0.0604  0.0008 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0007  0.0000  0.0003  0.0221  0.0035  0.0000  0.0017  0.1572 </r>
+        <r>  0.0000  0.0006  0.0000  0.0003  0.0222  0.0036  0.0000  0.0017  0.1574 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0435  0.0005  0.0446  0.0010  0.1177  0.0007  0.0309  0.0014  0.0166 </r>
+        <r>  0.0435  0.0004  0.0444  0.0009  0.1173  0.0006  0.0311  0.0014  0.0165 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0258  0.0000  0.0124  0.0005  0.2726  0.0000  0.1310  0.0036 </r>
+        <r>  0.0000  0.0259  0.0000  0.0124  0.0006  0.2731  0.0000  0.1310  0.0038 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.1006  0.0002  0.0481  0.0004  0.0648  0.0062  0.0087  0.0128  0.0091 </r>
+        <r>  0.1004  0.0002  0.0482  0.0003  0.0646  0.0062  0.0088  0.0130  0.0091 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0203  0.0000  0.0097  0.0111  0.0085  0.0000  0.0041  0.0793 </r>
+        <r>  0.0000  0.0202  0.0000  0.0097  0.0112  0.0085  0.0000  0.0041  0.0797 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0211  0.0034  0.0137  0.0071  0.0476  0.0767  0.0412  0.1597  0.0067 </r>
+        <r>  0.0213  0.0034  0.0138  0.0070  0.0473  0.0761  0.0417  0.1584  0.0067 </r>
+       </set>
+      </set>
+      <set comment="kpoint 49">
+       <set comment="band 1">
+        <r>  0.4146  0.0021  0.0081  0.0011  0.0025  0.0001  0.0005  0.0002  0.0003 </r>
+        <r>  0.4147  0.0021  0.0081  0.0012  0.0025  0.0001  0.0005  0.0002  0.0003 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4179  0.0050  0.0066  0.0053  0.0019  0.0002  0.0014  0.0001  0.0003 </r>
+        <r>  0.4179  0.0049  0.0066  0.0053  0.0019  0.0002  0.0014  0.0001  0.0003 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0051  0.0975  0.0010  0.1933  0.0007  0.0004  0.0006  0.0008  0.0010 </r>
+        <r>  0.0051  0.0976  0.0010  0.1932  0.0006  0.0005  0.0006  0.0008  0.0010 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0015  0.1146  0.1337  0.0658  0.0015  0.0004  0.0016  0.0002  0.0008 </r>
+        <r>  0.0015  0.1143  0.1337  0.0659  0.0015  0.0004  0.0016  0.0002  0.0008 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0220  0.1051  0.1660  0.0474  0.0036  0.0029  0.0006  0.0015  0.0015 </r>
+        <r>  0.0220  0.1051  0.1660  0.0473  0.0036  0.0029  0.0006  0.0015  0.0015 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0233  0.0837  0.1666  0.0410  0.0073  0.0098  0.0075  0.0101  0.0024 </r>
+        <r>  0.0233  0.0837  0.1666  0.0410  0.0073  0.0099  0.0075  0.0101  0.0024 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0015  0.0790  0.0315  0.0375  0.0241  0.0090  0.0653  0.0032  0.0014 </r>
+        <r>  0.0015  0.0791  0.0315  0.0373  0.0238  0.0090  0.0653  0.0032  0.0014 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0046  0.0840  0.1289  0.0433  0.0090  0.0047  0.0287  0.0010  0.0049 </r>
+        <r>  0.0046  0.0839  0.1290  0.0435  0.0089  0.0047  0.0287  0.0010  0.0048 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0058  0.1176  0.0105  0.2435  0.0105  0.0016  0.0025  0.0075  0.0033 </r>
+        <r>  0.0058  0.1176  0.0105  0.2435  0.0105  0.0016  0.0025  0.0075  0.0033 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0019  0.0225  0.0041  0.0334  0.0176  0.0266  0.0012  0.0357  0.0611 </r>
+        <r>  0.0018  0.0225  0.0041  0.0334  0.0175  0.0265  0.0012  0.0356  0.0613 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0388  0.0041  0.0142  0.0117  0.0115  0.1141  0.0070  0.0382  0.0415 </r>
+        <r>  0.0386  0.0041  0.0141  0.0116  0.0112  0.1146  0.0071  0.0380  0.0418 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0277  0.0041  0.0111  0.0282  0.0619  0.0128  0.0121  0.0555  0.0378 </r>
+        <r>  0.0276  0.0041  0.0111  0.0281  0.0615  0.0128  0.0122  0.0551  0.0375 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0177  0.0073  0.0061  0.0106  0.0600  0.0785  0.0018  0.0171  0.0082 </r>
+        <r>  0.0176  0.0073  0.0061  0.0105  0.0602  0.0781  0.0018  0.0172  0.0082 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0252  0.0226  0.0044  0.0008  0.0423  0.0071  0.0423  0.0382  0.1093 </r>
+        <r>  0.0251  0.0226  0.0044  0.0007  0.0423  0.0071  0.0424  0.0376  0.1089 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0076  0.0040  0.0043  0.0058  0.0111  0.0138  0.0041  0.1148  0.0831 </r>
+        <r>  0.0075  0.0039  0.0044  0.0059  0.0110  0.0137  0.0041  0.1136  0.0836 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0685  0.0243  0.0483  0.0096  0.0649  0.1541  0.0114  0.0344  0.0084 </r>
+        <r>  0.0682  0.0242  0.0483  0.0096  0.0651  0.1540  0.0116  0.0348  0.0082 </r>
+       </set>
+      </set>
+      <set comment="kpoint 50">
+       <set comment="band 1">
+        <r>  0.4077  0.0016  0.0076  0.0034  0.0022  0.0000  0.0004  0.0001  0.0003 </r>
+        <r>  0.4077  0.0016  0.0076  0.0034  0.0022  0.0000  0.0004  0.0001  0.0003 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4168  0.0034  0.0104  0.0071  0.0017  0.0000  0.0016  0.0000  0.0002 </r>
+        <r>  0.4169  0.0034  0.0104  0.0071  0.0017  0.0000  0.0016  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0149  0.0913  0.0008  0.1902  0.0026  0.0004  0.0010  0.0009  0.0004 </r>
+        <r>  0.0149  0.0914  0.0008  0.1902  0.0026  0.0004  0.0010  0.0009  0.0004 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2336  0.0000  0.1122  0.0003  0.0026  0.0000  0.0012  0.0025 </r>
+        <r>  0.0000  0.2334  0.0000  0.1121  0.0003  0.0026  0.0000  0.0012  0.0024 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0215  0.0002  0.2920  0.0004  0.0053  0.0003  0.0008  0.0006  0.0007 </r>
+        <r>  0.0215  0.0002  0.2920  0.0004  0.0053  0.0003  0.0008  0.0006  0.0007 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0151  0.0006  0.2175  0.0012  0.0220  0.0009  0.0397  0.0018  0.0031 </r>
+        <r>  0.0151  0.0006  0.2174  0.0012  0.0219  0.0009  0.0397  0.0018  0.0031 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2271  0.0000  0.1091  0.0004  0.0284  0.0000  0.0136  0.0031 </r>
+        <r>  0.0000  0.2273  0.0000  0.1091  0.0004  0.0284  0.0000  0.0137  0.0031 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0174  0.0003  0.0928  0.0005  0.0150  0.0011  0.0648  0.0023  0.0021 </r>
+        <r>  0.0173  0.0002  0.0929  0.0005  0.0149  0.0011  0.0648  0.0023  0.0021 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0165  0.1089  0.0030  0.2268  0.0250  0.0025  0.0022  0.0053  0.0035 </r>
+        <r>  0.0166  0.1089  0.0030  0.2269  0.0249  0.0025  0.0022  0.0053  0.0035 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0020  0.0224  0.0330  0.0466  0.0148  0.0256  0.0026  0.0533  0.0021 </r>
+        <r>  0.0019  0.0224  0.0331  0.0467  0.0147  0.0255  0.0026  0.0531  0.0021 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0189  0.0000  0.0091  0.0177  0.0160  0.0000  0.0077  0.1256 </r>
+        <r>  0.0000  0.0189  0.0000  0.0090  0.0178  0.0161  0.0000  0.0078  0.1261 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0307  0.0136  0.0430  0.0285  0.0281  0.0324  0.0081  0.0678  0.0039 </r>
+        <r>  0.0304  0.0136  0.0428  0.0283  0.0278  0.0324  0.0082  0.0672  0.0039 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0193  0.0000  0.0093  0.0193  0.1454  0.0000  0.0699  0.1363 </r>
+        <r>  0.0000  0.0191  0.0000  0.0092  0.0190  0.1452  0.0000  0.0696  0.1355 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0153  0.0000  0.0074  0.0136  0.1377  0.0000  0.0665  0.0978 </r>
+        <r>  0.0000  0.0155  0.0000  0.0074  0.0140  0.1382  0.0000  0.0662  0.0982 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.1049  0.0044  0.0371  0.0091  0.0389  0.0187  0.0148  0.0380  0.0054 </r>
+        <r>  0.1038  0.0043  0.0373  0.0091  0.0391  0.0181  0.0149  0.0382  0.0056 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0522  0.0101  0.0048  0.0211  0.1364  0.0371  0.0922  0.0773  0.0193 </r>
+        <r>  0.0523  0.0102  0.0048  0.0213  0.1355  0.0367  0.0926  0.0765  0.0190 </r>
+       </set>
+      </set>
+      <set comment="kpoint 51">
+       <set comment="band 1">
+        <r>  0.3949  0.0013  0.0091  0.0027  0.0000  0.0001  0.0002  0.0002  0.0000 </r>
+        <r>  0.3950  0.0013  0.0091  0.0027  0.0000  0.0001  0.0002  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4029  0.0029  0.0204  0.0061  0.0000  0.0001  0.0001  0.0002  0.0000 </r>
+        <r>  0.4030  0.0029  0.0204  0.0061  0.0000  0.0001  0.0001  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.1356  0.0282  0.2011  0.0047  0.0059  0.0005  0.0036  0.0007 </r>
+        <r>  0.0000  0.1353  0.0267  0.2026  0.0029  0.0077  0.0005  0.0019  0.0025 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.1919  0.0865  0.0865  0.0068  0.0027  0.0015  0.0009  0.0034 </r>
+        <r>  0.0000  0.1943  0.0817  0.0888  0.0086  0.0010  0.0013  0.0027  0.0017 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0736  0.0244  0.1595  0.0503  0.0007  0.0023  0.0032  0.0048  0.0001 </r>
+        <r>  0.0735  0.0222  0.1659  0.0464  0.0007  0.0023  0.0033  0.0047  0.0001 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0000  0.1529  0.0060  0.1435  0.0085  0.0228  0.0002  0.0108  0.0092 </r>
+        <r>  0.0000  0.1532  0.0061  0.1434  0.0057  0.0255  0.0002  0.0081  0.0118 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.1199  0.0858  0.0970  0.0320  0.0027  0.0031  0.0036  0.0101 </r>
+        <r>  0.0000  0.1191  0.0871  0.0963  0.0344  0.0000  0.0031  0.0064  0.0073 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0577  0.0243  0.1731  0.0508  0.0006  0.0021  0.0030  0.0045  0.0001 </r>
+        <r>  0.0578  0.0249  0.1715  0.0516  0.0007  0.0021  0.0030  0.0044  0.0001 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0063  0.0060  0.0418  0.0125  0.0049  0.0165  0.0233  0.0344  0.0007 </r>
+        <r>  0.0063  0.0060  0.0419  0.0125  0.0049  0.0165  0.0233  0.0343  0.0007 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0047  0.0022  0.0095  0.0307  0.0198  0.0457  0.0176  0.1020 </r>
+        <r>  0.0000  0.0048  0.0022  0.0095  0.0483  0.0022  0.0463  0.0355  0.0838 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0100  0.0028  0.0035  0.0241  0.0104  0.0608  0.0366  0.0840 </r>
+        <r>  0.0000  0.0100  0.0029  0.0036  0.0063  0.0280  0.0603  0.0186  0.1026 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0369  0.0140  0.0975  0.0290  0.0001  0.0002  0.0003  0.0004  0.0000 </r>
+        <r>  0.0368  0.0140  0.0976  0.0291  0.0001  0.0002  0.0003  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0063  0.0035  0.0241  0.0075  0.0087  0.0248  0.0355  0.0546  0.0012 </r>
+        <r>  0.0062  0.0035  0.0245  0.0071  0.0066  0.0267  0.0374  0.0527  0.0010 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0404  0.0001  0.0190  0.0014  0.1641  0.0002  0.0756  0.0172 </r>
+        <r>  0.0000  0.0401  0.0001  0.0192  0.0045  0.1594  0.0002  0.0805  0.0141 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0132  0.0184  0.0280  0.1925  0.0005  0.0363  0.0040  0.0255 </r>
+        <r>  0.0000  0.0134  0.0180  0.0281  0.1911  0.0035  0.0345  0.0008  0.0288 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0044  0.0022  0.0024  0.0094  0.0521  0.1621  0.0323  0.0336 </r>
+        <r>  0.0000  0.0045  0.0022  0.0025  0.0113  0.0503  0.1622  0.0341  0.0318 </r>
+       </set>
+      </set>
+      <set comment="kpoint 52">
+       <set comment="band 1">
+        <r>  0.3967  0.0008  0.0087  0.0069  0.0001  0.0002  0.0002  0.0004  0.0000 </r>
+        <r>  0.3969  0.0008  0.0087  0.0069  0.0001  0.0002  0.0002  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4007  0.0014  0.0155  0.0094  0.0001  0.0007  0.0002  0.0000  0.0000 </r>
+        <r>  0.4007  0.0014  0.0155  0.0094  0.0001  0.0007  0.0002  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0128  0.0960  0.1360  0.0789  0.0036  0.0005  0.0012  0.0035  0.0007 </r>
+        <r>  0.0128  0.0960  0.1359  0.0787  0.0036  0.0005  0.0012  0.0035  0.0007 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2408  0.0819  0.0334  0.0103  0.0043  0.0048  0.0015  0.0020 </r>
+        <r>  0.0000  0.2404  0.0814  0.0343  0.0102  0.0044  0.0048  0.0014  0.0020 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0534  0.0059  0.0435  0.1847  0.0052  0.0133  0.0010  0.0001  0.0032 </r>
+        <r>  0.0533  0.0063  0.0440  0.1842  0.0052  0.0132  0.0010  0.0001  0.0032 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0507  0.0025  0.0695  0.2214  0.0004  0.0097  0.0038  0.0012  0.0002 </r>
+        <r>  0.0507  0.0037  0.0724  0.2168  0.0006  0.0095  0.0039  0.0012  0.0002 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2131  0.0736  0.0279  0.0210  0.0023  0.0005  0.0076  0.0121 </r>
+        <r>  0.0000  0.2118  0.0707  0.0320  0.0208  0.0026  0.0004  0.0076  0.0120 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0132  0.0979  0.1514  0.0609  0.0180  0.0065  0.0020  0.0106  0.0050 </r>
+        <r>  0.0132  0.0979  0.1511  0.0610  0.0179  0.0065  0.0020  0.0105  0.0049 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0046  0.0126  0.0366  0.0089  0.0180  0.0103  0.0367  0.0151  0.0090 </r>
+        <r>  0.0046  0.0126  0.0368  0.0089  0.0179  0.0103  0.0367  0.0149  0.0091 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0051  0.0017  0.0007  0.0064  0.0237  0.0773  0.0342  0.0701 </r>
+        <r>  0.0000  0.0051  0.0018  0.0007  0.0063  0.0237  0.0773  0.0341  0.0700 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0021  0.0041  0.0342  0.0362  0.0187  0.0043  0.0060  0.0268  0.0649 </r>
+        <r>  0.0021  0.0041  0.0341  0.0361  0.0186  0.0042  0.0061  0.0271  0.0653 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0097  0.0042  0.0385  0.0229  0.0111  0.0274  0.0050  0.1073  0.0776 </r>
+        <r>  0.0094  0.0042  0.0386  0.0233  0.0107  0.0269  0.0051  0.1076  0.0774 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0227  0.0122  0.0097  0.0199  0.0466  0.0826  0.0054  0.0133  0.0424 </r>
+        <r>  0.0228  0.0122  0.0098  0.0197  0.0468  0.0830  0.0054  0.0128  0.0428 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0025  0.0014  0.0051  0.0030  0.0139  0.0117  0.0310  0.0382  0.0039 </r>
+        <r>  0.0025  0.0013  0.0051  0.0030  0.0138  0.0117  0.0310  0.0381  0.0039 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0400  0.0134  0.0056  0.0295  0.0083  0.0404  0.0436  0.0834 </r>
+        <r>  0.0000  0.0399  0.0134  0.0056  0.0293  0.0084  0.0407  0.0435  0.0831 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0010  0.0053  0.0401  0.0180  0.0041  0.0911  0.0964  0.0225  0.0649 </r>
+        <r>  0.0010  0.0053  0.0401  0.0179  0.0040  0.0913  0.0963  0.0226  0.0650 </r>
+       </set>
+      </set>
+      <set comment="kpoint 53">
+       <set comment="band 1">
+        <r>  0.4015  0.0007  0.0070  0.0120  0.0002  0.0005  0.0002  0.0006  0.0001 </r>
+        <r>  0.4015  0.0007  0.0070  0.0120  0.0002  0.0005  0.0002  0.0006  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4058  0.0003  0.0063  0.0122  0.0003  0.0014  0.0003  0.0004  0.0000 </r>
+        <r>  0.4059  0.0003  0.0063  0.0122  0.0003  0.0014  0.0003  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0015  0.0955  0.1435  0.0674  0.0017  0.0000  0.0013  0.0013  0.0008 </r>
+        <r>  0.0015  0.0955  0.1434  0.0672  0.0017  0.0000  0.0013  0.0013  0.0008 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2290  0.0777  0.0320  0.0083  0.0036  0.0044  0.0015  0.0023 </r>
+        <r>  0.0000  0.2286  0.0776  0.0324  0.0083  0.0036  0.0044  0.0015  0.0023 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0495  0.0038  0.0551  0.1816  0.0053  0.0113  0.0008  0.0003  0.0028 </r>
+        <r>  0.0495  0.0041  0.0551  0.1815  0.0053  0.0112  0.0008  0.0003  0.0028 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0560  0.0002  0.0763  0.2158  0.0026  0.0084  0.0016  0.0008  0.0033 </r>
+        <r>  0.0560  0.0007  0.0778  0.2137  0.0026  0.0083  0.0017  0.0007  0.0034 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2278  0.0779  0.0313  0.0228  0.0057  0.0042  0.0050  0.0073 </r>
+        <r>  0.0000  0.2274  0.0765  0.0331  0.0228  0.0059  0.0041  0.0050  0.0072 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0030  0.1089  0.1732  0.0553  0.0173  0.0015  0.0061  0.0062  0.0068 </r>
+        <r>  0.0030  0.1089  0.1731  0.0554  0.0172  0.0015  0.0061  0.0062  0.0067 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0015  0.0235  0.0278  0.0320  0.0136  0.0171  0.0358  0.0137  0.0142 </r>
+        <r>  0.0015  0.0235  0.0281  0.0319  0.0136  0.0170  0.0358  0.0133  0.0145 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0030  0.0026  0.0244  0.0222  0.0102  0.0044  0.0058  0.0520  0.0546 </r>
+        <r>  0.0030  0.0026  0.0242  0.0224  0.0100  0.0044  0.0057  0.0521  0.0547 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0007  0.0002  0.0001  0.0074  0.0212  0.0726  0.0352  0.0720 </r>
+        <r>  0.0000  0.0007  0.0003  0.0001  0.0074  0.0212  0.0726  0.0353  0.0716 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0450  0.0021  0.0113  0.0034  0.0442  0.1030  0.0098  0.0314  0.0025 </r>
+        <r>  0.0447  0.0021  0.0113  0.0034  0.0439  0.1030  0.0099  0.0314  0.0026 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0008  0.0009  0.0228  0.0448  0.0139  0.0198  0.0012  0.0993  0.1086 </r>
+        <r>  0.0008  0.0009  0.0230  0.0449  0.0141  0.0196  0.0012  0.0992  0.1092 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0230  0.0077  0.0032  0.0009  0.0270  0.0730  0.0194  0.0425 </r>
+        <r>  0.0000  0.0230  0.0077  0.0032  0.0009  0.0272  0.0732  0.0193  0.0424 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0074  0.0077  0.0239  0.0005  0.0272  0.0622  0.1193  0.0048  0.0443 </r>
+        <r>  0.0075  0.0076  0.0238  0.0005  0.0269  0.0624  0.1194  0.0046  0.0447 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0005  0.0043  0.0184  0.0201  0.0152  0.0183  0.0256  0.0142  0.0267 </r>
+        <r>  0.0005  0.0041  0.0185  0.0200  0.0145  0.0181  0.0258  0.0141  0.0268 </r>
+       </set>
+      </set>
+      <set comment="kpoint 54">
+       <set comment="band 1">
+        <r>  0.4107  0.0006  0.0031  0.0144  0.0003  0.0015  0.0003  0.0005  0.0001 </r>
+        <r>  0.4107  0.0006  0.0031  0.0144  0.0003  0.0015  0.0003  0.0005  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4052  0.0018  0.0016  0.0148  0.0005  0.0012  0.0002  0.0010  0.0002 </r>
+        <r>  0.4053  0.0018  0.0016  0.0148  0.0005  0.0012  0.0002  0.0010  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0027  0.0937  0.1460  0.0570  0.0004  0.0007  0.0013  0.0001  0.0008 </r>
+        <r>  0.0027  0.0937  0.1460  0.0568  0.0004  0.0007  0.0013  0.0001  0.0008 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2304  0.0782  0.0323  0.0042  0.0026  0.0037  0.0006  0.0011 </r>
+        <r>  0.0000  0.2301  0.0782  0.0325  0.0042  0.0026  0.0037  0.0007  0.0010 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0408  0.0019  0.0661  0.1923  0.0046  0.0074  0.0002  0.0004  0.0024 </r>
+        <r>  0.0408  0.0020  0.0661  0.1922  0.0045  0.0073  0.0002  0.0004  0.0024 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0409  0.0002  0.0904  0.1974  0.0071  0.0081  0.0005  0.0022  0.0101 </r>
+        <r>  0.0409  0.0002  0.0908  0.1970  0.0070  0.0080  0.0005  0.0022  0.0101 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2268  0.0771  0.0318  0.0240  0.0095  0.0096  0.0032  0.0043 </r>
+        <r>  0.0000  0.2269  0.0768  0.0321  0.0240  0.0095  0.0096  0.0033  0.0042 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0094  0.0787  0.1652  0.0206  0.0052  0.0014  0.0052  0.0123  0.0261 </r>
+        <r>  0.0093  0.0786  0.1650  0.0209  0.0052  0.0013  0.0052  0.0124  0.0261 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0042  0.0357  0.0312  0.0586  0.0084  0.0214  0.0022  0.0381  0.0295 </r>
+        <r>  0.0043  0.0357  0.0314  0.0583  0.0085  0.0214  0.0022  0.0380  0.0297 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0043  0.0213  0.0212  0.0271  0.0254  0.0229  0.0466  0.0152  0.0133 </r>
+        <r>  0.0042  0.0212  0.0212  0.0271  0.0252  0.0229  0.0465  0.0150  0.0134 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0030  0.0010  0.0004  0.0087  0.0182  0.0665  0.0361  0.0728 </r>
+        <r>  0.0000  0.0030  0.0010  0.0004  0.0086  0.0182  0.0663  0.0360  0.0726 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0330  0.0121  0.0055  0.0371  0.0270  0.0874  0.0124  0.0257  0.0011 </r>
+        <r>  0.0328  0.0122  0.0056  0.0371  0.0268  0.0874  0.0124  0.0257  0.0011 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0389  0.0131  0.0055  0.1407  0.0298  0.0227  0.0420  0.0657 </r>
+        <r>  0.0000  0.0385  0.0132  0.0054  0.1392  0.0300  0.0235  0.0417  0.0653 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0302  0.0009  0.0418  0.0851  0.0167  0.0429  0.0030  0.0261  0.0457 </r>
+        <r>  0.0295  0.0009  0.0418  0.0847  0.0176  0.0429  0.0029  0.0256  0.0460 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0178  0.0059  0.0023  0.0744  0.0521  0.0800  0.0130  0.0216 </r>
+        <r>  0.0000  0.0175  0.0061  0.0027  0.0704  0.0533  0.0822  0.0136  0.0227 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0439  0.0052  0.0012  0.0233  0.1135  0.0133  0.0520  0.1542  0.0188 </r>
+        <r>  0.0437  0.0056  0.0009  0.0233  0.1166  0.0119  0.0496  0.1526  0.0175 </r>
+       </set>
+      </set>
+      <set comment="kpoint 55">
+       <set comment="band 1">
+        <r>  0.3997  0.0025  0.0102  0.0052  0.0004  0.0002  0.0002  0.0003  0.0000 </r>
+        <r>  0.3997  0.0025  0.0102  0.0052  0.0004  0.0002  0.0002  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3941  0.0027  0.0182  0.0055  0.0003  0.0000  0.0005  0.0001  0.0000 </r>
+        <r>  0.3942  0.0027  0.0182  0.0056  0.0003  0.0000  0.0005  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0323  0.0539  0.1179  0.1123  0.0058  0.0010  0.0017  0.0020  0.0008 </r>
+        <r>  0.0323  0.0540  0.1178  0.1124  0.0058  0.0010  0.0017  0.0020  0.0008 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2342  0.0000  0.1125  0.0006  0.0076  0.0000  0.0037  0.0041 </r>
+        <r>  0.0000  0.2341  0.0000  0.1124  0.0006  0.0076  0.0000  0.0037  0.0040 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0308  0.0389  0.1486  0.0811  0.0173  0.0008  0.0037  0.0017  0.0024 </r>
+        <r>  0.0308  0.0389  0.1487  0.0811  0.0172  0.0008  0.0037  0.0017  0.0024 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0426  0.0526  0.1313  0.1095  0.0068  0.0017  0.0066  0.0035  0.0010 </r>
+        <r>  0.0425  0.0525  0.1313  0.1093  0.0069  0.0017  0.0066  0.0035  0.0010 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2139  0.0000  0.1027  0.0018  0.0264  0.0000  0.0127  0.0127 </r>
+        <r>  0.0000  0.2139  0.0000  0.1028  0.0018  0.0264  0.0000  0.0127  0.0126 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0315  0.0497  0.1380  0.1036  0.0239  0.0026  0.0014  0.0055  0.0034 </r>
+        <r>  0.0315  0.0498  0.1377  0.1037  0.0238  0.0026  0.0014  0.0055  0.0033 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0040  0.0016  0.0392  0.0033  0.0216  0.0007  0.0907  0.0015  0.0030 </r>
+        <r>  0.0039  0.0016  0.0394  0.0033  0.0214  0.0007  0.0907  0.0015  0.0030 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0005  0.0126  0.0288  0.0263  0.0078  0.0312  0.0250  0.0650  0.0011 </r>
+        <r>  0.0005  0.0126  0.0289  0.0263  0.0077  0.0311  0.0250  0.0648  0.0011 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0182  0.0000  0.0087  0.0249  0.0040  0.0000  0.0019  0.1770 </r>
+        <r>  0.0000  0.0181  0.0000  0.0087  0.0251  0.0041  0.0000  0.0020  0.1781 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0045  0.0148  0.0440  0.0308  0.0046  0.0433  0.0063  0.0902  0.0007 </r>
+        <r>  0.0045  0.0148  0.0440  0.0309  0.0047  0.0433  0.0063  0.0900  0.0006 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0249  0.0000  0.0119  0.0236  0.0075  0.0000  0.0036  0.1674 </r>
+        <r>  0.0000  0.0249  0.0000  0.0120  0.0235  0.0076  0.0000  0.0037  0.1670 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0433  0.0008  0.0747  0.0017  0.0724  0.0192  0.0076  0.0398  0.0102 </r>
+        <r>  0.0433  0.0008  0.0748  0.0017  0.0719  0.0191  0.0077  0.0400  0.0101 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0179  0.0000  0.0086  0.0037  0.2182  0.0000  0.1049  0.0266 </r>
+        <r>  0.0000  0.0178  0.0000  0.0086  0.0038  0.2186  0.0000  0.1048  0.0265 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0012  0.0014  0.0076  0.0028  0.0141  0.0122  0.0507  0.0254  0.0020 </r>
+        <r>  0.0012  0.0013  0.0075  0.0028  0.0139  0.0121  0.0507  0.0253  0.0020 </r>
+       </set>
+      </set>
+      <set comment="kpoint 56">
+       <set comment="band 1">
+        <r>  0.4042  0.0006  0.0106  0.0081  0.0006  0.0003  0.0003  0.0004  0.0001 </r>
+        <r>  0.4042  0.0006  0.0106  0.0081  0.0006  0.0003  0.0003  0.0004  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4002  0.0003  0.0132  0.0061  0.0008  0.0004  0.0006  0.0001  0.0001 </r>
+        <r>  0.4003  0.0003  0.0132  0.0062  0.0008  0.0004  0.0006  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0123  0.0773  0.1147  0.1084  0.0026  0.0004  0.0006  0.0017  0.0006 </r>
+        <r>  0.0123  0.0775  0.1146  0.1082  0.0027  0.0004  0.0006  0.0017  0.0006 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0126  0.1450  0.0162  0.1378  0.0089  0.0022  0.0029  0.0020  0.0000 </r>
+        <r>  0.0126  0.1447  0.0162  0.1380  0.0089  0.0022  0.0029  0.0020  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0276  0.1118  0.1475  0.0495  0.0067  0.0084  0.0003  0.0006  0.0050 </r>
+        <r>  0.0276  0.1118  0.1476  0.0495  0.0066  0.0084  0.0003  0.0006  0.0049 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0304  0.1102  0.1296  0.0437  0.0013  0.0169  0.0015  0.0021  0.0081 </r>
+        <r>  0.0304  0.1102  0.1295  0.0437  0.0013  0.0169  0.0015  0.0021  0.0081 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0239  0.1125  0.0042  0.2092  0.0136  0.0013  0.0076  0.0120  0.0028 </r>
+        <r>  0.0238  0.1127  0.0043  0.2090  0.0137  0.0013  0.0076  0.0120  0.0028 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0116  0.1059  0.1486  0.0653  0.0269  0.0095  0.0051  0.0072  0.0012 </r>
+        <r>  0.0116  0.1058  0.1484  0.0655  0.0267  0.0095  0.0051  0.0072  0.0012 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0045  0.0038  0.0309  0.0131  0.0207  0.0007  0.0917  0.0040  0.0033 </r>
+        <r>  0.0044  0.0038  0.0310  0.0131  0.0206  0.0007  0.0916  0.0040  0.0032 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0035  0.0017  0.0148  0.0320  0.0098  0.0121  0.0037  0.0437  0.0595 </r>
+        <r>  0.0035  0.0017  0.0149  0.0321  0.0098  0.0120  0.0037  0.0436  0.0598 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0006  0.0198  0.0116  0.0008  0.0007  0.0300  0.0122  0.0510  0.0729 </r>
+        <r>  0.0006  0.0199  0.0116  0.0008  0.0007  0.0302  0.0122  0.0507  0.0727 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0130  0.0329  0.0352  0.0012  0.0388  0.0259  0.0076  0.0335  0.0440 </r>
+        <r>  0.0128  0.0329  0.0351  0.0011  0.0386  0.0261  0.0076  0.0334  0.0441 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0130  0.0011  0.0179  0.0214  0.0321  0.0949  0.0044  0.0256  0.1311 </r>
+        <r>  0.0129  0.0011  0.0176  0.0219  0.0319  0.0938  0.0045  0.0258  0.1344 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0118  0.0018  0.0074  0.0371  0.0184  0.0851  0.0016  0.0412  0.0546 </r>
+        <r>  0.0118  0.0018  0.0078  0.0366  0.0186  0.0862  0.0016  0.0411  0.0518 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0239  0.0108  0.0118  0.0179  0.1107  0.0282  0.1004  0.0327  0.0273 </r>
+        <r>  0.0239  0.0109  0.0119  0.0178  0.1087  0.0273  0.1027  0.0339  0.0273 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0046  0.0197  0.0552  0.0013  0.0439  0.0419  0.0572  0.0704  0.0075 </r>
+        <r>  0.0045  0.0194  0.0551  0.0013  0.0452  0.0428  0.0555  0.0692  0.0074 </r>
+       </set>
+      </set>
+      <set comment="kpoint 57">
+       <set comment="band 1">
+        <r>  0.4114  0.0001  0.0085  0.0093  0.0008  0.0009  0.0005  0.0004  0.0002 </r>
+        <r>  0.4114  0.0001  0.0085  0.0093  0.0008  0.0009  0.0005  0.0004  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4103  0.0009  0.0056  0.0072  0.0013  0.0008  0.0005  0.0006  0.0002 </r>
+        <r>  0.4103  0.0009  0.0056  0.0072  0.0013  0.0008  0.0005  0.0006  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0009  0.0933  0.1380  0.0698  0.0012  0.0000  0.0010  0.0004  0.0003 </r>
+        <r>  0.0009  0.0934  0.1379  0.0695  0.0012  0.0000  0.0010  0.0004  0.0003 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0091  0.1239  0.0025  0.1757  0.0048  0.0013  0.0019  0.0011  0.0005 </r>
+        <r>  0.0091  0.1236  0.0025  0.1760  0.0048  0.0013  0.0019  0.0011  0.0005 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0279  0.1085  0.1514  0.0486  0.0008  0.0120  0.0008  0.0020  0.0022 </r>
+        <r>  0.0279  0.1085  0.1514  0.0486  0.0008  0.0120  0.0008  0.0020  0.0022 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0295  0.1104  0.1425  0.0471  0.0048  0.0117  0.0009  0.0021  0.0089 </r>
+        <r>  0.0295  0.1103  0.1425  0.0471  0.0048  0.0117  0.0009  0.0021  0.0089 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0094  0.1140  0.0026  0.1928  0.0270  0.0017  0.0040  0.0167  0.0053 </r>
+        <r>  0.0094  0.1142  0.0026  0.1926  0.0270  0.0017  0.0040  0.0168  0.0053 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0037  0.1054  0.1597  0.0496  0.0178  0.0055  0.0236  0.0018  0.0012 </r>
+        <r>  0.0037  0.1052  0.1596  0.0498  0.0176  0.0055  0.0236  0.0018  0.0012 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0082  0.0151  0.0004  0.0549  0.0070  0.0132  0.0001  0.0376  0.0540 </r>
+        <r>  0.0083  0.0151  0.0004  0.0550  0.0071  0.0131  0.0001  0.0375  0.0541 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0016  0.0310  0.0506  0.0222  0.0179  0.0025  0.0840  0.0010  0.0057 </r>
+        <r>  0.0016  0.0311  0.0507  0.0222  0.0178  0.0025  0.0839  0.0010  0.0057 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0046  0.0120  0.0171  0.0016  0.0097  0.0317  0.0117  0.0472  0.0750 </r>
+        <r>  0.0045  0.0120  0.0171  0.0016  0.0097  0.0320  0.0118  0.0466  0.0749 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0373  0.0018  0.0081  0.0102  0.0319  0.0907  0.0099  0.0403  0.0014 </r>
+        <r>  0.0372  0.0018  0.0080  0.0102  0.0316  0.0906  0.0099  0.0404  0.0014 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0410  0.0101  0.0026  0.0451  0.1680  0.0238  0.0461  0.0002  0.0034 </r>
+        <r>  0.0411  0.0101  0.0026  0.0452  0.1677  0.0241  0.0464  0.0002  0.0031 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0111  0.0129  0.0054  0.0072  0.0156  0.0808  0.0031  0.0005  0.1082 </r>
+        <r>  0.0108  0.0128  0.0054  0.0070  0.0156  0.0806  0.0032  0.0004  0.1090 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0060  0.0008  0.0126  0.0087  0.0202  0.0100  0.0042  0.1483  0.1249 </r>
+        <r>  0.0058  0.0008  0.0127  0.0085  0.0199  0.0098  0.0043  0.1459  0.1255 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0031  0.0033  0.0345  0.0216  0.0072  0.0430  0.0699  0.0872  0.1059 </r>
+        <r>  0.0031  0.0032  0.0344  0.0218  0.0072  0.0431  0.0699  0.0883  0.1046 </r>
+       </set>
+      </set>
+      <set comment="kpoint 58">
+       <set comment="band 1">
+        <r>  0.4080  0.0017  0.0134  0.0036  0.0012  0.0001  0.0005  0.0003  0.0002 </r>
+        <r>  0.4080  0.0017  0.0134  0.0036  0.0012  0.0001  0.0005  0.0003  0.0002 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.4022  0.0008  0.0149  0.0017  0.0014  0.0000  0.0009  0.0000  0.0002 </r>
+        <r>  0.4023  0.0008  0.0149  0.0017  0.0014  0.0000  0.0009  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0085  0.0884  0.0239  0.1841  0.0021  0.0008  0.0009  0.0016  0.0003 </r>
+        <r>  0.0085  0.0884  0.0238  0.1842  0.0021  0.0007  0.0009  0.0016  0.0003 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2302  0.0000  0.1105  0.0004  0.0070  0.0000  0.0034  0.0028 </r>
+        <r>  0.0000  0.2300  0.0000  0.1104  0.0004  0.0070  0.0000  0.0034  0.0027 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0400  0.0071  0.2385  0.0148  0.0128  0.0003  0.0015  0.0006  0.0018 </r>
+        <r>  0.0400  0.0071  0.2385  0.0148  0.0128  0.0003  0.0015  0.0007  0.0018 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0459  0.0029  0.2796  0.0061  0.0092  0.0010  0.0089  0.0021  0.0013 </r>
+        <r>  0.0459  0.0029  0.2794  0.0060  0.0091  0.0010  0.0089  0.0021  0.0013 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2265  0.0000  0.1088  0.0010  0.0305  0.0000  0.0147  0.0068 </r>
+        <r>  0.0000  0.2266  0.0000  0.1088  0.0009  0.0305  0.0000  0.0146  0.0067 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0142  0.1079  0.0086  0.2247  0.0251  0.0049  0.0016  0.0101  0.0035 </r>
+        <r>  0.0142  0.1079  0.0086  0.2246  0.0250  0.0048  0.0016  0.0101  0.0035 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0064  0.0017  0.0338  0.0035  0.0196  0.0005  0.0982  0.0011  0.0028 </r>
+        <r>  0.0064  0.0017  0.0340  0.0035  0.0195  0.0005  0.0982  0.0011  0.0027 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0034  0.0183  0.0121  0.0382  0.0012  0.0292  0.0022  0.0608  0.0002 </r>
+        <r>  0.0034  0.0184  0.0121  0.0383  0.0012  0.0291  0.0022  0.0606  0.0002 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0057  0.0000  0.0028  0.0235  0.0043  0.0000  0.0021  0.1671 </r>
+        <r>  0.0000  0.0057  0.0000  0.0027  0.0236  0.0044  0.0000  0.0021  0.1675 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0105  0.0175  0.0257  0.0363  0.0746  0.0167  0.0106  0.0348  0.0105 </r>
+        <r>  0.0105  0.0174  0.0256  0.0363  0.0743  0.0166  0.0107  0.0347  0.0105 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0216  0.0000  0.0104  0.0245  0.0033  0.0000  0.0016  0.1750 </r>
+        <r>  0.0000  0.0219  0.0000  0.0105  0.0247  0.0037  0.0000  0.0018  0.1754 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0331  0.0017  0.0309  0.0036  0.0884  0.0450  0.0829  0.0939  0.0124 </r>
+        <r>  0.0336  0.0017  0.0313  0.0035  0.0874  0.0453  0.0832  0.0941  0.0123 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0269  0.0000  0.0129  0.0017  0.2360  0.0000  0.1137  0.0123 </r>
+        <r>  0.0000  0.0266  0.0000  0.0127  0.0017  0.2365  0.0000  0.1132  0.0121 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0474  0.0002  0.0869  0.0004  0.0671  0.0178  0.0002  0.0362  0.0094 </r>
+        <r>  0.0469  0.0002  0.0868  0.0003  0.0676  0.0170  0.0002  0.0361  0.0095 </r>
+       </set>
+      </set>
+      <set comment="kpoint 59">
+       <set comment="band 1">
+        <r>  0.4007  0.0020  0.0138  0.0041  0.0001  0.0002  0.0003  0.0004  0.0000 </r>
+        <r>  0.4007  0.0020  0.0138  0.0041  0.0001  0.0002  0.0003  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3811  0.0030  0.0210  0.0062  0.0000  0.0000  0.0000  0.0001  0.0000 </r>
+        <r>  0.3812  0.0030  0.0210  0.0063  0.0000  0.0000  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0877  0.0194  0.1402  0.0404  0.0006  0.0022  0.0032  0.0046  0.0001 </r>
+        <r>  0.0875  0.0203  0.1377  0.0423  0.0007  0.0022  0.0031  0.0046  0.0001 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0856  0.0395  0.2349  0.0072  0.0079  0.0012  0.0046  0.0000 </r>
+        <r>  0.0000  0.0856  0.0404  0.2335  0.0057  0.0094  0.0013  0.0031  0.0015 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.2391  0.0692  0.0515  0.0081  0.0054  0.0022  0.0019  0.0034 </r>
+        <r>  0.0000  0.2378  0.0710  0.0509  0.0095  0.0038  0.0023  0.0034  0.0019 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0000  0.1504  0.0061  0.1420  0.0086  0.0225  0.0001  0.0092  0.0103 </r>
+        <r>  0.0000  0.1507  0.0061  0.1421  0.0070  0.0239  0.0001  0.0077  0.0116 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.1187  0.0848  0.0953  0.0333  0.0016  0.0008  0.0046  0.0102 </r>
+        <r>  0.0000  0.1183  0.0856  0.0947  0.0346  0.0002  0.0008  0.0061  0.0086 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0659  0.0234  0.1658  0.0489  0.0009  0.0032  0.0045  0.0066  0.0001 </r>
+        <r>  0.0660  0.0238  0.1646  0.0494  0.0010  0.0032  0.0045  0.0066  0.0001 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0026  0.0111  0.0778  0.0232  0.0035  0.0119  0.0168  0.0248  0.0005 </r>
+        <r>  0.0026  0.0111  0.0780  0.0232  0.0035  0.0119  0.0168  0.0247  0.0005 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0073  0.0017  0.0147  0.0355  0.0099  0.0252  0.0135  0.1230 </r>
+        <r>  0.0000  0.0073  0.0017  0.0147  0.0449  0.0004  0.0252  0.0230  0.1143 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0141  0.0055  0.0041  0.0141  0.0192  0.0803  0.0387  0.0553 </r>
+        <r>  0.0000  0.0141  0.0056  0.0041  0.0046  0.0286  0.0802  0.0292  0.0647 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0083  0.0107  0.0744  0.0222  0.0059  0.0197  0.0278  0.0411  0.0008 </r>
+        <r>  0.0084  0.0107  0.0744  0.0222  0.0058  0.0197  0.0277  0.0410  0.0008 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0098  0.0023  0.0208  0.0387  0.0084  0.0276  0.0173  0.1367 </r>
+        <r>  0.0000  0.0099  0.0023  0.0209  0.0468  0.0002  0.0277  0.0257  0.1284 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0199  0.0078  0.0053  0.0118  0.0242  0.0931  0.0405  0.0590 </r>
+        <r>  0.0000  0.0198  0.0078  0.0053  0.0035  0.0325  0.0934  0.0323  0.0671 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0280  0.0000  0.0143  0.0004  0.1790  0.0001  0.0870  0.0051 </r>
+        <r>  0.0000  0.0280  0.0000  0.0143  0.0005  0.1793  0.0001  0.0871  0.0051 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0102  0.0129  0.0193  0.1455  0.0029  0.0995  0.0037  0.0201 </r>
+        <r>  0.0000  0.0101  0.0130  0.0191  0.1449  0.0029  0.1002  0.0035  0.0200 </r>
+       </set>
+      </set>
+      <set comment="kpoint 60">
+       <set comment="band 1">
+        <r>  0.4034  0.0018  0.0130  0.0060  0.0001  0.0004  0.0003  0.0005  0.0000 </r>
+        <r>  0.4034  0.0018  0.0131  0.0060  0.0001  0.0004  0.0003  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.3849  0.0021  0.0172  0.0066  0.0001  0.0004  0.0001  0.0002  0.0000 </r>
+        <r>  0.3850  0.0021  0.0171  0.0067  0.0001  0.0004  0.0001  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0244  0.0823  0.1202  0.0891  0.0040  0.0020  0.0009  0.0042  0.0004 </r>
+        <r>  0.0244  0.0824  0.1201  0.0889  0.0040  0.0020  0.0009  0.0041  0.0004 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.2309  0.0782  0.0322  0.0102  0.0028  0.0026  0.0026  0.0040 </r>
+        <r>  0.0000  0.2303  0.0783  0.0327  0.0101  0.0028  0.0026  0.0026  0.0040 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0441  0.0139  0.0526  0.1807  0.0055  0.0137  0.0016  0.0014  0.0026 </r>
+        <r>  0.0441  0.0144  0.0526  0.1805  0.0055  0.0137  0.0016  0.0014  0.0026 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.0518  0.0113  0.0541  0.2140  0.0005  0.0100  0.0045  0.0026  0.0004 </r>
+        <r>  0.0517  0.0125  0.0541  0.2126  0.0006  0.0099  0.0045  0.0025  0.0004 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0000  0.2180  0.0737  0.0300  0.0232  0.0031  0.0012  0.0081  0.0130 </r>
+        <r>  0.0000  0.2166  0.0739  0.0312  0.0230  0.0032  0.0012  0.0082  0.0129 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0244  0.0872  0.1454  0.0665  0.0170  0.0097  0.0011  0.0114  0.0034 </r>
+        <r>  0.0244  0.0874  0.1450  0.0667  0.0169  0.0096  0.0011  0.0114  0.0034 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0006  0.0088  0.0527  0.0289  0.0082  0.0104  0.0163  0.0275  0.0293 </r>
+        <r>  0.0006  0.0088  0.0529  0.0289  0.0082  0.0104  0.0163  0.0274  0.0296 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0063  0.0072  0.0271  0.0092  0.0217  0.0096  0.0183  0.0299  0.0408 </r>
+        <r>  0.0063  0.0072  0.0270  0.0092  0.0216  0.0096  0.0182  0.0300  0.0409 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0119  0.0040  0.0017  0.0050  0.0241  0.0771  0.0317  0.0658 </r>
+        <r>  0.0000  0.0119  0.0041  0.0017  0.0049  0.0242  0.0770  0.0317  0.0655 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0011  0.0204  0.0579  0.0048  0.0512  0.0036  0.0473  0.0064  0.0741 </r>
+        <r>  0.0011  0.0204  0.0579  0.0048  0.0510  0.0037  0.0474  0.0064  0.0745 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0206  0.0070  0.0028  0.0022  0.0319  0.0955  0.0332  0.0693 </r>
+        <r>  0.0000  0.0207  0.0070  0.0030  0.0021  0.0318  0.0957  0.0328  0.0700 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0013  0.0024  0.0215  0.0419  0.0261  0.0186  0.0016  0.0628  0.0837 </r>
+        <r>  0.0012  0.0024  0.0215  0.0419  0.0260  0.0186  0.0018  0.0633  0.0831 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0296  0.0076  0.0087  0.0078  0.0043  0.1461  0.0729  0.0268  0.0267 </r>
+        <r>  0.0294  0.0076  0.0087  0.0077  0.0042  0.1466  0.0729  0.0268  0.0266 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0338  0.0115  0.0048  0.1018  0.0575  0.0697  0.0064  0.0060 </r>
+        <r>  0.0000  0.0336  0.0114  0.0047  0.1017  0.0574  0.0700  0.0065  0.0059 </r>
+       </set>
+      </set>
+     </set>
+    </set>
+   </array>
+  </projected>
+ </calculation>
+ <structure name="finalpos" >
+  <crystal>
+   <varray name="basis" >
+    <v>       3.97062800      -0.01718700       2.52612800 </v>
+    <v>       1.37824500       3.72379200       2.52612800 </v>
+    <v>      -0.02480100      -0.01718700       4.70601700 </v>
+   </varray>
+   <i name="volume">     70.04059440 </i>
+   <varray name="rec_basis" >
+    <v>       0.25082090      -0.09349856       0.00098037 </v>
+    <v>       0.00053491       0.26768039       0.00098042 </v>
+    <v>      -0.13492449      -0.09349851       0.21144139 </v>
+   </varray>
+  </crystal>
+  <varray name="positions" >
+   <v>       0.23465600       0.23465600       0.23465600 </v>
+   <v>       0.76534400       0.76534400       0.76534400 </v>
+  </varray>
+ </structure>
+</modeling>


### PR DESCRIPTION
SCAN is a finicky beast. This seems to help quite a bit in getting convergence on the most finicky SCAN calculations. Especially effective on metals.

- Unconverged error handler uses Algo = All for SCAN 
- unit test for new functionality