### PR TITLE
shorten err msg for vasp6. Closes #156.

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -74,7 +74,7 @@ class VaspErrorHandler(ErrorHandler):
             "Tetrahedron method fails (number of k-points < 4)",
         ],
         "inv_rot_mat": [
-            "inverse of rotation matrix was not found (increase " "SYMPREC)"
+            "rotation matrix was not found (increase " "SYMPREC)"
         ],
         "brmix": ["BRMIX: very serious problems"],
         "subspacematrix": ["WARNING: Sub-Space-Matrix is not hermitian in " "DAV"],
@@ -101,7 +101,7 @@ class VaspErrorHandler(ErrorHandler):
         "elf_ncl": ["WARNING: ELF not implemented for non collinear case"],
         "rhosyg": ["RHOSYG internal error"],
         "posmap": ["POSMAP internal error: symmetry equivalent atom not found"],
-        "point_group": ["Error: point group operation missing"],
+        "point_group": ["group operation missing"],
     }
 
     def __init__(

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -279,6 +279,22 @@ class VaspErrorHandlerTest(unittest.TestCase):
         i = Incar.from_file("INCAR")
         self.assertEqual(i["ISYM"], 0)
 
+    def test_point_group_vasp6(self):
+        # the error message is formatted differently in VASP6 compared to VASP5
+        h = VaspErrorHandler("vasp6.point_group")
+        self.assertEqual(h.check(), True)
+        self.assertEqual(h.correct()["errors"], ["point_group"])
+        i = Incar.from_file("INCAR")
+        self.assertEqual(i["ISYM"], 0)
+
+    def test_inv_rot_matrix_vasp6(self):
+        # the error message is formatted differently in VASP6 compared to VASP5
+        h = VaspErrorHandler("vasp6.inv_rot_mat")
+        self.assertEqual(h.check(), True)
+        self.assertEqual(h.correct()["errors"], ["inv_rot_mat"])
+        i = Incar.from_file("INCAR")
+        self.assertEqual(i["SYMPREC"], 1e-08)
+
     def test_too_large_kspacing(self):
         shutil.copy("INCAR.kspacing", "INCAR")
         vi = VaspInput.from_directory(".")

--- a/test_files/vasp6.inv_rot_mat
+++ b/test_files/vasp6.inv_rot_mat
@@ -1,0 +1,16 @@
+ -----------------------------------------------------------------------------
+|                                                                             |
+|     EEEEEEE  RRRRRR   RRRRRR   OOOOOOO  RRRRRR      ###     ###     ###     |
+|     E        R     R  R     R  O     O  R     R     ###     ###     ###     |
+|     E        R     R  R     R  O     O  R     R     ###     ###     ###     |
+|     EEEEE    RRRRRR   RRRRRR   O     O  RRRRRR       #       #       #      |
+|     E        R   R    R   R    O     O  R   R                               |
+|     E        R    R   R    R   O     O  R    R      ###     ###     ###     |
+|     EEEEEEE  R     R  R     R  OOOOOOO  R     R     ###     ###     ###     |
+|                                                                             |
+|     VERY BAD NEWS! internal error in subroutine INVGRP: inverse of          |
+|     rotation matrix was not found (increase SYMPREC) 13                     |
+|                                                                             |
+|       ---->  I REFUSE TO CONTINUE WITH THIS SICK JOB ... BYE!!! <----       |
+|                                                                             |
+ -----------------------------------------------------------------------------

--- a/test_files/vasp6.point_group
+++ b/test_files/vasp6.point_group
@@ -1,0 +1,16 @@
+ -----------------------------------------------------------------------------
+|                                                                             |
+|     EEEEEEE  RRRRRR   RRRRRR   OOOOOOO  RRRRRR      ###     ###     ###     |
+|     E        R     R  R     R  O     O  R     R     ###     ###     ###     |
+|     E        R     R  R     R  O     O  R     R     ###     ###     ###     |
+|     EEEEE    RRRRRR   RRRRRR   O     O  RRRRRR       #       #       #      |
+|     E        R   R    R   R    O     O  R   R                               |
+|     E        R    R   R    R   O     O  R    R      ###     ###     ###     |
+|     EEEEEEE  R     R  R     R  OOOOOOO  R     R     ###     ###     ###     |
+|                                                                             |
+|     VERY BAD NEWS! internal error in subroutine IBZKPT: Error: point        |
+|     group operation missing 2                                               |
+|                                                                             |
+|       ---->  I REFUSE TO CONTINUE WITH THIS SICK JOB ... BYE!!! <----       |
+|                                                                             |
+ -----------------------------------------------------------------------------


### PR DESCRIPTION
Shorten error messages for 2 handlers so they are detected in VASP6. See #156.