### PR TITLE
VASP: Improve ZPOTRF handler

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -82,7 +82,7 @@ class VaspErrorHandler(ErrorHandler):
         "rot_matrix": ["Found some non-integer element in rotation matrix", "SGRCON"],
         "brions": ["BRIONS problems: POTIM should be increased"],
         "pricel": ["internal error in subroutine PRICEL"],
-        "zpotrf": ["LAPACK: Routine ZPOTRF failed", "Routine ZPOTRFZTRTRI"],
+        "zpotrf": ["LAPACK: Routine ZPOTRF failed", "Routine ZPOTRF ZTRTRI"],
         "amin": ["One of the lattice vectors is very long (>50 A), but AMIN"],
         "zbrent": ["ZBRENT: fatal internal in", "ZBRENT: fatal error in bracketing"],
         "pssyevx": ["ERROR in subspace rotation PSSYEVX"],

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -82,7 +82,7 @@ class VaspErrorHandler(ErrorHandler):
         "rot_matrix": ["Found some non-integer element in rotation matrix", "SGRCON"],
         "brions": ["BRIONS problems: POTIM should be increased"],
         "pricel": ["internal error in subroutine PRICEL"],
-        "zpotrf": ["LAPACK: Routine ZPOTRF failed"],
+        "zpotrf": ["LAPACK: Routine ZPOTRF failed", "Routine ZPOTRFZTRTRI"],
         "amin": ["One of the lattice vectors is very long (>50 A), but AMIN"],
         "zbrent": ["ZBRENT: fatal internal in", "ZBRENT: fatal error in bracketing"],
         "pssyevx": ["ERROR in subspace rotation PSSYEVX"],
@@ -304,6 +304,9 @@ class VaspErrorHandler(ErrorHandler):
             if vi["INCAR"].get("ICHARG", 0) < 10:
                 actions.append({"file": "CHGCAR", "action": {"_file_delete": {"mode": "actual"}}})
                 actions.append({"file": "WAVECAR", "action": {"_file_delete": {"mode": "actual"}}})
+
+            # A.S.R.: This can also happen if NCORE or NPAR is set to an unusually large value.
+            # We should add logic for this at some point.
 
         if self.errors.intersection(["subspacematrix"]):
             if self.error_count["subspacematrix"] == 0:

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -281,7 +281,7 @@ class VaspErrorHandler(ErrorHandler):
         if "zpotrf" in self.errors:
             # Usually caused by short bond distances. If on the first step,
             # volume needs to be increased. Otherwise, it was due to a step
-            # being too big and POTIM should be decreased.  If a static run
+            # being too big and POTIM should be decreased. If a static run
             # try turning off symmetry.
             try:
                 oszicar = Oszicar("OSZICAR")

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -295,6 +295,12 @@ class VaspErrorHandlerTest(unittest.TestCase):
         self.assertEqual(h.correct()["errors"], ["edddav"])
         self.assertFalse(os.path.exists("CHGCAR"))
 
+    def test_zpotrf(self):
+        h = VaspErrorHandler("vasp.ztrtri")
+        self.assertEqual(h.check(), True)
+        self.assertEqual(h.correct()["errors"], ["zpotrf"])
+        self.assertFalse(os.path.exists("CHGCAR"))
+
     def test_algo_tet(self):
         h = VaspErrorHandler("vasp.algo_tet")
         self.assertEqual(h.check(), True)
@@ -855,7 +861,7 @@ class ZpotrfErrorHandlerTest(unittest.TestCase):
         d = h.correct()
         self.assertEqual(d["errors"], ["zpotrf"])
         s2 = Structure.from_file("POSCAR")
-        self.assertAlmostEqual(s2.volume, s1.volume * 1.2 ** 3, 3)
+        self.assertAlmostEqual(s2.volume, s1.volume * 1.2**3, 3)
 
     def test_potim_correction(self):
         shutil.copy("OSZICAR.one_step", "OSZICAR")

--- a/test_files/vasp.ztrtri
+++ b/test_files/vasp.ztrtri
@@ -1,0 +1,23 @@
+ -----------------------------------------------------------------------------
+|                                                                             |
+|     EEEEEEE  RRRRRR   RRRRRR   OOOOOOO  RRRRRR      ###     ###     ###     |
+|     E        R     R  R     R  O     O  R     R     ###     ###     ###     |
+|     E        R     R  R     R  O     O  R     R     ###     ###     ###     |
+|     EEEEE    RRRRRR   RRRRRR   O     O  RRRRRR       #       #       #      |
+|     E        R   R    R   R    O     O  R   R                               |
+|     E        R    R   R    R   O     O  R    R      ###     ###     ###     |
+|     EEEEEEE  R     R  R     R  OOOOOOO  R     R     ###     ###     ###     |
+|                                                                             |
+|     Orbital orthonormalization failed in the inversion of matrix            |
+|     scaLAPACK: Routine ZPOTRF ZTRTRI failed! kpoint: 7 spin: 1              |
+|                                                                             |
+|     Possible solutions for this issue are:                                  |
+|     - Please check whether the atoms are too close to each other.           |
+|     - Decreasing POTIM might help during relaxations or MDs.                |
+|     - Deleting CHGCAR or WAVECAR if incompatible with the structure.        |
+|     - Try calculating without symmetrizing (ISYM = 0 or ISYM = -1).         |
+|     - As last resort: using a different PAW for some of the atoms.          |
+|                                                                             |
+|       ---->  I REFUSE TO CONTINUE WITH THIS SICK JOB ... BYE!!! <----       |
+|                                                                             |
+ -----------------------------------------------------------------------------


### PR DESCRIPTION
VASP 6+ has new phrasing for the `ZPOTRF` error, which I've now included in Custodian. Closes #216.