### PR TITLE
Add new error handler for DFPT error + test

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -98,7 +98,7 @@ class VaspErrorHandler(ErrorHandler):
         "posmap": ["POSMAP"],
         "point_group": ["group operation missing"],
         "symprec_noise": ["determination of the symmetry of your systems shows a strong"],
-        "dfpt_ncore": ["PEAD routines do not work for NCORE"]
+        "dfpt_ncore": ["PEAD routines do not work for NCORE"],
     }
 
     def __init__(

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -98,6 +98,7 @@ class VaspErrorHandler(ErrorHandler):
         "posmap": ["POSMAP"],
         "point_group": ["group operation missing"],
         "symprec_noise": ["determination of the symmetry of your systems shows a strong"],
+        "dfpt_ncore": ["PEAD routines do not work for NCORE"]
     }
 
     def __init__(
@@ -435,6 +436,13 @@ class VaspErrorHandler(ErrorHandler):
                 actions.append({"dict": "INCAR", "action": {"_set": {"SYMPREC": 1e-6}}})
             else:
                 actions.append({"dict": "INCAR", "action": {"_set": {"ISYM": 0}}})
+
+        if "dfpt_ncore" in self.errors:
+            # note that when using "_unset" action, the value is ignored
+            if "NCORE" in vi["INCAR"]:
+                actions.append({"dict": "INCAR", "action": {"_unset": {"NCORE": 0}}})
+            if "NPAR" in vi["INCAR"]:
+                actions.append({"dict": "INCAR", "action": {"_unset": {"NPAR": 0}}})
 
         VaspModder(vi=vi).apply_actions(actions)
         return {"errors": list(self.errors), "actions": actions}

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -300,6 +300,15 @@ class VaspErrorHandlerTest(unittest.TestCase):
         i = Incar.from_file("INCAR")
         self.assertEqual(i["SYMPREC"], 1e-6)
 
+    def test_dfpt_ncore(self):
+        h = VaspErrorHandler("vasp.dfpt_ncore")
+        self.assertEqual(h.check(), True)
+        self.assertEqual(h.correct()["errors"], ["dfpt_ncore"])
+        incar = Incar.from_file("INCAR")
+        self.assertTrue("NPAR" not in incar)
+        self.assertTrue("NCORE" not in incar)
+
+
     def test_point_group_vasp6(self):
         # the error message is formatted differently in VASP6 compared to VASP5
         h = VaspErrorHandler("vasp6.point_group")

--- a/test_files/vasp.dfpt_ncore
+++ b/test_files/vasp.dfpt_ncore
@@ -1,0 +1,18 @@
+ -----------------------------------------------------------------------------
+|                                                                             |
+|     EEEEEEE  RRRRRR   RRRRRR   OOOOOOO  RRRRRR      ###     ###     ###     |
+|     E        R     R  R     R  O     O  R     R     ###     ###     ###     |
+|     E        R     R  R     R  O     O  R     R     ###     ###     ###     |
+|     EEEEE    RRRRRR   RRRRRR   O     O  RRRRRR       #       #       #      |
+|     E        R   R    R   R    O     O  R   R                               |
+|     E        R    R   R    R   O     O  R    R      ###     ###     ###     |
+|     EEEEEEE  R     R  R     R  OOOOOOO  R     R     ###     ###     ###     |
+|                                                                             |
+|     The PEAD routines do not work for NCORE /= 1 (or NPAR /= NCPU).         |
+|     Several features internally rely on the PEAD routines, so even if       |
+|     you have not specified LPEAD=.TRUE., try restarting your job with       |
+|     NCORE=1.                                                                |
+|                                                                             |
+|       ---->  I REFUSE TO CONTINUE WITH THIS SICK JOB ... BYE!!! <----       |
+|                                                                             |
+ -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This just adds a new error handler for PEAD routines since they don't work with non-default NCORE or NPAR. These are then unset in INCAR.

Thanks to @Guaxixi for finding and helping with this issue.