### PR TITLE
bugfix for LargeSigmaHandler edge case

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -1035,7 +1035,11 @@ class LargeSigmaHandler(ErrorHandler):
 
     def check(self):
         incar = Incar.from_file("INCAR")
-        outcar = Outcar("OUTCAR")
+        try:
+            outcar = Outcar("OUTCAR")
+        except Exception:
+            # Can't perform check if Outcar not valid
+            return False
 
         if incar.get("ISMEAR", 0) > 0:
             # Read the latest entropy term.


### PR DESCRIPTION
Fix a just-identified edge case in `LargeSigmaHandler`. If a VASP calculation fails to generate a valid OUTCAR, `LargeSigmaHandler.check()` will fail when it tries to open the OUTCAR, preventing the calculation from being rerun. This PR simply adds a try/except clause to the OUTCAR load (following the pattern used in `DriftErrorHandler` [here]( https://github.com/materialsproject/custodian/blob/e9990756713be75cb773bfde5e4cb5e00a7b9097/custodian/vasp/handlers.py#L728) )to allow custodian to continue in such cases.