### PR TITLE
VASP: Address ZHEGV error when too many CPUs are requested for a small system

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -6,6 +6,7 @@ by modifying the input files.
 
 import datetime
 import logging
+import multiprocessing
 import operator
 import os
 import re
@@ -457,7 +458,32 @@ class VaspErrorHandler(ErrorHandler):
         if "edddav" in self.errors:
             if vi["INCAR"].get("ICHARG", 0) < 10:
                 actions.append({"file": "CHGCAR", "action": {"_file_delete": {"mode": "actual"}}})
-            actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "All"}}})
+
+            # This sometimes comes up with ALGO = Fast. We will switch the ALGO.
+            if vi["INCAR"].get("ALGO", "Normal").lower() != "all":
+                actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "All"}}})
+
+            # This can sometimes be due to load-balancing issues for small systems.
+            # See bottom of https://www.vasp.at/wiki/index.php/NCORE. A.S.R. ran some
+            # tests and found: 1) Changing LPLANE and NSIM does not help. 2) The suggestion
+            # of NCORE = # cores is not robust for KNL (too high). 3) Setting NPAR = sqrt(# cores)
+            # does not always resolve the issue. The best solution, aside from requesting fewer
+            # resources, seems to be to just increase NCORE slightly. That's what I do here.
+            nprocs = multiprocessing.cpu_count()
+            with open("OUTCAR", "r") as f:
+                for line in f:
+                    if "NELECT" in line:
+                        try:
+                            nelect = float(line.split("=")[-1].split("total")[0].strip())
+                            break
+                        except (IndexError, ValueError):
+                            nelect = 1  # dummy value
+            if (
+                nelect < nprocs
+                and vi["INCAR"].get("NCORE", 1) < nprocs
+                and vi["INCAR"].get("NPAR", 1) < np.sqrt(nprocs)
+            ):
+                actions.append({"dict": "INCAR", "action": {"_set": {"NCORE": vi["INCAR"].get("NCORE", 1) * 2}}})
 
         if "algo_tet" in self.errors:
             # ALGO=All/Damped / IALGO=5X often fails with ISMEAR < 0. There are two options VASP

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -472,7 +472,7 @@ class VaspErrorHandler(ErrorHandler):
             nprocs = multiprocessing.cpu_count()
             try:
                 nelect = Outcar("OUTCAR").nelect
-            except:
+            except Exception:
                 nelect = 1  # dummy value
             if nelect < nprocs:
                 actions.append({"dict": "INCAR", "action": {"_set": {"NCORE": vi["INCAR"].get("NCORE", 1) * 2}}})

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -470,14 +470,10 @@ class VaspErrorHandler(ErrorHandler):
             # does not always resolve the issue. The best solution, aside from requesting fewer
             # resources, seems to be to just increase NCORE slightly. That's what I do here.
             nprocs = multiprocessing.cpu_count()
-            with open("OUTCAR", "r") as f:
-                for line in f:
-                    if "NELECT" in line:
-                        try:
-                            nelect = float(line.split("=")[-1].split("total")[0].strip())
-                            break
-                        except (IndexError, ValueError):
-                            nelect = 1  # dummy value
+            try:
+                nelect = Outcar("OUTCAR").nelect
+            except:
+                nelect = 1  # dummy value
             if (
                 nelect < nprocs
                 and vi["INCAR"].get("NCORE", 1) < nprocs

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -474,11 +474,7 @@ class VaspErrorHandler(ErrorHandler):
                 nelect = Outcar("OUTCAR").nelect
             except:
                 nelect = 1  # dummy value
-            if (
-                nelect < nprocs
-                and vi["INCAR"].get("NCORE", 1) < nprocs
-                and vi["INCAR"].get("NPAR", 1) < np.sqrt(nprocs)
-            ):
+            if nelect < nprocs:
                 actions.append({"dict": "INCAR", "action": {"_set": {"NCORE": vi["INCAR"].get("NCORE", 1) * 2}}})
 
         if "algo_tet" in self.errors:

--- a/custodian/vasp/tests/conftest.py
+++ b/custodian/vasp/tests/conftest.py
@@ -1,3 +1,6 @@
+"""
+This module mocks functions needed for pytest.
+"""
 import multiprocessing
 import pytest
 

--- a/custodian/vasp/tests/conftest.py
+++ b/custodian/vasp/tests/conftest.py
@@ -1,0 +1,14 @@
+import multiprocessing
+import pytest
+
+
+def mock_cpu_count(self, **kwargs):
+    # Instead of running multiprocessing.cpu_count(), we return a fixed
+    # value during tests
+    return 64
+
+
+@pytest.fixture(autouse=True)
+def patch_get_potential_energy(monkeypatch):
+    # Monkeypatch the multiprocessing.cpu_count() function
+    monkeypatch.setattr(multiprocessing, "cpu_count", mock_cpu_count)

--- a/custodian/vasp/tests/conftest.py
+++ b/custodian/vasp/tests/conftest.py
@@ -6,12 +6,17 @@ import pytest
 
 
 def mock_cpu_count(*args, **kwargs):
-    # Instead of running multiprocessing.cpu_count(), we return a fixed
-    # value during tests
+    """
+    Instead of running multiprocessing.cpu_count(), we return a fixed
+    value during tests
+    """
+
     return 64
 
 
 @pytest.fixture(autouse=True)
 def patch_get_potential_energy(monkeypatch):
-    # Monkeypatch the multiprocessing.cpu_count() function
+    """
+    Monkeypatch the multiprocessing.cpu_count() function
+    """
     monkeypatch.setattr(multiprocessing, "cpu_count", mock_cpu_count)

--- a/custodian/vasp/tests/conftest.py
+++ b/custodian/vasp/tests/conftest.py
@@ -5,7 +5,7 @@ import multiprocessing
 import pytest
 
 
-def mock_cpu_count(self, **kwargs):
+def mock_cpu_count(*args, **kwargs):
     # Instead of running multiprocessing.cpu_count(), we return a fixed
     # value during tests
     return 64

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -290,16 +290,16 @@ class VaspErrorHandlerTest(unittest.TestCase):
         self.assertEqual(i["LREAL"], False)
 
     def test_edddav(self):
-        h = VaspErrorHandler("vasp.edddav")
-        self.assertEqual(h.check(), True)
-        self.assertEqual(h.correct()["errors"], ["edddav"])
-        self.assertFalse(os.path.exists("CHGCAR"))
-
         h = VaspErrorHandler("vasp.edddav2")
         self.assertEqual(h.check(), True)
         self.assertEqual(h.correct()["errors"], ["edddav"])
         i = Incar.from_file("INCAR")
         self.assertEqual(i["NCORE"], 2)
+
+        h = VaspErrorHandler("vasp.edddav")
+        self.assertEqual(h.check(), True)
+        self.assertEqual(h.correct()["errors"], ["edddav"])
+        self.assertFalse(os.path.exists("CHGCAR"))
 
     def test_algo_tet(self):
         h = VaspErrorHandler("vasp.algo_tet")

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -295,6 +295,12 @@ class VaspErrorHandlerTest(unittest.TestCase):
         self.assertEqual(h.correct()["errors"], ["edddav"])
         self.assertFalse(os.path.exists("CHGCAR"))
 
+        h = VaspErrorHandler("vasp.edddav2")
+        self.assertEqual(h.check(), True)
+        self.assertEqual(h.correct()["errors"], ["edddav"])
+        i = Incar.from_file("INCAR")
+        self.assertEqual(i["NCORE"], 2)
+
     def test_algo_tet(self):
         h = VaspErrorHandler("vasp.algo_tet")
         self.assertEqual(h.check(), True)
@@ -855,7 +861,7 @@ class ZpotrfErrorHandlerTest(unittest.TestCase):
         d = h.correct()
         self.assertEqual(d["errors"], ["zpotrf"])
         s2 = Structure.from_file("POSCAR")
-        self.assertAlmostEqual(s2.volume, s1.volume * 1.2 ** 3, 3)
+        self.assertAlmostEqual(s2.volume, s1.volume * 1.2**3, 3)
 
     def test_potim_correction(self):
         shutil.copy("OSZICAR.one_step", "OSZICAR")

--- a/test_files/vasp.edddav2
+++ b/test_files/vasp.edddav2
@@ -1,0 +1,680 @@
+ vasp.6.3.0 20Jan22 (build Feb 22 2022 12:35:36) complex                        
+  
+ executed on      IFC19_CrayMPICH date 2022.04.16  14:48:53
+ running   64 mpi-ranks, with    1 threads/rank
+ distrk:  each k-point on   64 cores,    1 groups
+ distr:  one band on NCORE=   1 cores,   64 groups
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ INCAR:
+   ALGO = Fast
+   EDIFF = 0.0001
+   GGA = Pe
+   ISMEAR = 0
+   ISYM = 0
+   IVDW = 12
+   LASPH = False
+   LCHARG = False
+   LMAXMIX = 4
+   LORBIT = 11
+   LREAL = False
+   LWAVE = True
+   NELM = 225
+   NELMIN = 3
+   NSW = 0
+   PREC = Accurate
+   SIGMA = 0.01
+   SYMPREC = 1e-08
+
+ POTCAR:    PAW_PBE Zr_sv 04Jan2005               
+ POTCAR:    PAW_PBE Zr_sv 04Jan2005               
+   VRHFIN =Zr: 4s4p5s4d                                                                             
+   LEXCH  = PE                                                                                      
+   EATOM  =  1284.2219 eV,   94.3876 Ry                                                             
+                                                                                                    
+   TITEL  = PAW_PBE Zr_sv 04Jan2005                                                                 
+   LULTRA =        F    use ultrasoft PP ?                                                          
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                                               
+   RPACOR =    2.200    partial core radius                                                         
+   POMASS =   91.224; ZVAL   =   12.000    mass and valenz                                          
+   RCORE  =    2.500    outmost cutoff radius                                                       
+   RWIGS  =    3.070; RWIGS  =    1.625    wigner-seitz radius (au A)                               
+   ENMAX  =  229.898; ENMIN  =  172.424 eV                                                          
+   ICORE  =        3    local potential                                                             
+   LCOR   =        T    correct aug charges                                                         
+   LPAW   =        T    paw PP                                                                      
+   EAUG   =  461.257                                                                                
+   DEXC   =    0.000                                                                                
+   RMAX   =    2.561    core radius for proj-oper                                                   
+   RAUG   =    1.300    factor for augmentation sphere                                              
+   RDEP   =    2.597    radius for radial grids                                                     
+   RDEPT  =    2.007    core radius for aug-charge                                                  
+                                                                                                    
+   Atomic configuration                                                                             
+   11 entries                                                                                       
+     n  l   j            E        occ.                                                              
+     1  0  0.50    -17820.0161   2.0000                                                             
+     2  0  0.50     -2467.0882   2.0000                                                             
+     2  1  1.50     -2199.6095   6.0000                                                             
+     3  0  0.50      -402.4863   2.0000                                                             
+     3  1  1.50      -315.3675   6.0000                                                             
+     3  2  2.50      -172.4472  10.0000                                                             
+     4  0  0.50       -52.4146   2.0000                                                             
+     5  0  0.50        -3.8421   1.0000                                                             
+     4  1  1.50       -30.5054   6.0000                                                             
+     4  2  2.50        -2.3341   3.0000                                                             
+     4  3  2.50        -1.3606   0.0000                                                             
+   Description                                                                                      
+     l       E           TYP  RCUT    TYP  RCUT                                                     
+     0    -52.4145962     23  2.200                                                                 
+     0     -3.8421270     23  2.500                                                                 
+     1    -30.5053914     23  2.200                                                                 
+     1     20.4087390     23  2.200                                                                 
+     2     -2.3340816     23  2.500                                                                 
+     2     -0.6120942     23  2.500                                                                 
+     3     -4.0817478     23  2.500                                                                 
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+  PAW_PBE Zr_sv 04Jan2005               :
+ energy of atom  1       EATOM=-1284.2219
+ kinetic energy error for atom=    0.0771 (will be added to EATOM!!)
+ 
+ 
+ POSCAR: Zr
+  positions in cartesian coordinates
+  No initial velocities read in
+ exchange correlation table for  LEXCH =        8
+   RHO(1)=    0.500       N(1)  =     2000
+   RHO(2)=  100.500       N(2)  =     4000
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ ion  position               nearest neighbor table
+   1  0.000  0.000  0.000-
+ 
+
+IMPORTANT INFORMATION: All symmetrisations will be switched off!
+NOSYMM: (Re-)initialisation of all symmetry stuff for point group C_1.
+
+
+----------------------------------------------------------------------------------------
+
+                                     Primitive cell                                     
+
+  volume of cell :      23.3447
+
+  direct lattice vectors                    reciprocal lattice vectors
+     0.000000000  2.268399000  2.268399000    -0.220419776  0.220419776  0.220419776
+     2.268399000  0.000000000  2.268399000     0.220419776 -0.220419776  0.220419776
+     2.268399000  2.268399000  0.000000000     0.220419776  0.220419776 -0.220419776
+
+  length of vectors
+     3.208000631  3.208000631  3.208000631     0.381778251  0.381778251  0.381778251
+
+  position of ions in fractional coordinates (direct lattice)
+     0.000000000  0.000000000  0.000000000
+
+  ion indices of the primitive-cell ions
+   primitive index   ion index
+                 1           1
+
+----------------------------------------------------------------------------------------
+
+ 
+ 
+ KPOINTS: KPOINTS created by Atomic Simulation Env
+
+Automatic generation of k-mesh.
+ Grid dimensions read from file:
+ generate k-points for:    4    4    4
+
+ Generating k-lattice:
+
+  Cartesian coordinates                     Fractional coordinates (reciprocal lattice)
+    -0.055104944  0.055104944  0.055104944     0.250000000 -0.000000000  0.000000000
+     0.055104944 -0.055104944  0.055104944    -0.000000000  0.250000000 -0.000000000
+     0.055104944  0.055104944 -0.055104944     0.000000000  0.000000000  0.250000000
+
+  Length of vectors
+     0.095444563  0.095444563  0.095444563
+
+  Shift w.r.t. Gamma in fractional coordinates (k-lattice)
+     0.000000000  0.000000000  0.000000000
+
+ 
+ Subroutine IBZKPT returns following result:
+ ===========================================
+ 
+ Found     36 irreducible k-points:
+ 
+ Following reciprocal coordinates:
+            Coordinates               Weight
+  0.000000  0.000000  0.000000      1.000000
+  0.250000  0.000000 -0.000000      2.000000
+ -0.000000  0.250000 -0.000000      2.000000
+  0.000000  0.000000  0.250000      2.000000
+  0.250000  0.250000  0.250000      2.000000
+  0.500000  0.000000 -0.000000      1.000000
+ -0.000000  0.500000 -0.000000      1.000000
+  0.000000  0.000000  0.500000      1.000000
+  0.500000  0.500000  0.500000      1.000000
+  0.250000  0.250000  0.000000      2.000000
+  0.000000  0.250000  0.250000      2.000000
+  0.250000  0.000000  0.250000      2.000000
+  0.500000  0.250000 -0.000000      2.000000
+  0.000000  0.500000  0.250000      2.000000
+  0.250000  0.000000  0.500000      2.000000
+  0.250000  0.250000 -0.250000      2.000000
+  0.500000  0.250000  0.500000      2.000000
+  0.250000  0.500000 -0.000000      2.000000
+  0.250000 -0.250000 -0.250000      2.000000
+  0.500000  0.500000  0.250000      2.000000
+  0.000000  0.250000  0.500000      2.000000
+ -0.250000  0.250000 -0.250000      2.000000
+  0.250000  0.500000  0.500000      2.000000
+  0.500000  0.000000  0.250000      2.000000
+ -0.250000  0.250000 -0.000000      2.000000
+  0.000000 -0.250000  0.250000      2.000000
+  0.250000 -0.000000 -0.250000      2.000000
+  0.250000  0.250000  0.500000      2.000000
+ -0.250000  0.500000 -0.250000      2.000000
+  0.500000 -0.250000 -0.250000      2.000000
+  0.500000  0.500000  0.000000      1.000000
+  0.000000  0.500000  0.500000      1.000000
+  0.500000  0.000000  0.500000      1.000000
+ -0.250000  0.500000  0.250000      2.000000
+  0.250000 -0.250000  0.500000      2.000000
+  0.500000  0.250000 -0.250000      2.000000
+ 
+ Following cartesian coordinates:
+            Coordinates               Weight
+  0.000000  0.000000  0.000000      1.000000
+ -0.055105  0.055105  0.055105      2.000000
+  0.055105 -0.055105  0.055105      2.000000
+  0.055105  0.055105 -0.055105      2.000000
+  0.055105  0.055105  0.055105      2.000000
+ -0.110210  0.110210  0.110210      1.000000
+  0.110210 -0.110210  0.110210      1.000000
+  0.110210  0.110210 -0.110210      1.000000
+  0.110210  0.110210  0.110210      1.000000
+  0.000000  0.000000  0.110210      2.000000
+  0.110210  0.000000  0.000000      2.000000
+  0.000000  0.110210  0.000000      2.000000
+ -0.055105  0.055105  0.165315      2.000000
+  0.165315 -0.055105  0.055105      2.000000
+  0.055105  0.165315 -0.055105      2.000000
+ -0.055105 -0.055105  0.165315      2.000000
+  0.055105  0.165315  0.055105      2.000000
+  0.055105 -0.055105  0.165315      2.000000
+ -0.165315  0.055105  0.055105      2.000000
+  0.055105  0.055105  0.165315      2.000000
+  0.165315  0.055105 -0.055105      2.000000
+  0.055105 -0.165315  0.055105      2.000000
+  0.165315  0.055105  0.055105      2.000000
+ -0.055105  0.165315  0.055105      2.000000
+  0.110210 -0.110210  0.000000      2.000000
+  0.000000  0.110210 -0.110210      2.000000
+ -0.110210 -0.000000  0.110210      2.000000
+  0.110210  0.110210  0.000000      2.000000
+  0.110210 -0.220420  0.110210      2.000000
+ -0.220420  0.110210  0.110210      2.000000
+  0.000000  0.000000  0.220420      1.000000
+  0.220420  0.000000  0.000000      1.000000
+  0.000000  0.220420  0.000000      1.000000
+  0.220420 -0.110210  0.000000      2.000000
+  0.000000  0.220420 -0.110210      2.000000
+ -0.110210  0.000000  0.220420      2.000000
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+ Dimension of arrays:
+   k-points           NKPTS =     36   k-points in BZ     NKDIM =     36   number of bands    NBANDS=     64
+   number of dos      NEDOS =    301   number of ions     NIONS =      1
+   non local maximal  LDIM  =      6   non local SUM 2l+1 LMDIM =     18
+   total plane-waves  NPLWV =   4096
+   max r-space proj   IRMAX =      1   max aug-charges    IRDMAX=   7495
+   dimension x,y,z NGX =    16 NGY =   16 NGZ =   16
+   dimension x,y,z NGXF=    32 NGYF=   32 NGZF=   32
+   support grid    NGXF=    32 NGYF=   32 NGZF=   32
+   ions per type =               1
+   NGX,Y,Z   is equivalent  to a cutoff of   8.29,  8.29,  8.29 a.u.
+   NGXF,Y,Z  is equivalent  to a cutoff of  16.58, 16.58, 16.58 a.u.
+
+ SYSTEM =  unknown system                          
+ POSCAR =  Zr                                      
+
+ Startparameter for this run:
+   NWRITE =      2    write-flag & timer
+   PREC   = accura    normal or accurate (medium, high low for compatibility)
+   ISTART =      0    job   : 0-new  1-cont  2-samecut
+   ICHARG =      2    charge: 1-file 2-atom 10-const
+   ISPIN  =      1    spin polarized calculation?
+   LNONCOLLINEAR =      F non collinear calculations
+   LSORBIT =      F    spin-orbit coupling
+   INIWAV =      1    electr: 0-lowe 1-rand  2-diag
+   LASPH  =      F    aspherical Exc in radial PAW
+ Electronic Relaxation 1
+   ENCUT  =  229.9 eV  16.90 Ry    4.11 a.u.   3.97  3.97  3.97*2*pi/ulx,y,z
+   ENINI  =  229.9     initial cutoff
+   ENAUG  =  461.3 eV  augmentation charge cutoff
+   NELM   =    225;   NELMIN=  3; NELMDL= -5     # of ELM steps 
+   EDIFF  = 0.1E-03   stopping-criterion for ELM
+   LREAL  =      F    real-space projection
+   NLSPLINE    = F    spline interpolate recip. space projectors
+   LCOMPAT=      F    compatible to vasp.4.4
+   GGA_COMPAT  = T    GGA compatible to vasp.4.4-vasp.4.6
+   LMAXPAW     = -100 max onsite density
+   LMAXMIX     =    4 max onsite mixed and CHGCAR
+   VOSKOWN=      0    Vosko Wilk Nusair interpolation
+   ROPT   =    0.00000
+ Ionic relaxation
+   EDIFFG = 0.1E-02   stopping-criterion for IOM
+   NSW    =      0    number of steps for IOM
+   NBLOCK =      1;   KBLOCK =      1    inner block; outer block 
+   IBRION =     -1    ionic relax: 0-MD 1-quasi-New 2-CG
+   NFREE  =      0    steps in history (QN), initial steepest desc. (CG)
+   ISIF   =      2    stress and relaxation
+   IWAVPR =     10    prediction:  0-non 1-charg 2-wave 3-comb
+   ISYM   =      0    0-nonsym 1-usesym 2-fastsym
+   LCORR  =      T    Harris-Foulkes like correction to forces
+
+   POTIM  = 0.5000    time-step for ionic-motion
+   TEIN   =    0.0    initial temperature
+   TEBEG  =    0.0;   TEEND  =   0.0 temperature during run
+   SMASS  =  -3.00    Nose mass-parameter (am)
+   estimated Nose-frequenzy (Omega)   =  0.10E-29 period in steps = 0.13E+47 mass=  -0.235E-27a.u.
+   SCALEE = 1.0000    scale energy and forces
+   NPACO  =    256;   APACO  = 10.0  distance and # of slots for P.C.
+   PSTRESS=    0.0 pullay stress
+
+  Mass of Ions in am
+   POMASS =  91.22
+  Ionic Valenz
+   ZVAL   =  12.00
+  Atomic Wigner-Seitz radii
+   RWIGS  =  -1.00
+  virtual crystal weights 
+   VCA    =   1.00
+   NELECT =      12.0000    total number of electrons
+   NUPDOWN=      -1.0000    fix difference up-down
+
+ DOS related values:
+   EMIN   =  10.00;   EMAX   =-10.00  energy-range for DOS
+   EFERMI =   0.00
+   ISMEAR =     0;   SIGMA  =   0.01  broadening in eV -4-tet -1-fermi 0-gaus
+
+ Electronic relaxation 2 (details)
+   IALGO  =     68    algorithm
+   LDIAG  =      T    sub-space diagonalisation (order eigenvalues)
+   LSUBROT=      F    optimize rotation matrix (better conditioning)
+   TURBO    =      0    0=normal 1=particle mesh
+   IRESTART =      0    0=no restart 2=restart with 2 vectors
+   NREBOOT  =      0    no. of reboots
+   NMIN     =      0    reboot dimension
+   EREF     =   0.00    reference energy to select bands
+   IMIX   =      4    mixing-type and parameters
+     AMIX     =   0.40;   BMIX     =  1.00
+     AMIX_MAG =   1.60;   BMIX_MAG =  1.00
+     AMIN     =   0.10
+     WC   =   100.;   INIMIX=   1;  MIXPRE=   1;  MAXMIX= -45
+
+ Intra band minimization:
+   WEIMIN = 0.0000     energy-eigenvalue tresh-hold
+   EBREAK =  0.39E-06  absolut break condition
+   DEPER  =   0.30     relativ break condition  
+
+   TIME   =   0.40     timestep for ELM
+
+  volume/ion in A,a.u.               =      23.34       157.54
+  Fermi-wavevector in a.u.,A,eV,Ry     =   1.311412  2.478209 23.399317  1.719801
+  Thomas-Fermi vector in A             =   2.441875
+ 
+ Write flags
+   LWAVE        =      T    write WAVECAR
+   LDOWNSAMPLE  =      F    k-point downsampling of WAVECAR
+   LCHARG       =      F    write CHGCAR
+   LVTOT        =      F    write LOCPOT, total local potential
+   LVHAR        =      F    write LOCPOT, Hartree potential only
+   LELF         =      F    write electronic localiz. function (ELF)
+   LORBIT       =     11    0 simple, 1 ext, 2 COOP (PROOUT), +10 PAW based schemes
+
+
+ Dipole corrections
+   LMONO  =      F    monopole corrections only (constant potential shift)
+   LDIPOL =      F    correct potential (dipole corrections)
+   IDIPOL =      0    1-x, 2-y, 3-z, 4-all directions 
+   EPSILON=  1.0000000 bulk dielectric constant
+
+ Exchange correlation treatment:
+   GGA     =    PE    GGA type
+   LEXCH   =     8    internal setting for exchange type
+   LIBXC   =     F    Libxc                    
+   VOSKOWN =     0    Vosko Wilk Nusair interpolation
+   LHFCALC =     F    Hartree Fock is set to
+   LHFONE  =     F    Hartree Fock one center treatment
+   AEXX    =    0.0000 exact exchange contribution
+
+ Linear response parameters
+   LEPSILON=     F    determine dielectric tensor
+   LRPA    =     F    only Hartree local field effects (RPA)
+   LNABLA  =     F    use nabla operator in PAW spheres
+   LVEL    =     F    velocity operator in full k-point grid
+   CSHIFT  =0.1000    complex shift for real part using Kramers Kronig
+   OMEGAMAX=  -1.0    maximum frequency
+   DEG_THRESHOLD= 0.2000000E-02 threshold for treating states as degnerate
+   RTIME   =   -0.100 relaxation time in fs
+  (WPLASMAI=    0.000 imaginary part of plasma frequency in eV, 0.658/RTIME)
+   DFIELD  = 0.0000000 0.0000000 0.0000000 field for delta impulse in time
+ 
+  Optional k-point grid parameters
+   LKPOINTS_OPT  =     F    use optional k-point grid
+   KPOINTS_OPT_MODE=     1    mode for optional k-point grid
+ 
+ Orbital magnetization related:
+   ORBITALMAG=     F  switch on orbital magnetization
+   LCHIMAG   =     F  perturbation theory with respect to B field
+   DQ        =  0.001000  dq finite difference perturbation B field
+   LLRAUG    =     F  two centre corrections for induced B field
+
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ Static calculation
+ charge density and potential will be updated during run
+ non-spin polarized calculation
+ RMM-DIIS sequential band-by-band and
+  variant of blocked Davidson during initial phase
+ perform sub-space diagonalisation
+    before iterative eigenvector-optimisation
+ modified Broyden-mixing scheme, WC =      100.0
+ initial mixing is a Kerker type mixing with AMIX =  0.4000 and BMIX =      1.0000
+ Hartree-type preconditioning will be used
+ using additional bands           58
+ reciprocal scheme for non local part
+ use partial core corrections
+ calculate Harris-corrections to forces 
+   (improved forces if not selfconsistent)
+ use gradient corrections 
+ use of overlap-Matrix (Vanderbilt PP)
+ Gauss-broadening in eV      SIGMA  =   0.01
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+  energy-cutoff  :      229.90
+  volume of cell :       23.34
+      direct lattice vectors                 reciprocal lattice vectors
+     0.000000000  2.268399000  2.268399000    -0.220419776  0.220419776  0.220419776
+     2.268399000  0.000000000  2.268399000     0.220419776 -0.220419776  0.220419776
+     2.268399000  2.268399000  0.000000000     0.220419776  0.220419776 -0.220419776
+
+  length of vectors
+     3.208000631  3.208000631  3.208000631     0.381778251  0.381778251  0.381778251
+
+
+ 
+ k-points in units of 2pi/SCALE and weight: KPOINTS created by Atomic Simulation Env
+   0.00000000  0.00000000  0.00000000       0.016
+  -0.05510494  0.05510494  0.05510494       0.031
+   0.05510494 -0.05510494  0.05510494       0.031
+   0.05510494  0.05510494 -0.05510494       0.031
+   0.05510494  0.05510494  0.05510494       0.031
+  -0.11020989  0.11020989  0.11020989       0.016
+   0.11020989 -0.11020989  0.11020989       0.016
+   0.11020989  0.11020989 -0.11020989       0.016
+   0.11020989  0.11020989  0.11020989       0.016
+   0.00000000  0.00000000  0.11020989       0.031
+   0.11020989  0.00000000  0.00000000       0.031
+   0.00000000  0.11020989  0.00000000       0.031
+  -0.05510494  0.05510494  0.16531483       0.031
+   0.16531483 -0.05510494  0.05510494       0.031
+   0.05510494  0.16531483 -0.05510494       0.031
+  -0.05510494 -0.05510494  0.16531483       0.031
+   0.05510494  0.16531483  0.05510494       0.031
+   0.05510494 -0.05510494  0.16531483       0.031
+  -0.16531483  0.05510494  0.05510494       0.031
+   0.05510494  0.05510494  0.16531483       0.031
+   0.16531483  0.05510494 -0.05510494       0.031
+   0.05510494 -0.16531483  0.05510494       0.031
+   0.16531483  0.05510494  0.05510494       0.031
+  -0.05510494  0.16531483  0.05510494       0.031
+   0.11020989 -0.11020989  0.00000000       0.031
+   0.00000000  0.11020989 -0.11020989       0.031
+  -0.11020989  0.00000000  0.11020989       0.031
+   0.11020989  0.11020989  0.00000000       0.031
+   0.11020989 -0.22041978  0.11020989       0.031
+  -0.22041978  0.11020989  0.11020989       0.031
+   0.00000000  0.00000000  0.22041978       0.016
+   0.22041978  0.00000000  0.00000000       0.016
+   0.00000000  0.22041978  0.00000000       0.016
+   0.22041978 -0.11020989  0.00000000       0.031
+   0.00000000  0.22041978 -0.11020989       0.031
+  -0.11020989  0.00000000  0.22041978       0.031
+ 
+ k-points in reciprocal lattice and weights: KPOINTS created by Atomic Simulation Env
+   0.00000000  0.00000000  0.00000000       0.016
+   0.25000000  0.00000000 -0.00000000       0.031
+  -0.00000000  0.25000000 -0.00000000       0.031
+   0.00000000  0.00000000  0.25000000       0.031
+   0.25000000  0.25000000  0.25000000       0.031
+   0.50000000  0.00000000 -0.00000000       0.016
+  -0.00000000  0.50000000 -0.00000000       0.016
+   0.00000000  0.00000000  0.50000000       0.016
+   0.50000000  0.50000000  0.50000000       0.016
+   0.25000000  0.25000000  0.00000000       0.031
+   0.00000000  0.25000000  0.25000000       0.031
+   0.25000000  0.00000000  0.25000000       0.031
+   0.50000000  0.25000000 -0.00000000       0.031
+   0.00000000  0.50000000  0.25000000       0.031
+   0.25000000  0.00000000  0.50000000       0.031
+   0.25000000  0.25000000 -0.25000000       0.031
+   0.50000000  0.25000000  0.50000000       0.031
+   0.25000000  0.50000000 -0.00000000       0.031
+   0.25000000 -0.25000000 -0.25000000       0.031
+   0.50000000  0.50000000  0.25000000       0.031
+   0.00000000  0.25000000  0.50000000       0.031
+  -0.25000000  0.25000000 -0.25000000       0.031
+   0.25000000  0.50000000  0.50000000       0.031
+   0.50000000  0.00000000  0.25000000       0.031
+  -0.25000000  0.25000000 -0.00000000       0.031
+   0.00000000 -0.25000000  0.25000000       0.031
+   0.25000000 -0.00000000 -0.25000000       0.031
+   0.25000000  0.25000000  0.50000000       0.031
+  -0.25000000  0.50000000 -0.25000000       0.031
+   0.50000000 -0.25000000 -0.25000000       0.031
+   0.50000000  0.50000000  0.00000000       0.016
+   0.00000000  0.50000000  0.50000000       0.016
+   0.50000000  0.00000000  0.50000000       0.016
+  -0.25000000  0.50000000  0.25000000       0.031
+   0.25000000 -0.25000000  0.50000000       0.031
+   0.50000000  0.25000000 -0.25000000       0.031
+ 
+ position of ions in fractional coordinates (direct lattice) 
+   0.00000000  0.00000000  0.00000000
+ 
+ position of ions in cartesian coordinates  (Angst):
+   0.00000000  0.00000000  0.00000000
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ k-point   1 :   0.0000 0.0000 0.0000  plane waves:     169
+ k-point   2 :   0.2500 0.0000-0.0000  plane waves:     180
+ k-point   3 :  -0.0000 0.2500-0.0000  plane waves:     180
+ k-point   4 :   0.0000 0.0000 0.2500  plane waves:     180
+ k-point   5 :   0.2500 0.2500 0.2500  plane waves:     180
+ k-point   6 :   0.5000 0.0000-0.0000  plane waves:     180
+ k-point   7 :  -0.0000 0.5000-0.0000  plane waves:     180
+ k-point   8 :   0.0000 0.0000 0.5000  plane waves:     180
+ k-point   9 :   0.5000 0.5000 0.5000  plane waves:     180
+ k-point  10 :   0.2500 0.2500 0.0000  plane waves:     178
+ k-point  11 :   0.0000 0.2500 0.2500  plane waves:     178
+ k-point  12 :   0.2500 0.0000 0.2500  plane waves:     178
+ k-point  13 :   0.5000 0.2500-0.0000  plane waves:     186
+ k-point  14 :   0.0000 0.5000 0.2500  plane waves:     186
+ k-point  15 :   0.2500 0.0000 0.5000  plane waves:     186
+ k-point  16 :   0.2500 0.2500-0.2500  plane waves:     186
+ k-point  17 :   0.5000 0.2500 0.5000  plane waves:     186
+ k-point  18 :   0.2500 0.5000-0.0000  plane waves:     186
+ k-point  19 :   0.2500-0.2500-0.2500  plane waves:     186
+ k-point  20 :   0.5000 0.5000 0.2500  plane waves:     186
+ k-point  21 :   0.0000 0.2500 0.5000  plane waves:     186
+ k-point  22 :  -0.2500 0.2500-0.2500  plane waves:     186
+ k-point  23 :   0.2500 0.5000 0.5000  plane waves:     186
+ k-point  24 :   0.5000 0.0000 0.2500  plane waves:     186
+ k-point  25 :  -0.2500 0.2500-0.0000  plane waves:     180
+ k-point  26 :   0.0000-0.2500 0.2500  plane waves:     180
+ k-point  27 :   0.2500-0.0000-0.2500  plane waves:     180
+ k-point  28 :   0.2500 0.2500 0.5000  plane waves:     180
+ k-point  29 :  -0.2500 0.5000-0.2500  plane waves:     180
+ k-point  30 :   0.5000-0.2500-0.2500  plane waves:     180
+ k-point  31 :   0.5000 0.5000 0.0000  plane waves:     190
+ k-point  32 :   0.0000 0.5000 0.5000  plane waves:     190
+ k-point  33 :   0.5000 0.0000 0.5000  plane waves:     190
+ k-point  34 :  -0.2500 0.5000 0.2500  plane waves:     200
+ k-point  35 :   0.2500-0.2500 0.5000  plane waves:     200
+ k-point  36 :   0.5000 0.2500-0.2500  plane waves:     200
+
+ maximum and minimum number of plane-waves per node :       200      169
+
+ maximum number of plane-waves:       200
+ maximum index in each direction: 
+   IXMAX=    4   IYMAX=    4   IZMAX=    4
+   IXMIN=   -4   IYMIN=   -4   IZMIN=   -4
+
+
+ serial   3D FFT for wavefunctions
+ parallel 3D FFT for charge:
+    minimum data exchange during FFTs selected (reduces bandwidth)
+
+
+ total amount of memory used by VASP MPI-rank0    31810. kBytes
+=======================================================================
+
+   base      :      30000. kBytes
+   nonl-proj :       1331. kBytes
+   fftplans  :         61. kBytes
+   grid      :        219. kBytes
+   one-center:         15. kBytes
+   wavefun   :        184. kBytes
+ 
+     INWAV:  cpu time      0.0002: real time      0.0004
+ Broyden mixing: mesh for mixing (old mesh)
+   NGX =  7   NGY =  7   NGZ =  7
+  (NGX  = 32   NGY  = 32   NGZ  = 32)
+  gives a total of    343 points
+
+ initial charge density was supplied:
+ charge density of overlapping atoms calculated
+ number of electron      12.0000000 magnetization 
+ keeping initial charge density in first step
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ Maximum index for augmentation-charges          421 (set IRDMAX)
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ First call to EWALD:  gamma=   0.620
+ Maximum number of real-space cells 3x 3x 3
+ Maximum number of reciprocal cells 3x 3x 3
+
+    FEWALD:  cpu time      0.0056: real time      0.0063
+
+
+--------------------------------------- Iteration      1(   1)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0116: real time      0.0158
+    SETDIJ:  cpu time      0.0094: real time      0.0099
+     EDDAV:  cpu time      2.4538: real time      2.4740
+       DOS:  cpu time      0.0079: real time      0.0104
+    --------------------------------------------
+      LOOP:  cpu time      2.4829: real time      2.5106
+
+ eigenvalue-minimisations  :  4672
+ total energy-change (2. order) : 0.2950866E+00  (-0.5160117E+03)
+ number of electron      12.0000000 magnetization 
+ augmentation part       12.0000000 magnetization 
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =        56.91503758
+  Ewald energy   TEWEN  =     -1047.76865520
+  -Hartree energ DENC   =      -228.05319922
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =        49.88420716
+  PAW double counting   =      1004.05751856     -985.08963361
+  entropy T*S    EENTRO =        -0.00017631
+  eigenvalues    EBANDS =      -133.79478191
+  atomic energy  EATOM  =      1284.14476957
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =         0.29508663 eV
+
+  energy without entropy =        0.29526294  energy(sigma->0) =        0.29517478
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   2)  ---------------------------------------
+
+
+ -----------------------------------------------------------------------------
+|                                                                             |
+|     EEEEEEE  RRRRRR   RRRRRR   OOOOOOO  RRRRRR      ###     ###     ###     |
+|     E        R     R  R     R  O     O  R     R     ###     ###     ###     |
+|     E        R     R  R     R  O     O  R     R     ###     ###     ###     |
+|     EEEEE    RRRRRR   RRRRRR   O     O  RRRRRR       #       #       #      |
+|     E        R   R    R   R    O     O  R   R                               |
+|     E        R    R   R    R   O     O  R    R      ###     ###     ###     |
+|     EEEEEEE  R     R  R     R  OOOOOOO  R     R     ###     ###     ###     |
+|                                                                             |
+|     Error EDDDAV: Call to ZHEGV failed. Returncode = 1 2 128                |
+|                                                                             |
+|       ---->  I REFUSE TO CONTINUE WITH THIS SICK JOB ... BYE!!! <----       |
+|                                                                             |
+ -----------------------------------------------------------------------------
+


### PR DESCRIPTION
This PR closes #192.

Calculations on small systems with too many requested cores can cause a `ZHEGV` error. This is common on KNL nodes with elemental systems. In practice, the best solution is to just drop the number of cores, but that's not trivial to do with Custodian. An easier solution is to increase `NCORE` so that the load-balancing is improved. That's what I do in this PR.