### PR TITLE
Fix AttributeError NoneType has no attribute 'style' 

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,12 @@
 name: Testing
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+    paths-ignore: [docs/**]
+  pull_request:
+    branches: [master]
+    paths-ignore: [docs/**]
 
 jobs:
   build:

--- a/custodian/cli/run_vasp.py
+++ b/custodian/cli/run_vasp.py
@@ -99,7 +99,7 @@ def get_jobs(args):
                 ]
             )
             auto_npar = False
-        elif job_type.startswith("static") and vinput["KPOINTS"] is not None:
+        elif job_type.startswith("static") and vinput["KPOINTS"]:
             m = [i * args.static_kpoint for i in vinput["KPOINTS"].kpts[0]]
             settings.extend(
                 [

--- a/custodian/cli/run_vasp.py
+++ b/custodian/cli/run_vasp.py
@@ -99,7 +99,7 @@ def get_jobs(args):
                 ]
             )
             auto_npar = False
-        elif job_type.startswith("static"):
+        elif job_type.startswith("static") and vinput["KPOINTS"] is not None:
             m = [i * args.static_kpoint for i in vinput["KPOINTS"].kpts[0]]
             settings.extend(
                 [

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -214,7 +214,7 @@ class VaspErrorHandler(ErrorHandler):
 
             elif (
                 self.error_count["brmix"] == 2
-                and vi["KPOINTS"] is not None
+                and vi["KPOINTS"]
                 and vi["KPOINTS"].style == Kpoints.supported_modes.Gamma
             ):
                 actions.append(
@@ -229,7 +229,7 @@ class VaspErrorHandler(ErrorHandler):
 
             elif (
                 self.error_count["brmix"] in [2, 3]
-                and vi["KPOINTS"] is not None
+                and vi["KPOINTS"]
                 and vi["KPOINTS"].style == Kpoints.supported_modes.Monkhorst
             ):
                 actions.append({"dict": "KPOINTS", "action": {"_set": {"generation_style": "Gamma"}}})
@@ -237,11 +237,7 @@ class VaspErrorHandler(ErrorHandler):
                     actions.append({"dict": "INCAR", "action": {"_unset": {"IMIX": 1}}})
                 self.error_count["brmix"] += 1
 
-                if (
-                    vi["KPOINTS"] is not None
-                    and vi["KPOINTS"].num_kpts < 1
-                    and all(n % 2 == 0 for n in vi["KPOINTS"].kpts[0])
-                ):
+                if vi["KPOINTS"] and vi["KPOINTS"].num_kpts < 1 and all(n % 2 == 0 for n in vi["KPOINTS"].kpts[0]):
                     new_kpts = (tuple(n + 1 for n in vi["KPOINTS"].kpts[0]),)
                     actions.append(
                         {
@@ -256,14 +252,14 @@ class VaspErrorHandler(ErrorHandler):
             else:
                 if vi["INCAR"].get("ISYM", 2) > 0:
                     actions.append({"dict": "INCAR", "action": {"_set": {"ISYM": 0}}})
-                if vi["KPOINTS"] is not None and vi["KPOINTS"].style == Kpoints.supported_modes.Monkhorst:
+                if vi["KPOINTS"] and vi["KPOINTS"].style == Kpoints.supported_modes.Monkhorst:
                     actions.append(
                         {
                             "dict": "KPOINTS",
                             "action": {"_set": {"generation_style": "Gamma"}},
                         }
                     )
-                if vi["KPOINTS"] is not None and vi["KPOINTS"].style == Kpoints.supported_modes.Monkhorst:
+                if vi["KPOINTS"] and vi["KPOINTS"].style == Kpoints.supported_modes.Monkhorst:
                     actions.append(
                         {
                             "dict": "KPOINTS",
@@ -334,7 +330,7 @@ class VaspErrorHandler(ErrorHandler):
 
         if (
             self.errors.intersection(["tetirr", "incorrect_shift"])
-            and vi["KPOINTS"] is not None
+            and vi["KPOINTS"]
             and vi["KPOINTS"].style == Kpoints.supported_modes.Monkhorst
         ):
             actions.append(
@@ -345,7 +341,7 @@ class VaspErrorHandler(ErrorHandler):
             )
 
         if "rot_matrix" in self.errors:
-            if vi["KPOINTS"] is not None and vi["KPOINTS"].style == Kpoints.supported_modes.Monkhorst:
+            if vi["KPOINTS"] and vi["KPOINTS"].style == Kpoints.supported_modes.Monkhorst:
                 actions.append(
                     {
                         "dict": "KPOINTS",
@@ -754,7 +750,7 @@ class StdErrHandler(ErrorHandler):
         if "kpoints_trans" in self.errors and self.error_count["kpoints_trans"] == 0:
             m = reduce(operator.mul, vi["KPOINTS"].kpts[0])
             m = max(int(round(m ** (1 / 3))), 1)
-            if vi["KPOINTS"] is not None and vi["KPOINTS"].style.name.lower().startswith("m"):
+            if vi["KPOINTS"] and vi["KPOINTS"].style.name.lower().startswith("m"):
                 m += m % 2
             actions.append({"dict": "KPOINTS", "action": {"_set": {"kpoints": [[m] * 3]}}})
             self.error_count["kpoints_trans"] += 1
@@ -985,7 +981,7 @@ class MeshSymmetryErrorHandler(ErrorHandler):
         # if symmetry is off
         # Also disregard if automatic KPOINT generation is used
         if (not vi["INCAR"].get("ISYM", True)) or (
-            vi["KPOINTS"] is not None and vi["KPOINTS"].style == Kpoints.supported_modes.Automatic
+            vi["KPOINTS"] and vi["KPOINTS"].style == Kpoints.supported_modes.Automatic
         ):
             return False
 
@@ -1008,7 +1004,7 @@ class MeshSymmetryErrorHandler(ErrorHandler):
         vi = VaspInput.from_directory(".")
         m = reduce(operator.mul, vi["KPOINTS"].kpts[0])
         m = max(int(round(m ** (1 / 3))), 1)
-        if vi["KPOINTS"] is not None and vi["KPOINTS"].style.name.lower().startswith("m"):
+        if vi["KPOINTS"] and vi["KPOINTS"].style.name.lower().startswith("m"):
             m += m % 2
         actions = [{"dict": "KPOINTS", "action": {"_set": {"kpoints": [[m] * 3]}}}]
         VaspModder(vi=vi).apply_actions(actions)

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -227,12 +227,12 @@ class VaspErrorHandler(ErrorHandler):
                     actions.append({"dict": "INCAR", "action": {"_unset": {"IMIX": 1}}})
                 self.error_count["brmix"] += 1
 
-            elif self.error_count["brmix"] in [2, 3]:
-                if vi["KPOINTS"] is not None and vi["KPOINTS"].style == Kpoints.supported_modes.Gamma:
-                    actions.append({"dict": "KPOINTS", "action": {"_set": {"generation_style": "Gamma"}}})
-                elif vi["INCAR"].get("KSPACING"):
-                    actions.append({"dict": "INCAR", "action": {"_set": {"KGAMMA": True}}})
-
+            elif (
+                self.error_count["brmix"] in [2, 3]
+                and vi["KPOINTS"] is not None
+                and vi["KPOINTS"].style == Kpoints.supported_modes.Monkhorst
+            ):
+                actions.append({"dict": "KPOINTS", "action": {"_set": {"generation_style": "Gamma"}}})
                 if "IMIX" in vi["INCAR"]:
                     actions.append({"dict": "INCAR", "action": {"_unset": {"IMIX": 1}}})
                 self.error_count["brmix"] += 1
@@ -249,6 +249,9 @@ class VaspErrorHandler(ErrorHandler):
                             "action": {"_set": {"kpoints": new_kpts}},
                         }
                     )
+
+            elif self.error_count["brmix"] in [2, 3] and vi["INCAR"].get("KSPACING"):
+                actions.append({"dict": "INCAR", "action": {"_set": {"KGAMMA": True}}})
 
             else:
                 if vi["INCAR"].get("ISYM", 2) > 0:

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -208,7 +208,7 @@ class VaspErrorHandler(ErrorHandler):
                 self.error_count["brmix"] += 1
 
             elif self.error_count["brmix"] == 1 and vi["INCAR"].get("IMIX", 4) != 1:
-                # Use Kerker mixing w/default values for other parameters
+                # Use Kerker mixing w/ default values for other parameters
                 actions.append({"dict": "INCAR", "action": {"_set": {"IMIX": 1}}})
                 self.error_count["brmix"] += 1
 
@@ -227,18 +227,21 @@ class VaspErrorHandler(ErrorHandler):
                     actions.append({"dict": "INCAR", "action": {"_unset": {"IMIX": 1}}})
                 self.error_count["brmix"] += 1
 
-            elif self.error_count["brmix"] in [2, 3] and vi["KPOINTS"].style == Kpoints.supported_modes.Monkhorst:
-                actions.append(
-                    {
-                        "dict": "KPOINTS",
-                        "action": {"_set": {"generation_style": "Gamma"}},
-                    }
-                )
+            elif self.error_count["brmix"] in [2, 3]:
+                if vi["KPOINTS"] is not None and vi["KPOINTS"].style == Kpoints.supported_modes.Gamma:
+                    actions.append({"dict": "KPOINTS", "action": {"_set": {"generation_style": "Gamma"}}})
+                elif vi["INCAR"].get("KSPACING"):
+                    actions.append({"dict": "INCAR", "action": {"_set": {"KGAMMA": True}}})
+
                 if "IMIX" in vi["INCAR"]:
                     actions.append({"dict": "INCAR", "action": {"_unset": {"IMIX": 1}}})
                 self.error_count["brmix"] += 1
 
-                if vi["KPOINTS"].num_kpts < 1 and all(n % 2 == 0 for n in vi["KPOINTS"].kpts[0]):
+                if (
+                    vi["KPOINTS"] is not None
+                    and vi["KPOINTS"].num_kpts < 1
+                    and all(n % 2 == 0 for n in vi["KPOINTS"].kpts[0])
+                ):
                     new_kpts = (tuple(n + 1 for n in vi["KPOINTS"].kpts[0]),)
                     actions.append(
                         {
@@ -748,7 +751,7 @@ class StdErrHandler(ErrorHandler):
         if "kpoints_trans" in self.errors and self.error_count["kpoints_trans"] == 0:
             m = reduce(operator.mul, vi["KPOINTS"].kpts[0])
             m = max(int(round(m ** (1 / 3))), 1)
-            if vi["KPOINTS"].style.name.lower().startswith("m"):
+            if vi["KPOINTS"] is not None and vi["KPOINTS"].style.name.lower().startswith("m"):
                 m += m % 2
             actions.append({"dict": "KPOINTS", "action": {"_set": {"kpoints": [[m] * 3]}}})
             self.error_count["kpoints_trans"] += 1
@@ -978,7 +981,9 @@ class MeshSymmetryErrorHandler(ErrorHandler):
         # According to VASP admins, you can disregard this error
         # if symmetry is off
         # Also disregard if automatic KPOINT generation is used
-        if (not vi["INCAR"].get("ISYM", True)) or vi["KPOINTS"].style == Kpoints.supported_modes.Automatic:
+        if (not vi["INCAR"].get("ISYM", True)) or (
+            vi["KPOINTS"] is not None and vi["KPOINTS"].style == Kpoints.supported_modes.Automatic
+        ):
             return False
 
         try:
@@ -1000,7 +1005,7 @@ class MeshSymmetryErrorHandler(ErrorHandler):
         vi = VaspInput.from_directory(".")
         m = reduce(operator.mul, vi["KPOINTS"].kpts[0])
         m = max(int(round(m ** (1 / 3))), 1)
-        if vi["KPOINTS"].style.name.lower().startswith("m"):
+        if vi["KPOINTS"] is not None and vi["KPOINTS"].style.name.lower().startswith("m"):
             m += m % 2
         actions = [{"dict": "KPOINTS", "action": {"_set": {"kpoints": [[m] * 3]}}}]
         VaspModder(vi=vi).apply_actions(actions)


### PR DESCRIPTION
When running VASP with `INCAR` tag `kspacing` instead of a `KPOINTS` file and encountering `brmix` 2 or 3 times. Reported by @esoteric-ephemera in atomate2 r2SCAN workflow.

