### PR TITLE
add VASP6 support for RHOSYG error

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -101,7 +101,7 @@ class VaspErrorHandler(ErrorHandler):
         "zheev": ["ERROR EDDIAG: Call to routine ZHEEV failed!"],
         "elf_kpar": ["ELF: KPAR>1 not implemented"],
         "elf_ncl": ["WARNING: ELF not implemented for non collinear case"],
-        "rhosyg": ["RHOSYG internal error"],
+        "rhosyg": ["RHOSYG"],
         "posmap": ["POSMAP internal error: symmetry equivalent atom not found"],
         "point_group": ["group operation missing"],
     }

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -268,6 +268,16 @@ class VaspErrorHandlerTest(unittest.TestCase):
         i = Incar.from_file("INCAR")
         self.assertEqual(i["ISYM"], 0)
 
+    def test_rhosyg_vasp6(self):
+        h = VaspErrorHandler("vasp6.rhosyg")
+        self.assertEqual(h.check(), True)
+        self.assertEqual(h.correct()["errors"], ["rhosyg"])
+        i = Incar.from_file("INCAR")
+        self.assertEqual(i["SYMPREC"], 1e-4)
+        self.assertEqual(h.correct()["errors"], ["rhosyg"])
+        i = Incar.from_file("INCAR")
+        self.assertEqual(i["ISYM"], 0)
+
     def test_posmap(self):
         h = VaspErrorHandler("vasp.posmap")
         self.assertEqual(h.check(), True)

--- a/test_files/vasp6.rhosyg
+++ b/test_files/vasp6.rhosyg
@@ -1,0 +1,16 @@
+ -----------------------------------------------------------------------------
+|                                                                             |
+|     EEEEEEE  RRRRRR   RRRRRR   OOOOOOO  RRRRRR      ###     ###     ###     |
+|     E        R     R  R     R  O     O  R     R     ###     ###     ###     |
+|     E        R     R  R     R  O     O  R     R     ###     ###     ###     |
+|     EEEEE    RRRRRR   RRRRRR   O     O  RRRRRR       #       #       #      |
+|     E        R   R    R   R    O     O  R   R                               |
+|     E        R    R   R    R   O     O  R    R      ###     ###     ###     |
+|     EEEEEEE  R     R  R     R  OOOOOOO  R     R     ###     ###     ###     |
+|                                                                             |
+|     VERY BAD NEWS! internal error in subroutineRHOSYG:stars are not         |
+|     distinct, try to increase SYMPREC to e.g. 1E-4 1                        |
+|                                                                             |
+|       ---->  I REFUSE TO CONTINUE WITH THIS SICK JOB ... BYE!!! <----       |
+|                                                                             |
+ -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Shorten error message in order to catch RHOSYG error in VASP6. See #156.

I will continue to open small PRs for VASP6 detection problems as I identify them.