### PR TITLE
Minor bug fix for `WalltimeHandler`

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -1087,7 +1087,7 @@ class WalltimeHandler(ErrorHandler):
             self.start_time = datetime.datetime.strptime(
                 os.environ["CUSTODIAN_WALLTIME_START"], "%a %b %d %H:%M:%S %Z %Y")
         else:
-            self.start_time = datetime.datetime.utcnow()
+            self.start_time = datetime.datetime.now()
             os.environ["CUSTODIAN_WALLTIME_START"] = datetime.datetime.strftime(
                 self.start_time, "%a %b %d %H:%M:%S UTC %Y")
 


### PR DESCRIPTION
## Summary

`WalltimeHandler` doesn't terminate a firetask in time because the wrong timezone is used in runtime calculation.
