### PR TITLE
Update DriftErrorHandler

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -643,7 +643,11 @@ class DriftErrorHandler(ErrorHandler):
         if not self.max_drift:
             self.max_drift = incar["EDIFFG"] * -1
 
-        outcar = Outcar("OUTCAR")
+        try:
+            outcar = Outcar("OUTCAR")
+        except:
+            # Can't perform check if Outcar not valid
+            return False
 
         if len(outcar.data.get('drift', [])) < self.to_average:
             # Ensure enough steps to get average drift


### PR DESCRIPTION
## Summary

Minor change to DriftErrorHandler so it's only run when Outcar is valid (if Outcar is not valid, this is a separate issue unrelated to drift).

I was getting a lot of exceptions caused by DriftErrorHandler that caused jobs to fail, even though the calculations looked fine (usually when parsing Outcar, `self.data.get(\"ibrion\", [[0]])[0][0] > 6:\nIndexError: list index out of range`).

I'm not 100% sure why this was happening, so still intend to investigate further to find the root cause, but this does fix the issue for now.