### PR TITLE
Fix broken link in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ VASP, NWChem, QChem, etc., you will likely need pymatgen to be install as well.
 # Usage
 
 Please refer to the `official custodian docs
-<http://pythonhosted.org//custodian>`_ for details on how to use
+<http://pythonhosted.org/custodian>`_ for details on how to use
 custodian.
 
 # How to cite custodian


### PR DESCRIPTION
## Summary
Custodian documentation link was wrong link. Original link was `//custodian` instead of `/custodian`. 

Also, I am not sure if below is the desired behavior:
<img width="1020" alt="image" src="https://github.com/R1j1t/custodian/assets/22280243/ef6d23f1-a9b5-4422-93af-fa01d6006063">

Let me know if this should be added to this PR?