### PR TITLE
add van_der_waals support to FrequencyFlatteningOptimizeFW

### DIFF
--- a/custodian/qchem/jobs.py
+++ b/custodian/qchem/jobs.py
@@ -244,6 +244,8 @@ class QCJob(Job):
                 pcm=orig_input.pcm,
                 solvent=orig_input.solvent,
                 smx=orig_input.smx,
+                vdw_mode=orig_input.vdw_mode,
+                van_der_waals=orig_input.van_der_waals,
             )
             opt_QCInput.write_file(input_file)
             first = False
@@ -286,6 +288,8 @@ class QCJob(Job):
                     pcm=orig_input.pcm,
                     solvent=orig_input.solvent,
                     smx=orig_input.smx,
+                    vdw_mode=orig_input.vdw_mode,
+                    van_der_waals=orig_input.van_der_waals,
                 )
                 freq_QCInput.write_file(input_file)
                 yield (
@@ -329,6 +333,8 @@ class QCJob(Job):
                         pcm=orig_input.pcm,
                         solvent=orig_input.solvent,
                         smx=orig_input.smx,
+                        vdw_mode=orig_input.vdw_mode,
+                        van_der_waals=orig_input.van_der_waals,
                     )
                     opt_QCInput.write_file(input_file)
                 else:
@@ -350,6 +356,8 @@ class QCJob(Job):
                         pcm=orig_input.pcm,
                         solvent=orig_input.solvent,
                         smx=orig_input.smx,
+                        vdw_mode=orig_input.vdw_mode,
+                        van_der_waals=orig_input.van_der_waals,
                     )
                     opt_QCInput.write_file(input_file)
             if not save_final_scratch:

--- a/custodian/qchem/jobs.py
+++ b/custodian/qchem/jobs.py
@@ -400,6 +400,8 @@ class QCJob(Job):
                     pcm=orig_opt_input.pcm,
                     solvent=orig_opt_input.solvent,
                     smx=orig_opt_input.smx,
+                    vdw_mode=orig_opt_input.vdw_mode,
+                    van_der_waals=orig_opt_input.van_der_waals,
                 )
                 freq_QCInput.write_file(input_file)
                 yield (
@@ -572,5 +574,7 @@ class QCJob(Job):
                     pcm=orig_opt_input.pcm,
                     solvent=orig_opt_input.solvent,
                     smx=orig_opt_input.smx,
+                    vdw_mode=orig_opt_input.vdw_mode,
+                    van_der_waals=orig_opt_input.van_der_waals,
                 )
                 new_opt_QCInput.write_file(input_file)

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
-pymatgen==2022.0.4
+pymatgen==2022.0.8
 coverage==5.5
 coveralls==3.0.1
 pytest==6.2.2


### PR DESCRIPTION
Modifies the `opt_with_frequency_flattener` job type so that the `van_der_waals` section, if present, is passed to the child (frequency) fireworks