### PR TITLE
Change VASP terminate function to use the old `killall` method as a backup

### DIFF
--- a/custodian/vasp/jobs.py
+++ b/custodian/vasp/jobs.py
@@ -673,7 +673,16 @@ class VaspJob(Job):
         """
         logger.info(f"Custodian terminating all VASP processes within process group {self.sbprcss.pid}")
         try:
-            os.killpg(os.getpgid(self.sbprcss.pid), signal.SIGTERM)
+            try: # first try to terminate all VASP processes based on sbprcss.pid
+                os.killpg(os.getpgid(self.sbprcss.pid), signal.SIGTERM)
+            except Exception: # As a backup method, try to kill using "killall"
+                cmds = self.vasp_cmd
+                if self.gamma_vasp_cmd:
+                    cmds += self.gamma_vasp_cmd
+                for k in cmds:
+                    if "vasp" in k:
+                        try:
+                            os.system(f"killall {k}")
         except Exception:
             pass
 

--- a/custodian/vasp/jobs.py
+++ b/custodian/vasp/jobs.py
@@ -673,15 +673,15 @@ class VaspJob(Job):
         """
         logger.info(f"Custodian terminating all VASP processes within process group {self.sbprcss.pid}")
         try:
-            try: # first try to terminate all VASP processes based on sbprcss.pid
+            try:  # first try to terminate all VASP processes based on sbprcss.pid
                 os.killpg(os.getpgid(self.sbprcss.pid), signal.SIGTERM)
-            except Exception: # As a backup method, try to kill using "killall"
+            except Exception:  # As a backup method, try to kill using "killall"
                 cmds = self.vasp_cmd
                 if self.gamma_vasp_cmd:
                     cmds += self.gamma_vasp_cmd
                 for k in cmds:
                     if "vasp" in k:
-                    	try:
+                        try:
                             os.system(f"killall {k}")
                         except Exception:
                             pass

--- a/custodian/vasp/jobs.py
+++ b/custodian/vasp/jobs.py
@@ -681,8 +681,10 @@ class VaspJob(Job):
                     cmds += self.gamma_vasp_cmd
                 for k in cmds:
                     if "vasp" in k:
-                        try:
+                    	try:
                             os.system(f"killall {k}")
+                        except Exception:
+                            pass
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary

@shyuep This adds in a backup method for terminating VASP jobs. Specifically, if the recent method added in #231 does not work, try to use the old method (based on `killall`) as a backup.

Reason for this change: the newer method added in #231 did not work in many of my test cases on the NSF ACCESS' Bridges2 supercomputer or Berkeley's Savio supercomputer. The old method did, though is not preferable in cases where multiple jobs are running on a single node. Hence, using the old method as a backup seems sensible to me.