### PR TITLE
`LargeSigmaHandler` set `ISMEAR=0` if sigma reaches `0.02` minimum

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -1287,11 +1287,11 @@ class LargeSigmaHandler(ErrorHandler):
             )
         else:
             # https://vasp.at/wiki/index.php/ISMEAR recommends ISMEAR = 0 if you have
-            # no a priori knowledge of your system ("then always use Gaussian smearing")
+            # no a priori knowledge of your system ("then always use Gaussian smearing"
             actions.append(
                 {
                     "dict": "INCAR",
-                    "action": {"_set": {"ISMEAR": 0}},
+                    "action": {"_set": {"ISMEAR": 0, "SIGMA": 0.05}},
                 }
             )
 

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -1285,6 +1285,15 @@ class LargeSigmaHandler(ErrorHandler):
                     "action": {"_set": {"SIGMA": sigma - 0.06}},
                 }
             )
+        else:
+            # https://vasp.at/wiki/index.php/ISMEAR recommends ISMEAR = 0 if you have
+            # no a priori knowledge of your system ("then always use Gaussian smearing")
+            actions.append(
+                {
+                    "dict": "INCAR",
+                    "action": {"_set": {"ISMEAR": 0}},
+                }
+            )
 
         VaspModder(vi=vi).apply_actions(actions)
         return {"errors": ["LargeSigma"], "actions": actions}


### PR DESCRIPTION
Half the jobs in our atomate2 r2SCAN trial runs fizzle due to `LargeSigmaHandler`. The failed runs are mostly metals.

After starting with `sigma=0.2` and decreasing 3 times, we reach the minimum of 0.02 allowed by Custodian at which point the `LargeSigmaHandler` aborts the job.

VASP wiki says Gaussian smearing leads to reasonable results in most cases. In the final summary they say if you have no prior knowledge of the system, use `ISMEAR = 0`.

Alternative suggestion from @esoteric-ephemera is to increase the max allowed entropy from 1 meV/atom even though VASP docs recommend. They probably didn't benchmark that value for larger structures. Or better yet, make it a user overridable `entropy_tol` kwarg.

https://github.com/materialsproject/custodian/blob/202b941ab9c5d8fc3b9b9e5bb26a9e280ba1e0ea/custodian/vasp/handlers.py#L1264