### PR TITLE
VASP: Add handler for invalid WAVECAR when going from `vasp_gam` to `vasp_std`

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -365,7 +365,7 @@ class VaspErrorHandler(ErrorHandler):
                 actions.append({"dict": "INCAR", "action": {"_set": {"SYMPREC": 1e-8, "ISYM": 0}}})
 
         if "coef" in self.errors:
-            actions.append({"dict": "INCAR", "action": {"_set": {"ISTART": 0}}})
+            actions.append({"file": "WAVECAR", "action": {"_file_delete": {"mode": "actual"}}})
 
         if "brions" in self.errors:
             # Copy CONTCAR to POSCAR so we do not lose our progress.

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -102,7 +102,7 @@ class VaspErrorHandler(ErrorHandler):
         "bravais": ["Inconsistent Bravais lattice"],
         "nbands_not_sufficient": ["number of bands is not sufficient"],
         "hnform": ["HNFORM: k-point generating"],
-        "coef": ["while reading plane"],
+        "coef": ["while reading plane", "while reading WAVECAR"],
         "set_core_wf": ["internal error in SET_CORE_WF"],
     }
 
@@ -365,7 +365,7 @@ class VaspErrorHandler(ErrorHandler):
                 actions.append({"dict": "INCAR", "action": {"_set": {"SYMPREC": 1e-8, "ISYM": 0}}})
 
         if "coef" in self.errors:
-            actions.append({"file": "WAVECAR", "action": {"_file_delete": {"mode": "actual"}}})
+            actions.append({"dict": "INCAR", "action": {"_set": {"ISTART": 0}}})
 
         if "brions" in self.errors:
             # Copy CONTCAR to POSCAR so we do not lose our progress.

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -262,12 +262,23 @@ class VaspErrorHandlerTest(unittest.TestCase):
         h = VaspErrorHandler("vasp6.coef")
         h.check()
         d = h.correct()
-        self.assertEqual(d["actions"], [{"dict": "INCAR", "action": {"_set": {"ISTART": 0}}}])
+        self.assertEqual(
+            d["actions"],
+            [
+                {"file": "WAVECAR", "action": {"_file_delete": {"mode": "actual"}}},
+            ],
+        )
 
         h = VaspErrorHandler("vasp6.coef2")
         h.check()
         d = h.correct()
-        self.assertEqual(d["actions"], [{"dict": "INCAR", "action": {"_set": {"ISTART": 0}}}])
+        self.assertEqual(
+            d["actions"],
+            [
+                {"file": "WAVECAR", "action": {"_file_delete": {"mode": "actual"}}},
+            ],
+        )
+
 
     def test_to_from_dict(self):
         h = VaspErrorHandler("random_name")

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -262,12 +262,12 @@ class VaspErrorHandlerTest(unittest.TestCase):
         h = VaspErrorHandler("vasp6.coef")
         h.check()
         d = h.correct()
-        self.assertEqual(
-            d["actions"],
-            [
-                {"file": "WAVECAR", "action": {"_file_delete": {"mode": "actual"}}},
-            ],
-        )
+        self.assertEqual(d["actions"], [{"dict": "INCAR", "action": {"_set": {"ISTART": 0}}}])
+
+        h = VaspErrorHandler("vasp6.coef2")
+        h.check()
+        d = h.correct()
+        self.assertEqual(d["actions"], [{"dict": "INCAR", "action": {"_set": {"ISTART": 0}}}])
 
     def test_to_from_dict(self):
         h = VaspErrorHandler("random_name")
@@ -510,7 +510,7 @@ class VaspErrorHandlerTest(unittest.TestCase):
         self.assertEqual(d["actions"], None)
 
     def test_too_few_bands_round_error(self):
-        # originally there are  NBANDS= 7
+        # originally there are NBANDS= 7
         # correction should increase it
         shutil.copy("INCAR.too_few_bands_round_error", "INCAR")
         h = VaspErrorHandler("vasp.too_few_bands_round_error")

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -279,7 +279,6 @@ class VaspErrorHandlerTest(unittest.TestCase):
             ],
         )
 
-
     def test_to_from_dict(self):
         h = VaspErrorHandler("random_name")
         h2 = VaspErrorHandler.from_dict(h.as_dict())

--- a/test_files/vasp6.coef2
+++ b/test_files/vasp6.coef2
@@ -1,0 +1,16 @@
+ ------------------------------------------------------------------------
+|
+|     EEEEEEE  RRRRRR   RRRRRR   OOOOOOO  RRRRRR      ###     ###     ###
+|     E        R     R  R     R  O     O  R     R     ###     ###     ###
+|     E        R     R  R     R  O     O  R     R     ###     ###     ###
+|     EEEEE    RRRRRR   RRRRRR   O     O  RRRRRR       #       #       #
+|     E        R   R    R   R    O     O  R   R
+|     E        R    R   R    R   O     O  R    R      ###     ###     ###
+|     EEEEEEE  R     R  R     R  OOOOOOO  R     R     ###     ###     ###
+|
+|     ERROR: while reading WAVECAR, plane wave coefficients changed
+|     153785 76893
+|
+|       ---->  I REFUSE TO CONTINUE WITH THIS SICK JOB ... BYE!!! <----
+|
+ ------------------------------------------------------------------------


### PR DESCRIPTION
Closes #255.
