### PR TITLE
add RESTART card to FEFF handler

### DIFF
--- a/custodian/feff/handlers.py
+++ b/custodian/feff/handlers.py
@@ -17,7 +17,7 @@ __maintainer__ = "Chen Zheng"
 __email__ = "chz022@ucsd.edu"
 __date__ = "Oct 18, 2017"
 
-FEFF_BACKUP_FILES = ["ATOMS", "HEADER", "PARAMETERS", "POTENTIALS", "feff.inp", "*.cif"]
+FEFF_BACKUP_FILES = ["ATOMS", "HEADER", "PARAMETERS", "POTENTIALS", "feff.inp", "*.cif", "pot.bin"]
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +66,11 @@ class UnconvergedErrorHandler(ErrorHandler):
         ca = scf_values[3]
         nmix = scf_values[4]
         actions = []
+
+        #Add RESTART card to PARAMETERS
+        if not "RESTART" in feff_input.tags:
+            actions.append({"dict": "PARAMETERS",
+                            "action": {"_set": {"RESTART": []}}})
 
         if nscmt < 100 and ca == 0.2:
             scf_values[2] = 100

--- a/custodian/feff/tests/test_handler.py
+++ b/custodian/feff/tests/test_handler.py
@@ -9,7 +9,6 @@ __maintainer__ = "Chen Zheng"
 __email__ = "chz022@ucsd.edu"
 __date__ = "Oct 18, 2017"
 
-
 import unittest
 import os
 import glob
@@ -20,12 +19,13 @@ from custodian.feff.handlers import UnconvergedErrorHandler
 test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..",
                         "test_files")
 
+
 def clean_dir():
     for f in glob.glob("error.*.tar.gz"):
         os.remove(f)
 
-class UnconvergedErrorHandlerTest(unittest.TestCase):
 
+class UnconvergedErrorHandlerTest(unittest.TestCase):
     def setUp(cls):
         os.chdir(test_dir)
         subdir = os.path.join(test_dir, "feff_unconverge")
@@ -43,7 +43,9 @@ class UnconvergedErrorHandlerTest(unittest.TestCase):
         d = h.correct()
         self.assertEqual(d["errors"], ["Non-converging job"])
         self.assertEqual(d['actions'],
-                         [{'action': {'_set': {'SCF': [7, 0, 100, 0.2, 3]}},
+                         [{"dict": "PARAMETERS",
+                           "action": {"_set": {"RESTART": []}}},
+                          {'action': {'_set': {'SCF': [7, 0, 100, 0.2, 3]}},
                            'dict': 'PARAMETERS'}])
         shutil.move("ATOMS.orig", "ATOMS")
         shutil.move("PARAMETERS.orig", "PARAMETERS")


### PR DESCRIPTION
## Summary

In FEFF handler, add RESTART card option. The new calculation would now start from an existing 'pot.bin' file for SCF calculation. Unittest has been modified accordingly. Fixes #71 