### PR TITLE
VASP Handler: Do not set `ADDGRID` to True

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -898,11 +898,8 @@ class DriftErrorHandler(ErrorHandler):
         # Move CONTCAR to POSCAR
         actions.append({"file": "CONTCAR", "action": {"_file_copy": {"dest": "POSCAR"}}})
 
-        # First try adding ADDGRID
-        if not incar.get("ADDGRID", False):
-            actions.append({"dict": "INCAR", "action": {"_set": {"ADDGRID": True}}})
-        # Otherwise set PREC to High so ENAUG can be used to control Augmentation Grid Size
-        elif incar.get("PREC", "Accurate").lower() != "high":
+        # Set PREC to High so ENAUG can be used to control Augmentation Grid Size
+        if incar.get("PREC", "Accurate").lower() != "high":
             actions.append({"dict": "INCAR", "action": {"_set": {"PREC": "High"}}})
             actions.append(
                 {

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -1181,10 +1181,6 @@ class DriftErrorHandlerTest(unittest.TestCase):
         h.check()
         h.correct()
         incar = Incar.from_file("INCAR")
-        self.assertTrue(incar.get("ADDGRID", False))
-
-        h.correct()
-        incar = Incar.from_file("INCAR")
         self.assertEqual(incar.get("PREC"), "High")
         self.assertEqual(incar.get("ENAUG", 0), incar.get("ENCUT", 2) * 2)
 


### PR DESCRIPTION
This closes #226. In short, the VASP manual strongly advises caution against using the `ADDGRID` command, and in my experience, I have seen that it produces invalid `AECCAR` files. It should not be set in Custodian as a rule.