### PR TITLE
Fix recent merge conflict due to incorrect merging of test suite

### DIFF
--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -322,14 +322,6 @@ class VaspErrorHandlerTest(unittest.TestCase):
         c = Structure.from_file("CONTCAR")
         self.assertEqual(p, c)
 
-    def test_algo_tet(self):
-        h = VaspErrorHandler("vasp.algo_tet")
-        self.assertEqual(h.check(), True)
-        self.assertIn("algo_tet", h.correct()["errors"])
-        i = Incar.from_file("INCAR")
-        self.assertEqual(i["ISMEAR"], 0)
-        self.assertEqual(i["SIGMA"], 0.05)
-
     def test_gradient_not_orthogonal(self):
         h = VaspErrorHandler("vasp.gradient_not_orthogonal")
         self.assertEqual(h.check(), True)


### PR DESCRIPTION
Fixes the recent issue caused by a faulty merge conflict in master. Waiting on the tests this time, but locally we are good...

For context, there are now accidentally two algo_tet error handlers in the test suite, but only one was supposed to be kept (the one under the UnconvergedErrorHandler). The other one was supposed to be deleted when the new one was added.