### PR TITLE
QChem: handle basis_not_supported error

### DIFF
--- a/custodian/qchem/handlers.py
+++ b/custodian/qchem/handlers.py
@@ -10,7 +10,7 @@ from pymatgen.io.qchem.outputs import QCOutput
 from custodian.custodian import ErrorHandler
 from custodian.utils import backup
 
-__author__ = "Samuel Blau, Brandon Wood, Shyam Dwaraknath"
+__author__ = "Samuel Blau, Brandon Wood, Shyam Dwaraknath, Ryan Kingsbury"
 __copyright__ = "Copyright 2018, The Materials Project"
 __version__ = "0.1"
 __maintainer__ = "Samuel Blau"
@@ -177,6 +177,10 @@ class QChemErrorHandler(ErrorHandler):
                 actions.append({"symmetry": False})
             else:
                 print("Perhaps increase the threshold?")
+
+        elif "basis_not_supported" in self.errors:
+            print("Specify a different basis set. At least one of the atoms is not supported.")
+            return {"errors": self.errors, "actions": None}
 
         elif "input_file_error" in self.errors:
             print("Something is wrong with the input file. Examine error message by hand.")

--- a/custodian/qchem/tests/test_handlers.py
+++ b/custodian/qchem/tests/test_handlers.py
@@ -233,7 +233,7 @@ class QChemErrorHandlerTest(TestCase):
         d = h.correct()
         self.assertEqual(d["errors"], ["basis_not_supported"])
         self.assertEqual(d["actions"], None)
-    
+
     def test_NLebdevPts(self):
         shutil.copyfile(
             os.path.join(test_dir, "lebdevpts.qin"),

--- a/custodian/qchem/tests/test_handlers.py
+++ b/custodian/qchem/tests/test_handlers.py
@@ -10,7 +10,7 @@ import unittest
 from custodian.qchem.handlers import QChemErrorHandler
 from pymatgen.io.qchem.inputs import QCInput
 
-__author__ = "Samuel Blau, Brandon Woods, Shyam Dwaraknath"
+__author__ = "Samuel Blau, Brandon Woods, Shyam Dwaraknath, Ryan Kingsbury"
 __copyright__ = "Copyright 2018, The Materials Project"
 __version__ = "0.1"
 __maintainer__ = "Samuel Blau"
@@ -217,6 +217,21 @@ class QChemErrorHandlerTest(TestCase):
         h.check()
         d = h.correct()
         self.assertEqual(d["errors"], ["input_file_error"])
+        self.assertEqual(d["actions"], None)
+
+    def test_basis_not_supported(self):
+        shutil.copyfile(
+            os.path.join(test_dir, "basis_not_supported.qin"),
+            os.path.join(scr_dir, "basis_not_supported.qin"),
+        )
+        shutil.copyfile(
+            os.path.join(test_dir, "basis_not_supported.qout"),
+            os.path.join(scr_dir, "basis_not_supported.qout"),
+        )
+        h = QChemErrorHandler(input_file="basis_not_supported.qin", output_file="basis_not_supported.qout")
+        h.check()
+        d = h.correct()
+        self.assertEqual(d["errors"], ["basis_not_supported"])
         self.assertEqual(d["actions"], None)
 
     def test_read_error(self):

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
-pymatgen==2022.0.4
+pymatgen==2022.0.9
 coverage==5.5
 coveralls==3.0.1
 pytest==6.2.2

--- a/test_files/qchem/new_test_files/basis_not_supported.qin
+++ b/test_files/qchem/new_test_files/basis_not_supported.qin
@@ -1,0 +1,37 @@
+$molecule
+ 3 2
+ Dy      0.0000000000      0.0000000000      0.0000000000
+$end
+
+$rem
+   job_type = sp
+   basis = def2-tzvpd
+   max_scf_cycles = 200
+   gen_scfman = true
+   xc_grid = 3
+   scf_algorithm = diis
+   resp_charges = false
+   symmetry = false
+   sym_ignore = true
+   method = wb97xv
+   solvent_method = pcm
+   thresh = 14
+$end
+
+$pcm
+   heavypoints 590
+   hpoints 590
+   radii read
+   theory cpcm
+   vdwscale 1
+   sasradius 1.38
+$end
+
+$solvent
+   dielectric 78.4
+$end
+
+$van_der_waals
+1
+   66 0.91
+$end

--- a/test_files/qchem/new_test_files/basis_not_supported.qout
+++ b/test_files/qchem/new_test_files/basis_not_supported.qout
@@ -1,0 +1,159 @@
+
+Running Job 1 of 1 mol.qin
+qchem mol.qin_84268.0 /tmp/scratch/ 0
+/clusterfs/mp/software/qchem/exe/qcprog.exe_s mol.qin_84268.0 /tmp/scratch/
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 5.2, Q-Chem, Inc., Pleasanton, CA (2019)
+
+ Yihan Shao,  Zhengting Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  Jia Deng,  Xintian Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  T. Kus,  A. Landau,  
+ Jie Liu,  E. I. Proynov,  R. M. Richard,  R. P. Steele,  E. J. Sundstrom,  
+ H. L. Woodcock III,  P. M. Zimmerman,  D. Zuev,  B. Alam,  B. Albrecht,  
+ E. Alguire,  S. A. Baeppler,  D. Barton,  Z. Benda,  Y. A. Bernard,  
+ E. J. Berquist,  K. B. Bravaya,  H. Burton,  K. Carter-Fenk,  D. Casanova,  
+ Chun-Min Chang,  Yunqing Chen,  A. Chien,  K. D. Closser,  M. P. Coons,  
+ S. Coriani,  S. Dasgupta,  A. L. Dempwolff,  M. Diedenhofen,  Hainam Do,  
+ R. G. Edgar,  Po-Tung Fang,  S. Faraji,  S. Fatehi,  Qingguo Feng,  
+ J. Fosso-Tande,  J. Gayvert,  Qinghui Ge,  A. Ghysels,  G. Gidofalvi,  
+ J. Gomes,  J. Gonthier,  A. Gunina,  D. Hait,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  M. F. Herbst,  J. E. Herr,  
+ E. G. Hohenstein,  Z. C. Holden,  Kerwin Hui,  B. C. Huynh,  T.-C. Jagau,  
+ Hyunjun Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  P. Klunzinger,  K. Koh,  
+ D. Kosenkov,  L. Koulias,  T. Kowalczyk,  C. M. Krauter,  A. Kunitsa,  
+ Ka Un Lao,  A. Laurent,  K. V. Lawler,  Joonho Lee,  D. Lefrancois,  
+ S. Lehtola,  D. S. Levine,  Yi-Pei Li,  You-Sheng Lin,  Fenglai Liu,  
+ Kuan-Yu Liu,  E. Livshits,  M. Loipersberger,  A. Luenser,  P. Manohar,  
+ E. Mansoor,  S. F. Manzer,  Shan-Ping Mao,  Yuezhi Mao,  N. Mardirossian,  
+ A. V. Marenich,  T. Markovich,  L. A. Martinez-Martinez,  S. A. Maurer,  
+ N. J. Mayhall,  S. C. McKenzie,  J.-M. Mewes,  P. Morgante,  A. F. Morrison,  
+ J. W. Mullinax,  K. Nanda,  T. S. Nguyen-Beck,  R. Olivares-Amaya,  
+ J. A. Parkhill,  S. K. Paul,  Zheng Pei,  T. M. Perrine,  F. Plasser,  
+ P. Pokhilko,  S. Prager,  A. Prociuk,  E. Ramos,  B. Rana,  D. R. Rehn,  
+ F. Rob,  M. Scheurer,  M. Schneider,  N. Sergueev,  S. M. Sharada,  
+ S. Sharma,  D. W. Small,  T. Stauch,  C. J. Stein,  T. Stein,  Yu-Chuan Su,  
+ S. P. Veccham,  A. J. W. Thom,  A. Tkatchenko,  T. Tsuchimochi,  
+ N. M. Tubman,  L. Vogt,  M. L. Vidal,  O. Vydrov,  M. A. Watson,  J. Wenzel,  
+ M. de Wergifosse,  T. A. Wesolowski,  A. White,  J. Witte,  A. Yamada,  
+ Jun Yang,  K. Yao,  S. Yeganeh,  S. R. Yost,  Zhi-Qiang You,  A. Zech,  
+ Igor Ying Zhang,  Xing Zhang,  Yan Zhao,  Ying Zhu,  B. R. Brooks,  
+ G. K. L. Chan,  C. J. Cramer,  M. S. Gordon,  W. J. Hehre,  A. Klamt,  
+ M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  A. Aspuru-Guzik,  R. Baer,  
+ A. T. Bell,  N. A. Besley,  Jeng-Da Chai,  A. E. DePrince, III,  
+ R. A. DiStasio Jr.,  A. Dreuw,  B. D. Dunietz,  T. R. Furlani,  
+ Chao-Ping Hsu,  Yousung Jung,  Jing Kong,  D. S. Lambrecht,  WanZhen Liang,  
+ C. Ochsenfeld,  V. A. Rassolov,  L. V. Slipchenko,  J. E. Subotnik,  
+ T. Van Voorhis,  J. M. Herbert,  A. I. Krylov,  P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  B. Austin,  J. Baker,  G. J. O. Beran,  K. Brandhorst,  
+ S. T. Brown,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ Siu Hung Chien,  D. M. Chipman,  D. L. Crittenden,  H. Dachsel,  
+ R. J. Doerksen,  A. D. Dutoi,  L. Fusti-Molnar,  W. A. Goddard III,  
+ A. Golubeva-Zadorozhnaya,  S. R. Gwaltney,  G. Hawkins,  A. Heyden,  
+ S. Hirata,  G. Kedziora,  F. J. Keil,  C. Kelley,  Jihan Kim,  R. A. King,  
+ R. Z. Khaliullin,  P. P. Korambath,  W. Kurlancheek,  A. M. Lee,  M. S. Lee,  
+ S. V. Levchenko,  Ching Yeh Lin,  D. Liotard,  R. C. Lochan,  I. Lotan,  
+ P. E. Maslen,  N. Nair,  D. P. O'Neill,  D. Neuhauser,  E. Neuscamman,  
+ C. M. Oana,  R. Olson,  B. Peters,  R. Peverati,  P. A. Pieniazek,  
+ Y. M. Rhee,  J. Ritchie,  M. A. Rohrdanz,  E. Rosta,  N. J. Russ,  
+ H. F. Schaefer III,  N. E. Schultz,  N. Shenvi,  A. C. Simmonett,  A. Sodt,  
+ D. Stuck,  K. S. Thanthiriwatte,  V. Vanovschi,  Tao Wang,  A. Warshel,  
+ C. F. Williams,  Q. Wu,  X. Xu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2015)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 5.2.2 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 8.300.2 (Tropical Shenanigans).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Fri May  7 12:32:04 2021  
+
+Host: 
+0
+
+     Scratch files written to /tmp/scratch//
+ Nov2519 |scratch|qcdevops|jenkins|workspace|build_RNUM 7600   
+Processing $rem in /clusterfs/mp/software/qchem/config/preferences:
+	 MEM_TOTAL  96000 
+NAlpha2: 64
+NElect   63
+Mult     2
+Symmetry turned off for PCM/SM12/SMD calculation
+
+Checking the input file for inconsistencies... 	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+$molecule
+3 2
+Dy      0.0000000000      0.0000000000      0.0000000000
+$end
+
+$rem
+job_type = sp
+basis = def2-tzvpd
+max_scf_cycles = 200
+gen_scfman = true
+xc_grid = 3
+scf_algorithm = diis
+resp_charges = false
+symmetry = false
+sym_ignore = true
+method = wb97xv
+solvent_method = pcm
+thresh = 14
+$end
+
+$pcm
+heavypoints 590
+hpoints 590
+radii read
+theory cpcm
+vdwscale 1
+sasradius 1.38
+$end
+
+$solvent
+dielectric 78.4
+$end
+
+$van_der_waals
+1
+66 0.91
+$end
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      Dy      0.0000000000     0.0000000000     0.0000000000
+ ----------------------------------------------------------------
+ Nuclear Repulsion Energy =           0.00000000 hartrees
+ There are       32 alpha and       31 beta electrons
+ Requested basis set is def2-TZVPD
+
+ Unexpected End of File for file 
+
+  /clusterfs/mp/software/qchem/qcaux/basis/def2-TZVPD.bas
+
+ was found while looking for Atomic Symbol Dy.
+
+ Check to see if this file has a basis for that atomic symbol.
+ The input format searched for here should be:
+ <atomic symbol> <0>
+ Q-Chem fatal error occurred in module forms1/AtomicBasis.C, line 1001:
+
+ Basis not supported for the above atom.
+
+
+ Please submit a crash report at q-chem.com/reporter 
+ 
+ 


### PR DESCRIPTION
Adds handler for basis set not supported error to QChem. This error cannot be automatically corrected, so it is handled similarly to the existing `input_file_error`. No corrective action is taken.

See pymatgen #[2147](https://github.com/materialsproject/pymatgen/pull/2147). There should be no harm merging this PR before or after the pymatgen PR, but the test will not pass and obviously this PR will have no effect until #2147 is merged and the requirements.txt for custodian bumped to pick up the change.