### PR TITLE
VASP Handler: Add a new handler for the SET_CORE_WF error

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -592,12 +592,6 @@ class VaspErrorHandler(ErrorHandler):
             else:
                 actions.append({"dict": "INCAR", "action": {"_set": {"SYMPREC": symprec * 10}}})
 
-        if "hnform" in self.errors:
-            # The only solution is to change your k-point grid or disable symmetry
-            # For internal calculation compatibility's sake, we do the latter
-            if vi["INCAR"].get("ISYM", 2) > 0:
-                actions.append({"dict": "INCAR", "action": {"_set": {"ISYM": 0}}})
-
         if "nbands_not_sufficient" in self.errors:
             # There is something very wrong about the value of NBANDS. We don't make
             # any updates to NBANDS though because it's likely the user screwed something
@@ -614,6 +608,12 @@ class VaspErrorHandler(ErrorHandler):
                 "We suggest using a new version of the POTCAR files to resolve the SET_CORE_WF error.", UserWarning
             )
             return {"errors": ["set_core_wf"], "actions": None}
+
+        if "hnform" in self.errors:
+            # The only solution is to change your k-point grid or disable symmetry
+            # For internal calculation compatibility's sake, we do the latter
+            if vi["INCAR"].get("ISYM", 2) > 0:
+                actions.append({"dict": "INCAR", "action": {"_set": {"ISYM": 0}}})
 
         VaspModder(vi=vi).apply_actions(actions)
         return {"errors": list(self.errors), "actions": actions}

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -605,6 +605,7 @@ class VaspErrorHandler(ErrorHandler):
             # MAGMOM = 2*nan or something similar.
 
             # Unfixable error. Just return None for actions.
+            warnings.warn("Double-check your INCAR. Something is potentially wrong.", UserWarning)
             return {"errors": ["nbands_not_sufficient"], "actions": None}
 
         if "set_core_wf" in self.errors:

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -612,6 +612,7 @@ class VaspErrorHandler(ErrorHandler):
             warnings.warn(
                 "We suggest using a new version of the POTCAR files to resolve the SET_CORE_WF error.", UserWarning
             )
+            return {"errors": ["set_core_wf"], "actions": None}
 
         VaspModder(vi=vi).apply_actions(actions)
         return {"errors": list(self.errors), "actions": actions}

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -531,7 +531,8 @@ class VaspErrorHandler(ErrorHandler):
             if "algo_tet" not in self.errors:
                 warnings.warn(
                     "EDWAV error reported by VASP without a simultaneous algo_tet error. You may wish to consider "
-                    "recompiling VASP with the -O1 optimization if you used -O2 and this error keeps cropping up."
+                    "recompiling VASP with the -O1 optimization if you used -O2 and this error keeps cropping up.",
+                    UserWarning,
                 )
 
         if "zheev" in self.errors:

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -519,7 +519,8 @@ class VaspErrorHandlerTest(unittest.TestCase):
     def test_nbands_not_sufficient(self):
         h = VaspErrorHandler("vasp.nbands_not_sufficient")
         self.assertEqual(h.check(), True)
-        self.assertEqual(h.correct()["errors"], ["nbands_not_sufficient"])
+        d = h.correct()
+        self.assertEqual(d["errors"], ["nbands_not_sufficient"])
         self.assertEqual(d["actions"], None)
 
     def test_too_few_bands_round_error(self):
@@ -535,7 +536,8 @@ class VaspErrorHandlerTest(unittest.TestCase):
     def test_set_core_wf(self):
         h = VaspErrorHandler("vasp.set_core_wf")
         self.assertEqual(h.check(), True)
-        self.assertEqual(h.correct()["errors"], ["set_core_wf"])
+        d = h.correct()
+        self.assertEqual(d["errors"], ["set_core_wf"])
         self.assertEqual(d["actions"], None)
 
     def tearDown(self):

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -520,6 +520,7 @@ class VaspErrorHandlerTest(unittest.TestCase):
         h = VaspErrorHandler("vasp.nbands_not_sufficient")
         self.assertEqual(h.check(), True)
         self.assertEqual(h.correct()["errors"], ["nbands_not_sufficient"])
+        self.assertEqual(d["actions"], None)
 
     def test_too_few_bands_round_error(self):
         # originally there are  NBANDS= 7
@@ -530,6 +531,12 @@ class VaspErrorHandlerTest(unittest.TestCase):
         d = h.correct()
         self.assertEqual(d["errors"], ["too_few_bands"])
         self.assertEqual(d["actions"], [{"dict": "INCAR", "action": {"_set": {"NBANDS": 8}}}])
+
+    def test_set_core_wf(self):
+        h = VaspErrorHandler("vasp.set_core_wf")
+        self.assertEqual(h.check(), True)
+        self.assertEqual(h.correct()["errors"], ["set_core_wf"])
+        self.assertEqual(d["actions"], None)
 
     def tearDown(self):
         os.chdir(test_dir)

--- a/test_files/vasp.set_core_wf
+++ b/test_files/vasp.set_core_wf
@@ -1,0 +1,1 @@
+internal error in SET_CORE_WF: core electrons incorrect 51.0000000000000


### PR DESCRIPTION
Closes #227. A handler has been added for the `SET_CORE_WF` error. The only solution to this error is to update the POTCARs, so we warn the user and kill the job.