### PR TITLE
[VASP] Don't check for drift if NSW = 1

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -698,7 +698,7 @@ class DriftErrorHandler(ErrorHandler):
         Check for error.
         """
         incar = Incar.from_file("INCAR")
-        if incar.get("EDIFFG", 0.1) >= 0 or incar.get("NSW", 0) == 0:
+        if incar.get("EDIFFG", 0.1) >= 0 or incar.get("NSW", 0) <= 1:
             # Only activate when force relaxing and ionic steps
             # NSW check prevents accidental effects when running DFPT
             return False


### PR DESCRIPTION
The `DriftErrorHandler` currently checks to see if `NSW=0`; if it is, then it doesn't do the drift check. The code comment says "NSW check prevents accidental effects when running DFPT". However, when doing DFPT the value of `NSW` is set to 1 rather than 0, in which case the `DriftErrorHandler` may still run. As such, I've changed the handler to skip the drift error check if check `NSW <= 1`.

This suggestion was made by @utf (let me know if you had something else in mind).