### PR TITLE
Better handling of VASP algo_tet error

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -434,7 +434,8 @@ class VaspErrorHandler(ErrorHandler):
                 if vi["INCAR"].get("NEDOS") or vi["INCAR"].get("EMIN") or vi["INCAR"].get("EMAX"):
                     warnings.warn(
                         "This looks like a DOS run. You may want to follow-up this job with ALGO = Damped"
-                        " and ISMEAR = -5, using the wavefunction from the current job."
+                        " and ISMEAR = -5, using the wavefunction from the current job.",
+                        UserWarning,
                     )
                 actions.append({"dict": "INCAR", "action": {"_set": {"ISMEAR": 0, "SIGMA": 0.05}}})
 
@@ -456,7 +457,8 @@ class VaspErrorHandler(ErrorHandler):
             if "algo_tet" not in self.errors:
                 warnings.warn(
                     "EDWAV error reported by VASP. You may wish to consider recompiling VASP with"
-                    " the -O1 optimization if you used -O2"
+                    " the -O1 optimization if you used -O2",
+                    UserWarning,
                 )
 
         if "zheev" in self.errors:

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -431,13 +431,13 @@ class VaspErrorHandler(ErrorHandler):
             # DOS then they should consider running a subsequent job with ISMEAR = -5 and
             # ALGO = Damped, provided the wavefunction has been stored.
             if vi["INCAR"].get("ISMEAR", 1) < 0:
+                actions.append({"dict": "INCAR", "action": {"_set": {"ISMEAR": 0, "SIGMA": 0.05}}})
                 if vi["INCAR"].get("NEDOS") or vi["INCAR"].get("EMIN") or vi["INCAR"].get("EMAX"):
                     warnings.warn(
                         "This looks like a DOS run. You may want to follow-up this job with ALGO = Damped"
                         " and ISMEAR = -5, using the wavefunction from the current job.",
                         UserWarning,
                     )
-                actions.append({"dict": "INCAR", "action": {"_set": {"ISMEAR": 0, "SIGMA": 0.05}}})
 
         if "grad_not_orth" in self.errors:
             # This error is sometimes due to how VASP is compiled. Depending on the optimization flag and

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -423,17 +423,20 @@ class VaspErrorHandler(ErrorHandler):
             actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "All"}}})
 
         if "algo_tet" in self.errors:
-            # ALGO=All and IALGO=5X often fail with ISMEAR = -4/-5.
-            # ISMEAR should be changed to >= 0, except for DOS calculations
-            # in which case ALGO=Damped should be used after preconverging with ISMEAR >=0
+            # ALGO=All and IALGO=5X often fail with ISMEAR = -4/-5. There are two options here
+            # for the user: 1) Use ISMEAR = 0 (and a small sigma) to get the SCF to converge.
+            # 2) Use ALGO = Damped but only *after* an ISMEAR = 0 run where the wavefunction
+            # has been stored and read in for the subsequent run.
+            # For simplicity, we go with Option 1 here, but if the user wants high-quality
+            # DOS then they should consider running a subsequent job with ISMEAR = -5 and
+            # ALGO = Damped, provided the wavefunction has been stored.
             if vi["INCAR"].get("ISMEAR", 1) < 0:
                 if vi["INCAR"].get("NEDOS") or vi["INCAR"].get("EMIN") or vi["INCAR"].get("EMAX"):
                     warnings.warn(
-                        "This looks like a DOS run. Pre-converge with ISMEAR >= 0 and then use ALGO = Damped."
-                        "ALGO = All and IALGO = 5X often fail for ISMEAR < 0 otherwise."
+                        "This looks like a DOS run. You may want to follow-up this job with ALGO = Damped"
+                        " and ISMEAR = -5, using the wavefunction from the current job."
                     )
-                else:
-                    actions.append({"dict": "INCAR", "action": {"_set": {"ISMEAR": 0, "SIGMA": 0.05}}})
+                actions.append({"dict": "INCAR", "action": {"_set": {"ISMEAR": 0, "SIGMA": 0.05}}})
 
         if "grad_not_orth" in self.errors:
             # This error is due to how VASP is compiled. Depending on the optimization flag and

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -300,6 +300,7 @@ class VaspErrorHandlerTest(unittest.TestCase):
         self.assertIn("algo_tet", h.correct()["errors"])
         i = Incar.from_file("INCAR")
         self.assertEqual(i["ISMEAR"], 0)
+        self.assertEqual(i["SIGMA"], 0.05)
 
     def test_gradient_not_orthogonal(self):
         h = VaspErrorHandler("vasp.gradient_not_orthogonal")


### PR DESCRIPTION
Closes #195.

## Issue
When ISMEAR = -5 and ALGO = All, the `algo_tet` error generally occurs since these settings are incompatible. During a DOS calculation with this error, the handler currently does nothing. I had set this up intentionally, but after running a lot of calculations, I've noticed that it can lead to an undesirable number of jobs failing if SCF convergence is challenging and ALGO gets moved from Fast --> Normal --> All frequently.

## Solution
This PR changes ISMEAR to 0 and SIGMA to 0.05, which was the default behavior a few versions back when this error was instead handled under the `grad_not_orth` handler (`grad_not_orth` can occur without `algo_tet` when there are compilation flag issues, and in that case changing ISMEAR does not fix the issue, which is why I split them up in #180).

--------
A better solution for `algo_tet` DOS runs would be to: 1) Set ISMEAR = 0, SIGMA = 0.05, and LWAVE = True and run VASP; 2) From the prior run (if successful), set ISMEAR back to -5, set SIGMA back to the old value, and set ALGO = Damped [this is one of the options recommended in the VASP error message]. However, this two-step process is substantially more difficult to implement in Custodian. The user can always rerun their DOS calculations if desired on their own.