### PR TITLE
Handle PSMAXN / REALOPT errors

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -93,8 +93,7 @@ class VaspErrorHandler(ErrorHandler):
         "rhosyg": ["RHOSYG internal error"],
         "posmap": ["POSMAP internal error: symmetry equivalent atom not found"],
         "point_group": ["Error: point group operation missing"],
-        "psmaxn": ["REAL_OPT: internal ERROR:",
-                        "WARNING: PSMAXN for non-local potential too small"]
+        "realopt": ["REAL_OPT: internal ERROR:"]
     }
 
     def __init__(self, output_filename="vasp.out", natoms_large_cell=100,
@@ -169,7 +168,7 @@ class VaspErrorHandler(ErrorHandler):
             actions.append({"dict": "INCAR",
                             "action": {"_set": {"SYMPREC": 1e-8}}})
         
-        if "psmaxn" in self.errors:
+        if "realopt" in self.errors:
             actions.append({"dict": "INCAR",
                             "action": {"_set": {"LREAL": False}}})
 

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -92,7 +92,9 @@ class VaspErrorHandler(ErrorHandler):
         "elf_ncl": ["WARNING: ELF not implemented for non collinear case"],
         "rhosyg": ["RHOSYG internal error"],
         "posmap": ["POSMAP internal error: symmetry equivalent atom not found"],
-        "point_group": ["Error: point group operation missing"]
+        "point_group": ["Error: point group operation missing"],
+        "psmaxn": ["REAL_OPT: internal ERROR:",
+                        "WARNING: PSMAXN for non-local potential too small"]
     }
 
     def __init__(self, output_filename="vasp.out", natoms_large_cell=100,
@@ -166,6 +168,10 @@ class VaspErrorHandler(ErrorHandler):
         if "inv_rot_mat" in self.errors:
             actions.append({"dict": "INCAR",
                             "action": {"_set": {"SYMPREC": 1e-8}}})
+        
+        if "psmaxn" in self.errors:
+            actions.append({"dict": "INCAR",
+                            "action": {"_set": {"LREAL": False}}})
 
         if "brmix" in self.errors:
             # If there is not a valid OUTCAR already, increment

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -229,7 +229,7 @@ class VaspErrorHandlerTest(unittest.TestCase):
         h = VaspErrorHandler("vasp.nicht_konvergent")
         h.natoms_large_cell = 5
         self.assertEqual(h.check(), True)
-        self.assertEqual(h.correct()["errors"], ["psmaxn","nicht_konv"])
+        self.assertEqual(h.correct()["errors"], ["realopt","nicht_konv"])
         i = Incar.from_file("INCAR")
         self.assertEqual(i["LREAL"], True)
 
@@ -429,7 +429,7 @@ class ZpotrfErrorHandlerTest(unittest.TestCase):
         h = VaspErrorHandler("vasp.out")
         self.assertEqual(h.check(), True)
         d = h.correct()
-        self.assertEqual(d['errors'], ["psmaxn","zpotrf"])
+        self.assertEqual(d['errors'], ["realopt","zpotrf"])
         s2 = Structure.from_file("POSCAR")
         self.assertAlmostEqual(s2.volume, s1.volume * 1.2 ** 3, 3)
 
@@ -439,7 +439,7 @@ class ZpotrfErrorHandlerTest(unittest.TestCase):
         h = VaspErrorHandler("vasp.out")
         self.assertEqual(h.check(), True)
         d = h.correct()
-        self.assertEqual(d['errors'], ["psmaxn","zpotrf"])
+        self.assertEqual(d['errors'], ["realopt","zpotrf"])
         s2 = Structure.from_file("POSCAR")
         self.assertAlmostEqual(s2.volume, s1.volume, 3)
         self.assertAlmostEqual(Incar.from_file("INCAR")['POTIM'], 0.25)
@@ -455,7 +455,7 @@ class ZpotrfErrorHandlerTest(unittest.TestCase):
         h = VaspErrorHandler("vasp.out")
         self.assertEqual(h.check(), True)
         d = h.correct()
-        self.assertEqual(d['errors'], ["psmaxn","zpotrf"])
+        self.assertEqual(d['errors'], ["realopt","zpotrf"])
         s2 = Structure.from_file("POSCAR")
         self.assertAlmostEqual(s2.volume, s1.volume, 3)
         self.assertEqual(Incar.from_file("INCAR")["ISYM"], 0)

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -229,7 +229,7 @@ class VaspErrorHandlerTest(unittest.TestCase):
         h = VaspErrorHandler("vasp.nicht_konvergent")
         h.natoms_large_cell = 5
         self.assertEqual(h.check(), True)
-        self.assertEqual(h.correct()["errors"], ["nicht_konv"])
+        self.assertEqual(h.correct()["errors"], ["psmaxn","nicht_konv"])
         i = Incar.from_file("INCAR")
         self.assertEqual(i["LREAL"], True)
 
@@ -429,7 +429,7 @@ class ZpotrfErrorHandlerTest(unittest.TestCase):
         h = VaspErrorHandler("vasp.out")
         self.assertEqual(h.check(), True)
         d = h.correct()
-        self.assertEqual(d['errors'], ['zpotrf'])
+        self.assertEqual(d['errors'], ["psmaxn","zpotrf"])
         s2 = Structure.from_file("POSCAR")
         self.assertAlmostEqual(s2.volume, s1.volume * 1.2 ** 3, 3)
 
@@ -439,7 +439,7 @@ class ZpotrfErrorHandlerTest(unittest.TestCase):
         h = VaspErrorHandler("vasp.out")
         self.assertEqual(h.check(), True)
         d = h.correct()
-        self.assertEqual(d['errors'], ['zpotrf'])
+        self.assertEqual(d['errors'], ["psmaxn","zpotrf"])
         s2 = Structure.from_file("POSCAR")
         self.assertAlmostEqual(s2.volume, s1.volume, 3)
         self.assertAlmostEqual(Incar.from_file("INCAR")['POTIM'], 0.25)
@@ -455,7 +455,7 @@ class ZpotrfErrorHandlerTest(unittest.TestCase):
         h = VaspErrorHandler("vasp.out")
         self.assertEqual(h.check(), True)
         d = h.correct()
-        self.assertEqual(d['errors'], ['zpotrf'])
+        self.assertEqual(d['errors'], ["psmaxn","zpotrf"])
         s2 = Structure.from_file("POSCAR")
         self.assertAlmostEqual(s2.volume, s1.volume, 3)
         self.assertEqual(Incar.from_file("INCAR")["ISYM"], 0)


### PR DESCRIPTION
Add error handling for PSMAXN errors by setting LREAL=FALSE. See #133 .

Also note that several of the existing test files contain the PSMAXN warnings, so new tests are not required for this handler.