### PR TITLE
Bugfix for job termination when multiple VaspJobs are running on a single node

### DIFF
--- a/custodian/vasp/jobs.py
+++ b/custodian/vasp/jobs.py
@@ -257,7 +257,7 @@ class VaspJob(Job):
             self.sbprcss = subprocess.Popen(
                 cmd, stdout=f_std, stderr=f_err, start_new_session=True
             )  # pylint: disable=R1732
-            return self.sbrpcss
+            return self.sbprcss
 
     def postprocess(self):
         """
@@ -857,7 +857,7 @@ class VaspNEBJob(VaspJob):
             self.sbprcss = subprocess.Popen(
                 cmd, stdout=f_std, stderr=f_err, start_new_session=True
             )  # pylint: disable=R1732
-            return self.sbrpcss
+            return self.sbprcss
 
     def postprocess(self):
         """

--- a/custodian/vasp/jobs.py
+++ b/custodian/vasp/jobs.py
@@ -151,6 +151,7 @@ class VaspJob(Job):
         self.gamma_vasp_cmd = gamma_vasp_cmd
         self.copy_magmom = copy_magmom
         self.auto_continue = auto_continue
+        self.sbprcss = None
 
         if SENTRY_DSN:
             # if using Sentry logging, add specific VASP executable to scope
@@ -765,6 +766,7 @@ class VaspNEBJob(VaspJob):
         self.settings_override = settings_override
         self.neb_dirs = []  # 00, 01, etc.
         self.neb_sub = []  # 01, 02, etc.
+        self.sbprcss = None
 
         for path in os.listdir("."):
             if os.path.isdir(path) and path.isdigit():

--- a/custodian/vasp/jobs.py
+++ b/custodian/vasp/jobs.py
@@ -253,10 +253,9 @@ class VaspJob(Job):
         logger.info(f"Running {' '.join(cmd)}")
         with open(self.output_file, "w") as f_std, open(self.stderr_file, "w", buffering=1) as f_err:
             # use line buffering for stderr
-            self.sbprcss = subprocess.Popen(cmd,
-                                            stdout=f_std,
-                                            stderr=f_err,
-                                            start_new_session=True)  # pylint: disable=R1732
+            self.sbprcss = subprocess.Popen(
+                cmd, stdout=f_std, stderr=f_err, start_new_session=True
+            )  # pylint: disable=R1732
             return self.sbrpcss
 
     def postprocess(self):
@@ -853,10 +852,9 @@ class VaspNEBJob(VaspJob):
         logger.info(f"Running {' '.join(cmd)}")
         with open(self.output_file, "w") as f_std, open(self.stderr_file, "w", buffering=1) as f_err:
             # Use line buffering for stderr
-            self.sbprcss = subprocess.Popen(cmd,
-                                            stdout=f_std,
-                                            stderr=f_err,
-                                            start_new_session=True)  # pylint: disable=R1732
+            self.sbprcss = subprocess.Popen(
+                cmd, stdout=f_std, stderr=f_err, start_new_session=True
+            )  # pylint: disable=R1732
             return self.sbrpcss
 
     def postprocess(self):

--- a/custodian/vasp/jobs.py
+++ b/custodian/vasp/jobs.py
@@ -254,9 +254,9 @@ class VaspJob(Job):
         with open(self.output_file, "w") as f_std, open(self.stderr_file, "w", buffering=1) as f_err:
             # use line buffering for stderr
             self.sbprcss = subprocess.Popen(cmd,
-                                      stdout=f_std,
-                                      stderr=f_err,
-                                      start_new_session=True)  # pylint: disable=R1732
+                                            stdout=f_std,
+                                            stderr=f_err,
+                                            start_new_session=True)  # pylint: disable=R1732
             return self.sbrpcss
 
     def postprocess(self):
@@ -854,9 +854,9 @@ class VaspNEBJob(VaspJob):
         with open(self.output_file, "w") as f_std, open(self.stderr_file, "w", buffering=1) as f_err:
             # Use line buffering for stderr
             self.sbprcss = subprocess.Popen(cmd,
-                                      stdout=f_std,
-                                      stderr=f_err,
-                                      start_new_session=True)  # pylint: disable=R1732
+                                            stdout=f_std,
+                                            stderr=f_err,
+                                            start_new_session=True)  # pylint: disable=R1732
             return self.sbrpcss
 
     def postprocess(self):

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -283,6 +283,7 @@ class VaspErrorHandlerTest(unittest.TestCase):
         self.assertEqual(i["ALGO"], "Normal")
 
     def test_eddrmm(self):
+        shutil.copy("CONTCAR.eddav_eddrmm", "CONTCAR")
         h = VaspErrorHandler("vasp.eddrmm")
         self.assertEqual(h.check(), True)
         self.assertEqual(h.correct()["errors"], ["eddrmm"])
@@ -303,6 +304,7 @@ class VaspErrorHandlerTest(unittest.TestCase):
         self.assertEqual(i["LREAL"], False)
 
     def test_edddav(self):
+        shutil.copy("CONTCAR.eddav_eddrmm", "CONTCAR")
         h = VaspErrorHandler("vasp.edddav2")
         self.assertEqual(h.check(), True)
         self.assertEqual(h.correct()["errors"], ["edddav"])


### PR DESCRIPTION
## Summary

To date, custodian terminates all VASP instances on a node when it wants to make a correction by using `os.system(f"killall {k}")`, (where k are all strings in vasp_cmd that contain "vasp". This is no problem if only one `VaspJob` is running on the machine, but if there are more, e.g. because one is using `rlaunch multi` in FireWorks, all get killed.

This fix updates the termination of processes to be specific to a process id group, and sends a `SIGTERM` signal for the termination.

Necessary modifications:

* The `subprocess.Popen()` calls in `VapJob` and `VaspNEBJob` do now set `start_new_session=True` so setsid() system calls will be made in the child process prior to the execution of the subprocess.
* The `subprocess.Popen()` is not directly returned, but saved as a class property, so the `terminate` method has access to the pid.
* The terminate method has been completely changed to replace `killall` with `os.killpg(os.getpgid(self.sbprcss.pid), signal.SIGTERM)`, which will only target the classes own sub-process group.


## Possible changes

* I am not sure if the changes to `VaspNEBJob` are actually necessary, since this class has no terminate method. But I think it cannot hurt to have the object saved in the class.
