### PR TITLE
UnconvergedErrorHandler deprecated change_algo

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -1055,6 +1055,17 @@ class NonConvergingErrorHandler(ErrorHandler):
         # Unfixable error. Just return None for actions.
         else:
             return {"errors": ["Non-converging job"], "actions": None}
+        
+    @classmethod
+    def from_dict(cls, d):
+        """
+        Custom from_dict method to preserve backwards compatibility with 
+        older versions of Custodian.
+        """
+        if "change_algo" in d:
+            del d["change_algo"]
+        return cls(output_filename=d.get("output_filename", "OSZICAR"),
+                   nionic_steps=d.get("nionic_steps", 10))
 
 
 class WalltimeHandler(ErrorHandler):

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -1055,11 +1055,11 @@ class NonConvergingErrorHandler(ErrorHandler):
         # Unfixable error. Just return None for actions.
         else:
             return {"errors": ["Non-converging job"], "actions": None}
-        
+
     @classmethod
     def from_dict(cls, d):
         """
-        Custom from_dict method to preserve backwards compatibility with 
+        Custom from_dict method to preserve backwards compatibility with
         older versions of Custodian.
         """
         if "change_algo" in d:


### PR DESCRIPTION
change_algo input of UnconvergedErrorHandler is deprecated. Added a custom as_dict method as a fix to preserve backwards compatibility of Fireworks with older versions of Custodian that include change_algo.

@mkhorton was consulted for this fix. Note adding a logger warning was considered but this was not straightforward to incorporate.