### PR TITLE
QChem updates for Atomate

### DIFF
--- a/custodian/qchem/new_handlers.py
+++ b/custodian/qchem/new_handlers.py
@@ -29,8 +29,8 @@ class QChemErrorHandler(ErrorHandler):
     is_monitor = False
 
     def __init__(self,
-                 input_file="mol.qcin",
-                 output_file="mol.qcout",
+                 input_file="mol.qin",
+                 output_file="mol.qout",
                  scf_max_cycles=200,
                  geom_max_cycles=200):
         """
@@ -185,8 +185,8 @@ class QChemSCFErrorHandler(ErrorHandler):
     is_monitor = False
 
     def __init__(self,
-                 input_file="mol.qcin",
-                 output_file="mol.qcout",
+                 input_file="mol.qin",
+                 output_file="mol.qout",
                  rca_gdm_thresh=1.0E-3,
                  scf_max_cycles=200):
         """

--- a/custodian/qchem/new_handlers.py
+++ b/custodian/qchem/new_handlers.py
@@ -73,6 +73,9 @@ class QChemErrorHandler(ErrorHandler):
             elif self.qcinp.rem.get("scf_algorithm", "diis").lower() == "diis":
                 self.qcinp.rem["scf_algorithm"] = "rca_diis"
                 actions.append({"scf_algorithm": "rca_diis"})
+                if self.qcinp.rem.get("gen_scfman"):
+                    self.qcinp.rem["gen_scfman"] = False
+                    actions.append({"gen_scfman": False})
             else:
                 print(
                     "More advanced changes may impact the SCF result. Use the SCF error handler"

--- a/custodian/qchem/new_jobs.py
+++ b/custodian/qchem/new_jobs.py
@@ -197,17 +197,13 @@ class QCJob(Job):
             errors = outdata.get("errors")
             if len(errors) != 0:
                 raise AssertionError('No errors should be encountered while flattening frequencies!')
-            if float(outdata.get('frequencies')[0][0]) > 0.0:
+            if outdata.get('frequencies')[0] > 0.0:
                 print("All frequencies positive!")
                 break
             else:
-                negative_freq_vecs = outdata.get("negative_freq_vecs")
-                old_coords = outdata.get("freq_geometry")
-                old_molecule = Molecule(
-                    species=outdata.get('freq_species'),
-                    coords=old_coords,
-                    charge=outdata.get('charge'),
-                    spin_multiplicity=outdata.get('multiplicity'))
+                negative_freq_vecs = outdata.get("frequency_mode_vectors")[0]
+                old_coords = outdata.get("initial_geometry")
+                old_molecule = outdata.get("initial_molecule")
                 structure_successfully_perturbed = False
 
                 for molecule_perturb_scale in np.arange(
@@ -219,7 +215,7 @@ class QCJob(Job):
                         molecule_perturb_scale=molecule_perturb_scale,
                         reversed_direction=reversed_direction)
                     new_molecule = Molecule(
-                        species=outdata.get('freq_species'),
+                        species=outdata.get('species'),
                         coords=new_coords,
                         charge=outdata.get('charge'),
                         spin_multiplicity=outdata.get('multiplicity'))

--- a/custodian/qchem/new_jobs.py
+++ b/custodian/qchem/new_jobs.py
@@ -225,10 +225,10 @@ class QCJob(Job):
                     if msc.are_equal(old_molecule, new_molecule):
                         structure_successfully_perturbed = True
                         break
-                if ignore_connectivity:
-                    structure_successfully_perturbed = True
-                    break
-                elif not structure_successfully_perturbed:
+                    elif ignore_connectivity:
+                        structure_successfully_perturbed = True
+                        break
+                if not structure_successfully_perturbed:
                     raise Exception(
                         "Unable to perturb coordinates to remove negative frequency without changing the bonding structure"
                     )

--- a/custodian/qchem/new_jobs.py
+++ b/custodian/qchem/new_jobs.py
@@ -40,7 +40,7 @@ class QCJob(Job):
                  max_cores=32,
                  qclog_file="mol.qclog",
                  suffix="",
-                 scratch="/dev/shm/qcscratch/",
+                 scratch_dir="/dev/shm/qcscratch/",
                  save_scratch=False,
                  save_name="default_save_name"):
         """
@@ -55,7 +55,7 @@ class QCJob(Job):
                 to. None means not to record the standard output. Defaults to
                 None.
             suffix (str): String to append to the file in postprocess.
-            scratch (str): QCSCRATCH directory. Defaults to "/dev/shm/qcscratch/".
+            scratch_dir (str): QCSCRATCH directory. Defaults to "/dev/shm/qcscratch/".
             save_scratch (bool): Whether to save scratch directory contents.
                 Defaults to False.
             save_name (str): Name of the saved scratch directory. Defaults to
@@ -68,7 +68,7 @@ class QCJob(Job):
         self.max_cores = max_cores
         self.qclog_file = qclog_file
         self.suffix = suffix
-        self.scratch = scratch
+        self.scratch_dir = scratch_dir
         self.save_scratch = save_scratch
         self.save_name = save_name
 
@@ -96,7 +96,7 @@ class QCJob(Job):
         return command
 
     def setup(self):
-        os.putenv("QCSCRATCH", self.scratch)
+        os.putenv("QCSCRATCH", self.scratch_dir)
         if self.multimode == 'openmp':
             os.putenv('QCTHREADS', str(self.max_cores))
             os.putenv('OMP_NUM_THREADS', str(self.max_cores))
@@ -104,7 +104,7 @@ class QCJob(Job):
     def postprocess(self):
         if self.save_scratch:
             shutil.copytree(
-                os.path.join(self.scratch, self.save_name),
+                os.path.join(self.scratch_dir, self.save_name),
                 os.path.join(os.path.dirname(self.input_file), self.save_name))
         if self.suffix != "":
             shutil.move(self.input_file, self.input_file + self.suffix)

--- a/custodian/qchem/new_jobs.py
+++ b/custodian/qchem/new_jobs.py
@@ -222,10 +222,7 @@ class QCJob(Job):
                         coords=new_coords,
                         charge=outdata.get('charge'),
                         spin_multiplicity=outdata.get('multiplicity'))
-                    if msc.are_equal(old_molecule, new_molecule):
-                        structure_successfully_perturbed = True
-                        break
-                    elif ignore_connectivity:
+                    if msc.are_equal(old_molecule, new_molecule) or ignore_connectivity:
                         structure_successfully_perturbed = True
                         break
                 if not structure_successfully_perturbed:

--- a/custodian/qchem/new_jobs.py
+++ b/custodian/qchem/new_jobs.py
@@ -132,6 +132,7 @@ class QCJob(Job):
                                      max_iterations=10,
                                      max_molecule_perturb_scale=0.3,
                                      reversed_direction=False,
+                                     ignore_connectivity=False,
                                      **QCJob_kwargs):
         """
         Optimize a structure and calculate vibrational frequencies to check if the
@@ -150,7 +151,9 @@ class QCJob(Job):
                 can be applied to the molecule. Defaults to 0.3.
             reversed_direction (bool): Whether to reverse the direction of the
                 vibrational frequency vectors. Defaults to False.
-            \*\*QCJob_kwargs: Passthrough kwargs to QCJob. See
+            ignore_connectivity (bool): Whether to ignore differences in connectivity
+                introduced by structural perturbation. Defaults to False.
+            **QCJob_kwargs: Passthrough kwargs to QCJob. See
                 :class:`custodian.qchem.new_jobs.QCJob`.
         """
 
@@ -222,8 +225,10 @@ class QCJob(Job):
                     if msc.are_equal(old_molecule, new_molecule):
                         structure_successfully_perturbed = True
                         break
-
-                if not structure_successfully_perturbed:
+                if ignore_connectivity:
+                    structure_successfully_perturbed = True
+                    break
+                elif not structure_successfully_perturbed:
                     raise Exception(
                         "Unable to perturb coordinates to remove negative frequency without changing the bonding structure"
                     )

--- a/custodian/qchem/new_jobs.py
+++ b/custodian/qchem/new_jobs.py
@@ -144,7 +144,7 @@ class QCJob(Job):
             multimode (str): Parallelization scheme, either openmp or mpi.
             input_file (str): Name of the QChem input file.
             output_file (str): Name of the QChem output file
-            max_iterations (int): Number of perturbation -> optimization -> freqency
+            max_iterations (int): Number of perturbation -> optimization -> frequency
                 iterations to perform. Defaults to 10.
             max_molecule_perturb_scale (float): The maximum scaled perturbation that
                 can be applied to the molecule. Defaults to 0.3.


### PR DESCRIPTION
## Summary

Small tweaks that were found to be necessary when building QChem functionality into Atomate and testing workflows.

* Standardized default input and output filenames. 
* Standardized variable name for scratch directory.
* Added option to ignore connectivity when flattening negative frequencies.

We would greatly appreciate if this could be merged as soon as possible and that a new version could be released immediately afterwards so that we can do a pull request for Atomate before Codebusters tomorrow. Thank you!