### PR TITLE
Rewrite handler tests

### DIFF
--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -36,13 +36,14 @@ __date__ = "Jun 1, 2012"
 
 TEST_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "test_files")
 CWD = os.getcwd()
+os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
 
 
 def clean_dir():
-    for f in glob("error.*.tar.gz"):
-        os.remove(f)
-    for f in glob("custodian.chk.*.tar.gz"):
-        os.remove(f)
+    for file in glob("error.*.tar.gz"):
+        os.remove(file)
+    for file in glob("custodian.chk.*.tar.gz"):
+        os.remove(file)
 
 
 class VaspErrorHandlerTest(unittest.TestCase):
@@ -55,175 +56,175 @@ class VaspErrorHandlerTest(unittest.TestCase):
         shutil.copy("CHGCAR", "CHGCAR.orig")
 
     def test_frozen_job(self):
-        h = FrozenJobErrorHandler()
-        d = h.correct()
-        assert d["errors"] == ["Frozen job"]
+        handler = FrozenJobErrorHandler()
+        dct = handler.correct()
+        assert dct["errors"] == ["Frozen job"]
         assert Incar.from_file("INCAR")["ALGO"] == "Normal"
 
     def test_algotet(self):
         shutil.copy("INCAR.algo_tet_only", "INCAR")
-        h = VaspErrorHandler("vasp.algo_tet_only")
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["algo_tet"]
-        assert d["actions"] == [{"action": {"_set": {"ALGO": "Fast"}}, "dict": "INCAR"}]
-        assert h.error_count["algo_tet"] == 1
+        handler = VaspErrorHandler("vasp.algo_tet_only")
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["algo_tet"]
+        assert dct["actions"] == [{"action": {"_set": {"ALGO": "Fast"}}, "dict": "INCAR"}]
+        assert handler.error_count["algo_tet"] == 1
 
         # 2nd error should set ISMEAR to 0.
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["algo_tet"]
-        assert h.error_count["algo_tet"] == 2
-        assert d["actions"] == [{"action": {"_set": {"ISMEAR": 0, "SIGMA": 0.05}}, "dict": "INCAR"}]
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["algo_tet"]
+        assert handler.error_count["algo_tet"] == 2
+        assert dct["actions"] == [{"action": {"_set": {"ISMEAR": 0, "SIGMA": 0.05}}, "dict": "INCAR"}]
 
     def test_subspace(self):
-        h = VaspErrorHandler("vasp.subspace")
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["subspacematrix"]
-        assert d["actions"] == [{"action": {"_set": {"LREAL": False}}, "dict": "INCAR"}]
+        handler = VaspErrorHandler("vasp.subspace")
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["subspacematrix"]
+        assert dct["actions"] == [{"action": {"_set": {"LREAL": False}}, "dict": "INCAR"}]
 
         # 2nd error should set PREC to accurate.
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["subspacematrix"]
-        assert d["actions"] == [{"action": {"_set": {"PREC": "Accurate"}}, "dict": "INCAR"}]
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["subspacematrix"]
+        assert dct["actions"] == [{"action": {"_set": {"PREC": "Accurate"}}, "dict": "INCAR"}]
 
     def test_check_correct(self):
-        h = VaspErrorHandler("vasp.teterror")
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["tet"]
-        assert d["actions"] == [{"action": {"_set": {"kpoints": ((10, 2, 2),)}}, "dict": "KPOINTS"}]
+        handler = VaspErrorHandler("vasp.teterror")
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["tet"]
+        assert dct["actions"] == [{"action": {"_set": {"kpoints": ((10, 2, 2),)}}, "dict": "KPOINTS"}]
 
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["tet"]
-        assert d["actions"] == [{"action": {"_set": {"ISMEAR": 0, "SIGMA": 0.05}}, "dict": "INCAR"}]
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["tet"]
+        assert dct["actions"] == [{"action": {"_set": {"ISMEAR": 0, "SIGMA": 0.05}}, "dict": "INCAR"}]
 
-        h = VaspErrorHandler("vasp.teterror", errors_subset_to_catch=["eddrmm"])
-        assert not h.check()
+        handler = VaspErrorHandler("vasp.teterror", errors_subset_to_catch=["eddrmm"])
+        assert not handler.check()
 
-        h = VaspErrorHandler("vasp.sgrcon")
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["rot_matrix"]
-        assert {a["dict"] for a in d["actions"]} == {"KPOINTS"}
+        handler = VaspErrorHandler("vasp.sgrcon")
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["rot_matrix"]
+        assert {a["dict"] for a in dct["actions"]} == {"KPOINTS"}
 
-        h = VaspErrorHandler("vasp.real_optlay")
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["real_optlay"]
-        assert d["actions"] == [{"action": {"_set": {"LREAL": False}}, "dict": "INCAR"}]
+        handler = VaspErrorHandler("vasp.real_optlay")
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["real_optlay"]
+        assert dct["actions"] == [{"action": {"_set": {"LREAL": False}}, "dict": "INCAR"}]
 
     def test_mesh_symmetry(self):
-        h = MeshSymmetryErrorHandler("vasp.ibzkpt")
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["mesh_symmetry"]
-        assert d["actions"] == [{"action": {"_set": {"kpoints": [[4, 4, 4]]}}, "dict": "KPOINTS"}]
+        handler = MeshSymmetryErrorHandler("vasp.ibzkpt")
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["mesh_symmetry"]
+        assert dct["actions"] == [{"action": {"_set": {"kpoints": [[4, 4, 4]]}}, "dict": "KPOINTS"}]
 
     def test_brions(self):
         shutil.copy("INCAR.ibrion", "INCAR")
-        h = VaspErrorHandler("vasp.brions")
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["brions"]
-        i = Incar.from_file("INCAR")
-        assert i["IBRION"] == 1
-        assert i["POTIM"] == pytest.approx(1.5)
+        handler = VaspErrorHandler("vasp.brions")
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["brions"]
+        incar = Incar.from_file("INCAR")
+        assert incar["IBRION"] == 1
+        assert incar["POTIM"] == pytest.approx(1.5)
 
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["brions"]
-        i = Incar.from_file("INCAR")
-        assert i["IBRION"] == 2
-        assert i["POTIM"] == pytest.approx(0.5)
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["brions"]
+        incar = Incar.from_file("INCAR")
+        assert incar["IBRION"] == 2
+        assert incar["POTIM"] == pytest.approx(0.5)
 
     def test_dentet(self):
-        h = VaspErrorHandler("vasp.dentet")
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["dentet"]
-        assert d["actions"] == [{"action": {"_set": {"kpoints": ((10, 2, 2),)}}, "dict": "KPOINTS"}]
+        handler = VaspErrorHandler("vasp.dentet")
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["dentet"]
+        assert dct["actions"] == [{"action": {"_set": {"kpoints": ((10, 2, 2),)}}, "dict": "KPOINTS"}]
 
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["dentet"]
-        assert d["actions"] == [{"action": {"_set": {"ISMEAR": 0, "SIGMA": 0.05}}, "dict": "INCAR"}]
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["dentet"]
+        assert dct["actions"] == [{"action": {"_set": {"ISMEAR": 0, "SIGMA": 0.05}}, "dict": "INCAR"}]
 
     def test_zbrent(self):
-        h = VaspErrorHandler("vasp.zbrent")
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["zbrent"]
-        i = Incar.from_file("INCAR")
-        assert i["IBRION"] == 2
-        assert i["EDIFF"] == 1e-06
-        assert i["NELMIN"] == 8
+        handler = VaspErrorHandler("vasp.zbrent")
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["zbrent"]
+        incar = Incar.from_file("INCAR")
+        assert incar["IBRION"] == 2
+        assert incar["EDIFF"] == 1e-06
+        assert incar["NELMIN"] == 8
 
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["zbrent"]
-        i = Incar.from_file("INCAR")
-        assert i["IBRION"] == 1
-        assert i["EDIFF"] == 1e-07
-        assert i["NELMIN"] == 8
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["zbrent"]
+        incar = Incar.from_file("INCAR")
+        assert incar["IBRION"] == 1
+        assert incar["EDIFF"] == 1e-07
+        assert incar["NELMIN"] == 8
 
         shutil.copy("INCAR.orig", "INCAR")
-        h = VaspErrorHandler("vasp.zbrent")
-        h.vtst_fixes = True
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["zbrent"]
-        i = Incar.from_file("INCAR")
-        assert i["IBRION"] == 3
-        assert i["IOPT"] == 7
-        assert i["POTIM"] == 0
-        assert i["EDIFF"] == 1e-06
-        assert i["NELMIN"] == 8
+        handler = VaspErrorHandler("vasp.zbrent")
+        handler.vtst_fixes = True
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["zbrent"]
+        incar = Incar.from_file("INCAR")
+        assert incar["IBRION"] == 3
+        assert incar["IOPT"] == 7
+        assert incar["POTIM"] == 0
+        assert incar["EDIFF"] == 1e-06
+        assert incar["NELMIN"] == 8
 
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["zbrent"]
-        i = Incar.from_file("INCAR")
-        assert i["IBRION"] == 3
-        assert i["IOPT"] == 7
-        assert i["POTIM"] == 0
-        assert i["EDIFF"] == 1e-07
-        assert i["NELMIN"] == 8
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["zbrent"]
+        incar = Incar.from_file("INCAR")
+        assert incar["IBRION"] == 3
+        assert incar["IOPT"] == 7
+        assert incar["POTIM"] == 0
+        assert incar["EDIFF"] == 1e-07
+        assert incar["NELMIN"] == 8
 
         shutil.copy("INCAR.ediff", "INCAR")
-        h = VaspErrorHandler("vasp.zbrent")
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["zbrent"]
-        i = Incar.from_file("INCAR")
-        assert i["IBRION"] == 2
-        assert i["EDIFF"] == 1e-07
-        assert i["NELMIN"] == 8
+        handler = VaspErrorHandler("vasp.zbrent")
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["zbrent"]
+        incar = Incar.from_file("INCAR")
+        assert incar["IBRION"] == 2
+        assert incar["EDIFF"] == 1e-07
+        assert incar["NELMIN"] == 8
 
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["zbrent"]
-        i = Incar.from_file("INCAR")
-        assert i["IBRION"] == 1
-        assert i["EDIFF"] == 1e-08
-        assert i["NELMIN"] == 8
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["zbrent"]
+        incar = Incar.from_file("INCAR")
+        assert incar["IBRION"] == 1
+        assert incar["EDIFF"] == 1e-08
+        assert incar["NELMIN"] == 8
 
     def test_brmix(self):
-        h = VaspErrorHandler("vasp.brmix")
-        assert h.check() is True
+        handler = VaspErrorHandler("vasp.brmix")
+        assert handler.check() is True
 
         # The first (no good OUTCAR) correction, check IMIX
-        d = h.correct()
-        assert d["errors"] == ["brmix"]
+        dct = handler.correct()
+        assert dct["errors"] == ["brmix"]
         vi = VaspInput.from_directory(".")
         assert vi["INCAR"]["IMIX"] == 1
         assert os.path.exists("CHGCAR")
 
         # The next correction check Gamma and evenize
-        h.correct()
+        handler.correct()
         vi = VaspInput.from_directory(".")
         assert "IMIX" not in vi["INCAR"]
         assert os.path.exists("CHGCAR")
@@ -232,278 +233,277 @@ class VaspErrorHandlerTest(unittest.TestCase):
             assert not all_kpts_even
 
         # The next correction check ISYM and no CHGCAR
-        h.correct()
+        handler.correct()
         vi = VaspInput.from_directory(".")
         assert vi["INCAR"]["ISYM"] == 0
         assert not os.path.exists("CHGCAR")
 
         shutil.copy("INCAR.nelect", "INCAR")
-        h = VaspErrorHandler("vasp.brmix")
-        assert h.check() is False
-        d = h.correct()
-        assert d["errors"] == []
+        handler = VaspErrorHandler("vasp.brmix")
+        assert handler.check() is False
+        dct = handler.correct()
+        assert dct["errors"] == []
 
     def test_too_few_bands(self):
         os.chdir(os.path.join(TEST_DIR, "too_few_bands"))
         shutil.copy("INCAR", "INCAR.orig")
-        h = VaspErrorHandler("vasp.too_few_bands")
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["too_few_bands"]
-        assert d["actions"] == [{"action": {"_set": {"NBANDS": 501}}, "dict": "INCAR"}]
+        handler = VaspErrorHandler("vasp.too_few_bands")
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["too_few_bands"]
+        assert dct["actions"] == [{"action": {"_set": {"NBANDS": 501}}, "dict": "INCAR"}]
         clean_dir()
         shutil.move("INCAR.orig", "INCAR")
         os.chdir(TEST_DIR)
 
     def test_rot_matrix(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
         subdir = os.path.join(TEST_DIR, "poscar_error")
         os.chdir(subdir)
         shutil.copy("KPOINTS", "KPOINTS.orig")
-        h = VaspErrorHandler()
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["rot_matrix"]
+        handler = VaspErrorHandler()
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["rot_matrix"]
         os.remove(os.path.join(subdir, "error.1.tar.gz"))
         shutil.copy("KPOINTS.orig", "KPOINTS")
         os.remove("KPOINTS.orig")
 
     def test_rot_matrix_vasp6(self):
-        h = VaspErrorHandler("vasp6.sgrcon")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["rot_matrix"]
+        handler = VaspErrorHandler("vasp6.sgrcon")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["rot_matrix"]
 
     def test_coef(self):
-        h = VaspErrorHandler("vasp6.coef")
-        h.check()
-        d = h.correct()
-        assert d["actions"] == [{"file": "WAVECAR", "action": {"_file_delete": {"mode": "actual"}}}]
+        handler = VaspErrorHandler("vasp6.coef")
+        handler.check()
+        dct = handler.correct()
+        assert dct["actions"] == [{"file": "WAVECAR", "action": {"_file_delete": {"mode": "actual"}}}]
 
-        h = VaspErrorHandler("vasp6.coef2")
-        h.check()
-        d = h.correct()
-        assert d["actions"] == [{"file": "WAVECAR", "action": {"_file_delete": {"mode": "actual"}}}]
+        handler = VaspErrorHandler("vasp6.coef2")
+        handler.check()
+        dct = handler.correct()
+        assert dct["actions"] == [{"file": "WAVECAR", "action": {"_file_delete": {"mode": "actual"}}}]
 
     def test_to_from_dict(self):
-        h = VaspErrorHandler("random_name")
-        h2 = VaspErrorHandler.from_dict(h.as_dict())
-        assert type(h2) == type(h)
+        handler = VaspErrorHandler("random_name")
+        h2 = VaspErrorHandler.from_dict(handler.as_dict())
+        assert type(h2) == type(handler)
         assert h2.output_filename == "random_name"
 
     def test_pssyevx(self):
-        h = VaspErrorHandler("vasp.pssyevx")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["pssyevx"]
-        i = Incar.from_file("INCAR")
-        assert i["ALGO"] == "Normal"
+        handler = VaspErrorHandler("vasp.pssyevx")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["pssyevx"]
+        incar = Incar.from_file("INCAR")
+        assert incar["ALGO"] == "Normal"
 
     def test_eddrmm(self):
         shutil.copy("CONTCAR.eddav_eddrmm", "CONTCAR")
-        h = VaspErrorHandler("vasp.eddrmm")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["eddrmm"]
-        i = Incar.from_file("INCAR")
-        assert i["ALGO"] == "Normal"
-        assert h.correct()["errors"] == ["eddrmm"]
-        i = Incar.from_file("INCAR")
-        assert i["POTIM"] == 0.25
+        handler = VaspErrorHandler("vasp.eddrmm")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["eddrmm"]
+        incar = Incar.from_file("INCAR")
+        assert incar["ALGO"] == "Normal"
+        assert handler.correct()["errors"] == ["eddrmm"]
+        incar = Incar.from_file("INCAR")
+        assert incar["POTIM"] == 0.25
         p = Structure.from_file("POSCAR")
         c = Structure.from_file("CONTCAR")
         assert p == c
 
     def test_nicht_konv(self):
-        h = VaspErrorHandler("vasp.nicht_konvergent")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["nicht_konv"]
-        i = Incar.from_file("INCAR")
-        assert i["LREAL"] is False
+        handler = VaspErrorHandler("vasp.nicht_konvergent")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["nicht_konv"]
+        incar = Incar.from_file("INCAR")
+        assert incar["LREAL"] is False
 
     def test_edddav(self):
         shutil.copy("CONTCAR.eddav_eddrmm", "CONTCAR")
-        h = VaspErrorHandler("vasp.edddav2")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["edddav"]
-        i = Incar.from_file("INCAR")
-        assert i["NCORE"] == 2
+        handler = VaspErrorHandler("vasp.edddav2")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["edddav"]
+        incar = Incar.from_file("INCAR")
+        assert incar["NCORE"] == 2
         p = Structure.from_file("POSCAR")
         c = Structure.from_file("CONTCAR")
         assert p == c
 
-        h = VaspErrorHandler("vasp.edddav")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["edddav"]
+        handler = VaspErrorHandler("vasp.edddav")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["edddav"]
         assert not os.path.exists("CHGCAR")
         p = Structure.from_file("POSCAR")
         c = Structure.from_file("CONTCAR")
         assert p == c
 
     def test_gradient_not_orthogonal(self):
-        h = VaspErrorHandler("vasp.gradient_not_orthogonal")
-        assert h.check() is True
-        assert "grad_not_orth" in h.correct()["errors"]
-        i = Incar.from_file("INCAR")
-        assert i["ALGO"] == "Fast"
+        handler = VaspErrorHandler("vasp.gradient_not_orthogonal")
+        assert handler.check() is True
+        assert "grad_not_orth" in handler.correct()["errors"]
+        incar = Incar.from_file("INCAR")
+        assert incar["ALGO"] == "Fast"
 
         shutil.copy("INCAR.gga_all", "INCAR")
-        h = VaspErrorHandler("vasp.gradient_not_orthogonal")
-        assert h.check() is True
-        assert "grad_not_orth" in h.correct()["errors"]
-        i = Incar.from_file("INCAR")
-        assert i["ALGO"] == "Fast"
+        handler = VaspErrorHandler("vasp.gradient_not_orthogonal")
+        assert handler.check() is True
+        assert "grad_not_orth" in handler.correct()["errors"]
+        incar = Incar.from_file("INCAR")
+        assert incar["ALGO"] == "Fast"
 
         shutil.copy("INCAR.gga_ialgo53", "INCAR")
-        h = VaspErrorHandler("vasp.gradient_not_orthogonal")
-        assert h.check() is True
-        assert "grad_not_orth" in h.correct()["errors"]
-        i = Incar.from_file("INCAR")
-        assert i["ALGO"] == "Fast"
-        assert "IALGO" not in i
+        handler = VaspErrorHandler("vasp.gradient_not_orthogonal")
+        assert handler.check() is True
+        assert "grad_not_orth" in handler.correct()["errors"]
+        incar = Incar.from_file("INCAR")
+        assert incar["ALGO"] == "Fast"
+        assert "IALGO" not in incar
 
         shutil.copy("INCAR.hybrid_normal", "INCAR")
-        h = VaspErrorHandler("vasp.gradient_not_orthogonal")
-        assert h.check() is True
-        assert "grad_not_orth" in h.correct()["errors"]
-        i = Incar.from_file("INCAR")
-        assert i["ALGO"] == "Normal"
+        handler = VaspErrorHandler("vasp.gradient_not_orthogonal")
+        assert handler.check() is True
+        assert "grad_not_orth" in handler.correct()["errors"]
+        incar = Incar.from_file("INCAR")
+        assert incar["ALGO"] == "Normal"
 
         shutil.copy("INCAR.hybrid_all", "INCAR")
-        h = VaspErrorHandler("vasp.gradient_not_orthogonal")
-        assert h.check() is True
-        assert "grad_not_orth" in h.correct()["errors"]
-        i = Incar.from_file("INCAR")
-        assert i["ALGO"] == "All"
+        handler = VaspErrorHandler("vasp.gradient_not_orthogonal")
+        assert handler.check() is True
+        assert "grad_not_orth" in handler.correct()["errors"]
+        incar = Incar.from_file("INCAR")
+        assert incar["ALGO"] == "All"
 
         shutil.copy("INCAR.metagga_all", "INCAR")
-        h = VaspErrorHandler("vasp.gradient_not_orthogonal")
-        assert h.check() is True
-        assert "grad_not_orth" in h.correct()["errors"]
-        i = Incar.from_file("INCAR")
-        assert i["ALGO"] == "All"
+        handler = VaspErrorHandler("vasp.gradient_not_orthogonal")
+        assert handler.check() is True
+        assert "grad_not_orth" in handler.correct()["errors"]
+        incar = Incar.from_file("INCAR")
+        assert incar["ALGO"] == "All"
 
     def test_rhosyg(self):
-        h = VaspErrorHandler("vasp.rhosyg")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["rhosyg"]
-        i = Incar.from_file("INCAR")
-        assert i["SYMPREC"] == 0.0001
-        assert h.correct()["errors"] == ["rhosyg"]
-        i = Incar.from_file("INCAR")
-        assert i["ISYM"] == 0
+        handler = VaspErrorHandler("vasp.rhosyg")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["rhosyg"]
+        incar = Incar.from_file("INCAR")
+        assert incar["SYMPREC"] == 0.0001
+        assert handler.correct()["errors"] == ["rhosyg"]
+        incar = Incar.from_file("INCAR")
+        assert incar["ISYM"] == 0
 
     def test_rhosyg_vasp6(self):
-        h = VaspErrorHandler("vasp6.rhosyg")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["rhosyg"]
-        i = Incar.from_file("INCAR")
-        assert i["SYMPREC"] == 0.0001
-        assert h.correct()["errors"] == ["rhosyg"]
-        i = Incar.from_file("INCAR")
-        assert i["ISYM"] == 0
+        handler = VaspErrorHandler("vasp6.rhosyg")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["rhosyg"]
+        incar = Incar.from_file("INCAR")
+        assert incar["SYMPREC"] == 0.0001
+        assert handler.correct()["errors"] == ["rhosyg"]
+        incar = Incar.from_file("INCAR")
+        assert incar["ISYM"] == 0
 
     def test_hnform(self):
-        h = VaspErrorHandler("vasp.hnform")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["hnform"]
-        i = Incar.from_file("INCAR")
-        assert i["ISYM"] == 0
+        handler = VaspErrorHandler("vasp.hnform")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["hnform"]
+        incar = Incar.from_file("INCAR")
+        assert incar["ISYM"] == 0
 
     def test_bravais(self):
-        h = VaspErrorHandler("vasp6.bravais")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["bravais"]
-        i = Incar.from_file("INCAR")
-        assert i["SYMPREC"] == 0.0001
+        handler = VaspErrorHandler("vasp6.bravais")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["bravais"]
+        incar = Incar.from_file("INCAR")
+        assert incar["SYMPREC"] == 0.0001
 
         shutil.copy("INCAR.symprec", "INCAR")
-        h = VaspErrorHandler("vasp6.bravais")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["bravais"]
-        i = Incar.from_file("INCAR")
-        assert i["SYMPREC"] == 1e-6
+        handler = VaspErrorHandler("vasp6.bravais")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["bravais"]
+        incar = Incar.from_file("INCAR")
+        assert incar["SYMPREC"] == 1e-6
 
     def test_posmap(self):
-        h = VaspErrorHandler("vasp.posmap")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["posmap"]
-        i = Incar.from_file("INCAR")
-        assert i["SYMPREC"] == pytest.approx(1e-6)
+        handler = VaspErrorHandler("vasp.posmap")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["posmap"]
+        incar = Incar.from_file("INCAR")
+        assert incar["SYMPREC"] == pytest.approx(1e-6)
 
-        assert h.check() is True
-        assert h.correct()["errors"] == ["posmap"]
-        i = Incar.from_file("INCAR")
-        assert i["SYMPREC"] == pytest.approx(1e-4)
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["posmap"]
+        incar = Incar.from_file("INCAR")
+        assert incar["SYMPREC"] == pytest.approx(1e-4)
 
     def test_posmap_vasp6(self):
-        h = VaspErrorHandler("vasp6.posmap")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["posmap"]
-        i = Incar.from_file("INCAR")
-        assert i["SYMPREC"] == pytest.approx(1e-6)
+        handler = VaspErrorHandler("vasp6.posmap")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["posmap"]
+        incar = Incar.from_file("INCAR")
+        assert incar["SYMPREC"] == pytest.approx(1e-6)
 
-        assert h.check() is True
-        assert h.correct()["errors"] == ["posmap"]
-        i = Incar.from_file("INCAR")
-        assert i["SYMPREC"] == pytest.approx(1e-4)
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["posmap"]
+        incar = Incar.from_file("INCAR")
+        assert incar["SYMPREC"] == pytest.approx(1e-4)
 
     def test_point_group(self):
-        h = VaspErrorHandler("vasp.point_group")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["point_group"]
-        i = Incar.from_file("INCAR")
-        assert i["ISYM"] == 0
+        handler = VaspErrorHandler("vasp.point_group")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["point_group"]
+        incar = Incar.from_file("INCAR")
+        assert incar["ISYM"] == 0
 
     def test_symprec_noise(self):
-        h = VaspErrorHandler("vasp.symprec_noise")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["symprec_noise"]
-        i = Incar.from_file("INCAR")
-        assert i["SYMPREC"] == 1e-06
+        handler = VaspErrorHandler("vasp.symprec_noise")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["symprec_noise"]
+        incar = Incar.from_file("INCAR")
+        assert incar["SYMPREC"] == 1e-06
 
     def test_dfpt_ncore(self):
-        h = VaspErrorHandler("vasp.dfpt_ncore")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["dfpt_ncore"]
+        handler = VaspErrorHandler("vasp.dfpt_ncore")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["dfpt_ncore"]
         incar = Incar.from_file("INCAR")
         assert "NPAR" not in incar
         assert "NCORE" not in incar
 
     def test_finite_difference_ncore(self):
-        h = VaspErrorHandler("vasp.fd_ncore")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["dfpt_ncore"]
+        handler = VaspErrorHandler("vasp.fd_ncore")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["dfpt_ncore"]
         incar = Incar.from_file("INCAR")
         assert "NPAR" not in incar
         assert "NCORE" not in incar
 
     def test_point_group_vasp6(self):
         # the error message is formatted differently in VASP6 compared to VASP5
-        h = VaspErrorHandler("vasp6.point_group")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["point_group"]
-        i = Incar.from_file("INCAR")
-        assert i["ISYM"] == 0
+        handler = VaspErrorHandler("vasp6.point_group")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["point_group"]
+        incar = Incar.from_file("INCAR")
+        assert incar["ISYM"] == 0
 
     def test_inv_rot_matrix_vasp6(self):
         # the error message is formatted differently in VASP6 compared to VASP5
-        h = VaspErrorHandler("vasp6.inv_rot_mat")
-        assert h.check() is True
-        assert h.correct()["errors"] == ["inv_rot_mat"]
-        i = Incar.from_file("INCAR")
-        assert i["SYMPREC"] == 1e-08
+        handler = VaspErrorHandler("vasp6.inv_rot_mat")
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["inv_rot_mat"]
+        incar = Incar.from_file("INCAR")
+        assert incar["SYMPREC"] == 1e-08
 
     def test_bzint_vasp6(self):
         # the BZINT error message is formatted differently in VASP6 compared to VASP5
-        h = VaspErrorHandler("vasp6.bzint")
-        assert h.check() is True
-        d = h.correct()
-        assert d["errors"] == ["tet"]
+        handler = VaspErrorHandler("vasp6.bzint")
+        assert handler.check() is True
+        dct = handler.correct()
+        assert dct["errors"] == ["tet"]
         incar = Incar.from_file("INCAR")
         assert incar["ISMEAR"] == -5
         assert incar["SIGMA"] == 0.05
-        assert d["actions"] == [{"action": {"_set": {"kpoints": ((10, 2, 2),)}}, "dict": "KPOINTS"}]
+        assert dct["actions"] == [{"action": {"_set": {"kpoints": ((10, 2, 2),)}}, "dict": "KPOINTS"}]
 
-        assert h.check() is True
-        assert h.correct()["errors"] == ["tet"]
+        assert handler.check() is True
+        assert handler.correct()["errors"] == ["tet"]
         incar = Incar.from_file("INCAR")
         assert incar["ISMEAR"] == 0
         assert incar["SIGMA"] == 0.05
@@ -511,42 +511,44 @@ class VaspErrorHandlerTest(unittest.TestCase):
     def test_too_large_kspacing(self):
         shutil.copy("INCAR.kspacing", "INCAR")
         vi = VaspInput.from_directory(".")
-        h = VaspErrorHandler("vasp.teterror")
-        h.check()
-        d = h.correct()
-        assert d["errors"] == ["tet"]
-        assert d["actions"] == [{"action": {"_set": {"KSPACING": vi["INCAR"].get("KSPACING") * 0.8}}, "dict": "INCAR"}]
+        handler = VaspErrorHandler("vasp.teterror")
+        handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["tet"]
+        assert dct["actions"] == [
+            {"action": {"_set": {"KSPACING": vi["INCAR"].get("KSPACING") * 0.8}}, "dict": "INCAR"}
+        ]
 
     def test_nbands_not_sufficient(self):
-        h = VaspErrorHandler("vasp.nbands_not_sufficient")
-        assert h.check() is True
-        d = h.correct()
-        assert d["errors"] == ["nbands_not_sufficient"]
-        assert d["actions"] is None
+        handler = VaspErrorHandler("vasp.nbands_not_sufficient")
+        assert handler.check() is True
+        dct = handler.correct()
+        assert dct["errors"] == ["nbands_not_sufficient"]
+        assert dct["actions"] is None
 
     def test_too_few_bands_round_error(self):
         # originally there are NBANDS= 7
         # correction should increase it
         shutil.copy("INCAR.too_few_bands_round_error", "INCAR")
-        h = VaspErrorHandler("vasp.too_few_bands_round_error")
-        assert h.check() is True
-        d = h.correct()
-        assert d["errors"] == ["too_few_bands"]
-        assert d["actions"] == [{"dict": "INCAR", "action": {"_set": {"NBANDS": 8}}}]
+        handler = VaspErrorHandler("vasp.too_few_bands_round_error")
+        assert handler.check() is True
+        dct = handler.correct()
+        assert dct["errors"] == ["too_few_bands"]
+        assert dct["actions"] == [{"dict": "INCAR", "action": {"_set": {"NBANDS": 8}}}]
 
     def test_set_core_wf(self):
-        h = VaspErrorHandler("vasp.set_core_wf")
-        assert h.check() is True
-        d = h.correct()
-        assert d["errors"] == ["set_core_wf"]
-        assert d["actions"] is None
+        handler = VaspErrorHandler("vasp.set_core_wf")
+        assert handler.check() is True
+        dct = handler.correct()
+        assert dct["errors"] == ["set_core_wf"]
+        assert dct["actions"] is None
 
     def test_read_error(self):
-        h = VaspErrorHandler("vasp.read_error")
-        assert h.check() is True
-        d = h.correct()
-        assert d["errors"] == ["read_error"]
-        assert d["actions"] is None
+        handler = VaspErrorHandler("vasp.read_error")
+        assert handler.check() is True
+        dct = handler.correct()
+        assert dct["errors"] == ["read_error"]
+        assert dct["actions"] is None
 
     def tearDown(self):
         os.chdir(TEST_DIR)
@@ -560,7 +562,6 @@ class VaspErrorHandlerTest(unittest.TestCase):
 
 class AliasingErrorHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
         os.chdir(TEST_DIR)
         shutil.copy("INCAR", "INCAR.orig")
         shutil.copy("KPOINTS", "KPOINTS.orig")
@@ -570,15 +571,15 @@ class AliasingErrorHandlerTest(unittest.TestCase):
     def test_aliasing(self):
         os.chdir(os.path.join(TEST_DIR, "aliasing"))
         shutil.copy("INCAR", "INCAR.orig")
-        h = AliasingErrorHandler("vasp.aliasing")
-        h.check()
-        d = h.correct()
+        handler = AliasingErrorHandler("vasp.aliasing")
+        handler.check()
+        dct = handler.correct()
         shutil.move("INCAR.orig", "INCAR")
         clean_dir()
         os.chdir(TEST_DIR)
 
-        assert d["errors"] == ["aliasing"]
-        assert d["actions"] == [
+        assert dct["errors"] == ["aliasing"]
+        assert dct["actions"] == [
             {"action": {"_set": {"NGX": 34}}, "dict": "INCAR"},
             {"file": "CHGCAR", "action": {"_file_delete": {"mode": "actual"}}},
             {"file": "WAVECAR", "action": {"_file_delete": {"mode": "actual"}}},
@@ -587,12 +588,12 @@ class AliasingErrorHandlerTest(unittest.TestCase):
     def test_aliasing_incar(self):
         os.chdir(os.path.join(TEST_DIR, "aliasing"))
         shutil.copy("INCAR", "INCAR.orig")
-        h = AliasingErrorHandler("vasp.aliasing_incar")
-        h.check()
-        d = h.correct()
+        handler = AliasingErrorHandler("vasp.aliasing_incar")
+        handler.check()
+        dct = handler.correct()
 
-        assert d["errors"] == ["aliasing_incar"]
-        assert d["actions"] == [
+        assert dct["errors"] == ["aliasing_incar"]
+        assert dct["actions"] == [
             {"action": {"_unset": {"NGY": 1, "NGZ": 1}}, "dict": "INCAR"},
             {"file": "CHGCAR", "action": {"_file_delete": {"mode": "actual"}}},
             {"file": "WAVECAR", "action": {"_file_delete": {"mode": "actual"}}},
@@ -601,9 +602,9 @@ class AliasingErrorHandlerTest(unittest.TestCase):
         incar = Incar.from_file("INCAR.orig")
         incar["ICHARG"] = 10
         incar.write_file("INCAR")
-        d = h.correct()
-        assert d["errors"] == ["aliasing_incar"]
-        assert d["actions"] == [{"action": {"_unset": {"NGY": 1, "NGZ": 1}}, "dict": "INCAR"}]
+        dct = handler.correct()
+        assert dct["errors"] == ["aliasing_incar"]
+        assert dct["actions"] == [{"action": {"_unset": {"NGY": 1, "NGZ": 1}}, "dict": "INCAR"}]
 
         shutil.move("INCAR.orig", "INCAR")
         clean_dir()
@@ -621,7 +622,6 @@ class AliasingErrorHandlerTest(unittest.TestCase):
 
 class UnconvergedErrorHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
         os.chdir(TEST_DIR)
         subdir = os.path.join(TEST_DIR, "unconverged")
         os.chdir(subdir)
@@ -633,99 +633,102 @@ class UnconvergedErrorHandlerTest(unittest.TestCase):
 
     def test_check_correct_electronic(self):
         shutil.copy("vasprun.xml.electronic", "vasprun.xml")
-        h = UnconvergedErrorHandler()
-        assert h.check()
-        d = h.correct()
-        assert d["errors"] == ["Unconverged"]
-        assert d == {"actions": [{"action": {"_set": {"ALGO": "Normal"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
+        handler = UnconvergedErrorHandler()
+        assert handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["Unconverged"]
+        assert dct == {
+            "actions": [{"action": {"_set": {"ALGO": "Normal"}}, "dict": "INCAR"}],
+            "errors": ["Unconverged"],
+        }
         os.remove("vasprun.xml")
 
         shutil.copy("vasprun.xml.electronic_veryfast", "vasprun.xml")
-        h = UnconvergedErrorHandler()
-        assert h.check()
-        d = h.correct()
-        assert d["errors"] == ["Unconverged"]
-        assert d == {"actions": [{"action": {"_set": {"ALGO": "Fast"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
+        handler = UnconvergedErrorHandler()
+        assert handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["Unconverged"]
+        assert dct == {"actions": [{"action": {"_set": {"ALGO": "Fast"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
         os.remove("vasprun.xml")
 
         shutil.copy("vasprun.xml.electronic_normal", "vasprun.xml")
-        h = UnconvergedErrorHandler()
-        assert h.check()
-        d = h.correct()
-        assert d["errors"] == ["Unconverged"]
-        assert d == {"actions": [{"action": {"_set": {"ALGO": "All"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
+        handler = UnconvergedErrorHandler()
+        assert handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["Unconverged"]
+        assert dct == {"actions": [{"action": {"_set": {"ALGO": "All"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
         os.remove("vasprun.xml")
 
         shutil.copy("vasprun.xml.electronic_metagga_fast", "vasprun.xml")
-        h = UnconvergedErrorHandler()
-        assert h.check()
-        d = h.correct()
-        assert d["errors"] == ["Unconverged"]
-        assert d == {"actions": [{"action": {"_set": {"ALGO": "All"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
+        handler = UnconvergedErrorHandler()
+        assert handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["Unconverged"]
+        assert dct == {"actions": [{"action": {"_set": {"ALGO": "All"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
         os.remove("vasprun.xml")
 
         shutil.copy("vasprun.xml.electronic_hybrid_fast", "vasprun.xml")
-        h = UnconvergedErrorHandler()
-        assert h.check()
-        d = h.correct()
-        assert d["errors"] == ["Unconverged"]
-        assert d == {"actions": [{"action": {"_set": {"ALGO": "All"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
+        handler = UnconvergedErrorHandler()
+        assert handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["Unconverged"]
+        assert dct == {"actions": [{"action": {"_set": {"ALGO": "All"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
         os.remove("vasprun.xml")
 
         shutil.copy("vasprun.xml.electronic_hybrid_all", "vasprun.xml")
-        h = UnconvergedErrorHandler()
-        assert h.check()
-        d = h.correct()
-        assert d["errors"] == ["Unconverged"]
-        assert [{"dict": "INCAR", "action": {"_set": {"ALGO": "Damped", "TIME": 0.5}}}] == d["actions"]
+        handler = UnconvergedErrorHandler()
+        assert handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["Unconverged"]
+        assert [{"dict": "INCAR", "action": {"_set": {"ALGO": "Damped", "TIME": 0.5}}}] == dct["actions"]
         os.remove("vasprun.xml")
 
     def test_check_correct_electronic_repeat(self):
         shutil.copy("vasprun.xml.electronic2", "vasprun.xml")
-        h = UnconvergedErrorHandler()
-        assert h.check()
-        d = h.correct()
-        assert d == {"actions": [{"action": {"_set": {"ALGO": "All"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
+        handler = UnconvergedErrorHandler()
+        assert handler.check()
+        dct = handler.correct()
+        assert dct == {"actions": [{"action": {"_set": {"ALGO": "All"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
         os.remove("vasprun.xml")
 
     def test_check_correct_ionic(self):
         shutil.copy("vasprun.xml.ionic", "vasprun.xml")
-        h = UnconvergedErrorHandler()
-        assert h.check()
-        d = h.correct()
-        assert d["errors"] == ["Unconverged"]
+        handler = UnconvergedErrorHandler()
+        assert handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["Unconverged"]
         os.remove("vasprun.xml")
 
     def test_check_correct_scan(self):
         shutil.copy("vasprun.xml.scan", "vasprun.xml")
-        h = UnconvergedErrorHandler()
-        assert h.check()
-        d = h.correct()
-        assert d["errors"] == ["Unconverged"]
-        assert {"dict": "INCAR", "action": {"_set": {"ALGO": "All"}}} in d["actions"]
+        handler = UnconvergedErrorHandler()
+        assert handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["Unconverged"]
+        assert {"dict": "INCAR", "action": {"_set": {"ALGO": "All"}}} in dct["actions"]
         os.remove("vasprun.xml")
 
     def test_amin(self):
         shutil.copy("vasprun.xml.electronic_amin", "vasprun.xml")
-        h = UnconvergedErrorHandler()
-        assert h.check()
-        d = h.correct()
-        assert [{"dict": "INCAR", "action": {"_set": {"AMIN": 0.01}}}] == d["actions"]
+        handler = UnconvergedErrorHandler()
+        assert handler.check()
+        dct = handler.correct()
+        assert [{"dict": "INCAR", "action": {"_set": {"AMIN": 0.01}}}] == dct["actions"]
         os.remove("vasprun.xml")
 
     def test_to_from_dict(self):
-        h = UnconvergedErrorHandler("random_name.xml")
-        h2 = UnconvergedErrorHandler.from_dict(h.as_dict())
+        handler = UnconvergedErrorHandler("random_name.xml")
+        h2 = UnconvergedErrorHandler.from_dict(handler.as_dict())
         assert type(h2) == UnconvergedErrorHandler
         assert h2.output_filename == "random_name.xml"
 
     def test_correct_normal_with_condition(self):
         shutil.copy("vasprun.xml.electronic_normal", "vasprun.xml")  # Reuse an existing file
-        h = UnconvergedErrorHandler()
-        assert h.check()
-        d = h.correct()
-        assert d["errors"] == ["Unconverged"]
-        assert d == {"actions": [{"action": {"_set": {"ALGO": "All"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
+        handler = UnconvergedErrorHandler()
+        assert handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["Unconverged"]
+        assert dct == {"actions": [{"action": {"_set": {"ALGO": "All"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
         os.remove("vasprun.xml")
 
     @classmethod
@@ -740,7 +743,6 @@ class UnconvergedErrorHandlerTest(unittest.TestCase):
 
 class IncorrectSmearingHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
         os.chdir(TEST_DIR)
         subdir = os.path.join(TEST_DIR, "scan_metal")
         os.chdir(subdir)
@@ -749,10 +751,10 @@ class IncorrectSmearingHandlerTest(unittest.TestCase):
         shutil.copy("vasprun.xml", "vasprun.xml.orig")
 
     def test_check_correct_scan_metal(self):
-        h = IncorrectSmearingHandler()
-        assert h.check()
-        d = h.correct()
-        assert d["errors"] == ["IncorrectSmearing"]
+        handler = IncorrectSmearingHandler()
+        assert handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["IncorrectSmearing"]
         assert Incar.from_file("INCAR")["ISMEAR"] == 2
         assert Incar.from_file("INCAR")["SIGMA"] == 0.2
         os.remove("vasprun.xml")
@@ -767,7 +769,6 @@ class IncorrectSmearingHandlerTest(unittest.TestCase):
 
 class IncorrectSmearingHandlerStaticTest(unittest.TestCase):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
         os.chdir(TEST_DIR)
         subdir = os.path.join(TEST_DIR, "static_smearing")
         os.chdir(subdir)
@@ -776,8 +777,8 @@ class IncorrectSmearingHandlerStaticTest(unittest.TestCase):
         shutil.copy("vasprun.xml", "vasprun.xml.orig")
 
     def test_check_correct_scan_metal(self):
-        h = IncorrectSmearingHandler()
-        assert not h.check()
+        handler = IncorrectSmearingHandler()
+        assert not handler.check()
 
     def tearDown(self):
         shutil.move("INCAR.orig", "INCAR")
@@ -788,7 +789,6 @@ class IncorrectSmearingHandlerStaticTest(unittest.TestCase):
 
 class IncorrectSmearingHandlerFermiTest(unittest.TestCase):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
         os.chdir(TEST_DIR)
         subdir = os.path.join(TEST_DIR, "fermi_smearing")
         os.chdir(subdir)
@@ -797,8 +797,8 @@ class IncorrectSmearingHandlerFermiTest(unittest.TestCase):
         shutil.copy("vasprun.xml", "vasprun.xml.orig")
 
     def test_check_correct_scan_metal(self):
-        h = IncorrectSmearingHandler()
-        assert not h.check()
+        handler = IncorrectSmearingHandler()
+        assert not handler.check()
 
     def tearDown(self):
         shutil.move("INCAR.orig", "INCAR")
@@ -809,7 +809,6 @@ class IncorrectSmearingHandlerFermiTest(unittest.TestCase):
 
 class KspacingMetalHandlerTest(PymatgenTest):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
         os.chdir(TEST_DIR)
         subdir = os.path.join(TEST_DIR, "scan_metal")
         os.chdir(subdir)
@@ -818,10 +817,10 @@ class KspacingMetalHandlerTest(PymatgenTest):
         shutil.copy("vasprun.xml", "vasprun.xml.orig")
 
     def test_check_correct_scan_metal(self):
-        h = KspacingMetalHandler()
-        assert h.check()
-        d = h.correct()
-        assert d["errors"] == ["ScanMetal"]
+        handler = KspacingMetalHandler()
+        assert handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["ScanMetal"]
         assert Incar.from_file("INCAR")["KSPACING"] == 0.22
         os.remove("vasprun.xml")
 
@@ -829,8 +828,8 @@ class KspacingMetalHandlerTest(PymatgenTest):
         os.chdir(TEST_DIR)
         shutil.copy("INCAR", f"{self.tmp_path}/INCAR")
         shutil.copy("vasprun.xml", f"{self.tmp_path}/vasprun.xml")
-        h = KspacingMetalHandler(output_filename=f"{self.tmp_path}/vasprun.xml")
-        assert h.check() is False
+        handler = KspacingMetalHandler(output_filename=f"{self.tmp_path}/vasprun.xml")
+        assert handler.check() is False
         os.chdir(os.path.join(TEST_DIR, "scan_metal"))
 
         # TODO (@janosh 2023-11-03) remove when ending ScanMetalHandler deprecation period
@@ -845,7 +844,6 @@ class KspacingMetalHandlerTest(PymatgenTest):
 
 class LargeSigmaHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
         os.chdir(TEST_DIR)
         subdir = os.path.join(TEST_DIR, "large_sigma")
         os.chdir(subdir)
@@ -854,10 +852,10 @@ class LargeSigmaHandlerTest(unittest.TestCase):
         shutil.copy("vasprun.xml", "vasprun.xml.orig")
 
     def test_check_correct_large_sigma(self):
-        h = LargeSigmaHandler()
-        assert h.check()
-        d = h.correct()
-        assert d["errors"] == ["LargeSigma"]
+        handler = LargeSigmaHandler()
+        assert handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["LargeSigma"]
         assert Incar.from_file("INCAR")["SIGMA"] == 1.44
         os.remove("vasprun.xml")
 
@@ -870,7 +868,6 @@ class LargeSigmaHandlerTest(unittest.TestCase):
 
 class ZpotrfErrorHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
         os.chdir(TEST_DIR)
         os.chdir("zpotrf")
         shutil.copy("POSCAR", "POSCAR.orig")
@@ -879,10 +876,10 @@ class ZpotrfErrorHandlerTest(unittest.TestCase):
     def test_first_step(self):
         shutil.copy("OSZICAR.empty", "OSZICAR")
         s1 = Structure.from_file("POSCAR.orig")
-        h = VaspErrorHandler("vasp.out")
-        assert h.check() is True
-        d = h.correct()
-        assert d["errors"] == ["zpotrf"]
+        handler = VaspErrorHandler("vasp.out")
+        assert handler.check() is True
+        dct = handler.correct()
+        assert dct["errors"] == ["zpotrf"]
         s2 = Structure.from_file("POSCAR")
         # NOTE (@janosh on 2023-09-10) next code line used to be:
         # assert s2.volume == pytest.approx(s1.volume * 1.2**3)
@@ -893,10 +890,10 @@ class ZpotrfErrorHandlerTest(unittest.TestCase):
     def test_potim_correction(self):
         shutil.copy("OSZICAR.one_step", "OSZICAR")
         s1 = Structure.from_file("POSCAR.orig")
-        h = VaspErrorHandler("vasp.out")
-        assert h.check() is True
-        d = h.correct()
-        assert d["errors"] == ["zpotrf"]
+        handler = VaspErrorHandler("vasp.out")
+        assert handler.check() is True
+        dct = handler.correct()
+        assert dct["errors"] == ["zpotrf"]
         s2 = Structure.from_file("POSCAR")
         assert s2.volume == pytest.approx(s1.volume)
         assert s1.volume == pytest.approx(64.3462)
@@ -910,10 +907,10 @@ class ZpotrfErrorHandlerTest(unittest.TestCase):
         # Test for NSW 0
         incar.update({"NSW": 0})
         incar.write_file("INCAR")
-        h = VaspErrorHandler("vasp.out")
-        assert h.check() is True
-        d = h.correct()
-        assert d["errors"] == ["zpotrf"]
+        handler = VaspErrorHandler("vasp.out")
+        assert handler.check() is True
+        dct = handler.correct()
+        assert dct["errors"] == ["zpotrf"]
         s2 = Structure.from_file("POSCAR")
         assert s2.volume == pytest.approx(s1.volume)
         assert s2.volume == pytest.approx(64.346221)
@@ -931,19 +928,18 @@ class ZpotrfErrorHandlerTest(unittest.TestCase):
 
 class ZpotrfErrorHandlerSmallTest(unittest.TestCase):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
         os.chdir(TEST_DIR)
         os.chdir("zpotrf_small")
         shutil.copy("POSCAR", "POSCAR.orig")
         shutil.copy("INCAR", "INCAR.orig")
 
     def test_small(self):
-        h = VaspErrorHandler("vasp.out")
+        handler = VaspErrorHandler("vasp.out")
         shutil.copy("OSZICAR.empty", "OSZICAR")
-        assert h.check()
-        d = h.correct()
-        assert d["errors"] == ["zpotrf"]
-        assert d["actions"] == [
+        assert handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["zpotrf"]
+        assert dct["actions"] == [
             {"dict": "INCAR", "action": {"_set": {"NCORE": 1}}},
             {"dict": "INCAR", "action": {"_unset": {"NPAR": 1}}},
         ]
@@ -966,44 +962,44 @@ class WalltimeHandlerTest(unittest.TestCase):
 
     def test_walltime_start(self):
         # checks the walltime handlers starttime initialization
-        h = WalltimeHandler(wall_time=3600)
-        new_starttime = h.start_time
-        assert os.environ.get("CUSTODIAN_WALLTIME_START") == new_starttime.strftime("%a %b %d %H:%M:%S UTC %Y")
+        handler = WalltimeHandler(wall_time=3600)
+        new_starttime = handler.start_time
+        assert os.environ.get("CUSTODIAN_WALLTIME_START") == new_starttime.strftime("%a %b %dct %H:%M:%S UTC %Y")
         # Test that walltime persists if new handler is created
-        h = WalltimeHandler(wall_time=3600)
-        assert os.environ.get("CUSTODIAN_WALLTIME_START") == new_starttime.strftime("%a %b %d %H:%M:%S UTC %Y")
+        handler = WalltimeHandler(wall_time=3600)
+        assert os.environ.get("CUSTODIAN_WALLTIME_START") == new_starttime.strftime("%a %b %dct %H:%M:%S UTC %Y")
 
     def test_check_and_correct(self):
         # Try a 1 hr wall time with a 2 min buffer
-        h = WalltimeHandler(wall_time=3600, buffer_time=120)
-        assert not h.check()
+        handler = WalltimeHandler(wall_time=3600, buffer_time=120)
+        assert not handler.check()
 
         # This makes sure the check returns True when the time left is less
         # than the buffer time.
-        h.start_time = datetime.datetime.now() - datetime.timedelta(minutes=59)
-        assert h.check()
+        handler.start_time = datetime.datetime.now() - datetime.timedelta(minutes=59)
+        assert handler.check()
 
         # This makes sure the check returns True when the time left is less
         # than 3 x the average time per ionic step. We have a 62 min wall
         # time, a very short buffer time, but the start time was 62 mins ago
-        h = WalltimeHandler(wall_time=3720, buffer_time=10)
-        h.start_time = datetime.datetime.now() - datetime.timedelta(minutes=62)
-        assert h.check()
+        handler = WalltimeHandler(wall_time=3720, buffer_time=10)
+        handler.start_time = datetime.datetime.now() - datetime.timedelta(minutes=62)
+        assert handler.check()
 
         # Test that the STOPCAR is written correctly.
-        h.correct()
+        handler.correct()
         with open("STOPCAR") as f:
             content = f.read()
             assert content == "LSTOP = .TRUE."
         os.remove("STOPCAR")
 
-        h = WalltimeHandler(wall_time=3600, buffer_time=120, electronic_step_stop=True)
+        handler = WalltimeHandler(wall_time=3600, buffer_time=120, electronic_step_stop=True)
 
-        assert not h.check()
-        h.start_time = datetime.datetime.now() - datetime.timedelta(minutes=59)
-        assert h.check()
+        assert not handler.check()
+        handler.start_time = datetime.datetime.now() - datetime.timedelta(minutes=59)
+        assert handler.check()
 
-        h.correct()
+        handler.correct()
         with open("STOPCAR") as f:
             content = f.read()
             assert content == "LABORT = .TRUE."
@@ -1025,10 +1021,10 @@ class PositiveEnergyHandlerTest(unittest.TestCase):
         shutil.copy("POSCAR", "POSCAR.orig")
 
     def test_check_correct(self):
-        h = PositiveEnergyErrorHandler()
-        assert h.check()
-        d = h.correct()
-        assert d["errors"] == ["Positive energy"]
+        handler = PositiveEnergyErrorHandler()
+        assert handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["Positive energy"]
 
         os.remove(os.path.join(self.subdir, "error.1.tar.gz"))
 
@@ -1055,10 +1051,10 @@ class PotimHandlerTest(unittest.TestCase):
         incar = Incar.from_file("INCAR")
         original_potim = incar["POTIM"]
 
-        h = PotimErrorHandler()
-        assert h.check()
-        d = h.correct()
-        assert d["errors"] == ["POTIM"]
+        handler = PotimErrorHandler()
+        assert handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["POTIM"]
 
         os.remove(os.path.join(self.subdir, "error.1.tar.gz"))
 
@@ -1083,10 +1079,10 @@ class LrfCommHandlerTest(unittest.TestCase):
             shutil.copy(f, f + ".orig")
 
     def test_lrf_comm(self):
-        h = LrfCommutatorHandler("std_err.txt")
-        assert h.check() is True
-        d = h.correct()
-        assert d["errors"] == ["lrf_comm"]
+        handler = LrfCommutatorHandler("std_err.txt")
+        assert handler.check() is True
+        dct = handler.correct()
+        assert dct["errors"] == ["lrf_comm"]
         vi = VaspInput.from_directory(".")
         assert vi["INCAR"]["LPEAD"] is True
 
@@ -1105,16 +1101,16 @@ class KpointsTransHandlerTest(unittest.TestCase):
         shutil.copy("KPOINTS", "KPOINTS.orig")
 
     def test_kpoints_trans(self):
-        h = StdErrHandler("std_err.txt.kpoints_trans")
-        assert h.check() is True
-        d = h.correct()
-        assert d["errors"] == ["kpoints_trans"]
-        assert d["actions"] == [{"action": {"_set": {"kpoints": [[4, 4, 4]]}}, "dict": "KPOINTS"}]
+        handler = StdErrHandler("std_err.txt.kpoints_trans")
+        assert handler.check() is True
+        dct = handler.correct()
+        assert dct["errors"] == ["kpoints_trans"]
+        assert dct["actions"] == [{"action": {"_set": {"kpoints": [[4, 4, 4]]}}, "dict": "KPOINTS"}]
 
-        assert h.check() is True
-        d = h.correct()
-        assert d["errors"] == ["kpoints_trans"]
-        assert d["actions"] == []  # don't correct twice
+        assert handler.check() is True
+        dct = handler.correct()
+        assert dct["errors"] == ["kpoints_trans"]
+        assert dct["actions"] == []  # don't correct twice
 
     def tearDown(self):
         shutil.move("KPOINTS.orig", "KPOINTS")
@@ -1132,11 +1128,11 @@ class OutOfMemoryHandlerTest(unittest.TestCase):
         from custodian.vasp.interpreter import VaspModder
 
         VaspModder(vi=vi).apply_actions([{"dict": "INCAR", "action": {"_set": {"KPAR": 4}}}])
-        h = StdErrHandler("std_err.txt.oom")
-        assert h.check() is True
-        d = h.correct()
-        assert d["errors"] == ["out_of_memory"]
-        assert d["actions"] == [{"dict": "INCAR", "action": {"_set": {"KPAR": 2}}}]
+        handler = StdErrHandler("std_err.txt.oom")
+        assert handler.check() is True
+        dct = handler.correct()
+        assert dct["errors"] == ["out_of_memory"]
+        assert dct["actions"] == [{"dict": "INCAR", "action": {"_set": {"KPAR": 2}}}]
 
     def tearDown(self):
         shutil.move("INCAR.orig", "INCAR")
@@ -1151,32 +1147,32 @@ class DriftErrorHandlerTest(unittest.TestCase):
         shutil.copy("INCAR", "INCAR.orig")
 
     def test_check(self):
-        h = DriftErrorHandler(max_drift=0.05, to_average=11)
-        assert not h.check()
+        handler = DriftErrorHandler(max_drift=0.05, to_average=11)
+        assert not handler.check()
 
-        h = DriftErrorHandler(max_drift=0.05)
-        assert not h.check()
+        handler = DriftErrorHandler(max_drift=0.05)
+        assert not handler.check()
 
-        h = DriftErrorHandler(max_drift=0.0001)
-        assert not h.check()
+        handler = DriftErrorHandler(max_drift=0.0001)
+        assert not handler.check()
 
         incar = Incar.from_file("INCAR")
         incar["EDIFFG"] = -0.01
         incar.write_file("INCAR")
 
-        h = DriftErrorHandler(max_drift=0.0001)
-        assert h.check()
+        handler = DriftErrorHandler(max_drift=0.0001)
+        assert handler.check()
 
-        h = DriftErrorHandler()
-        h.check()
-        assert h.max_drift == 0.01
+        handler = DriftErrorHandler()
+        handler.check()
+        assert handler.max_drift == 0.01
 
         clean_dir()
 
     def test_correct(self):
-        h = DriftErrorHandler(max_drift=0.0001, enaug_multiply=2)
-        h.check()
-        h.correct()
+        handler = DriftErrorHandler(max_drift=0.0001, enaug_multiply=2)
+        handler.check()
+        handler.correct()
         incar = Incar.from_file("INCAR")
         assert incar.get("PREC") == "High"
         assert incar.get("ENAUG", 0) == incar.get("ENCUT", 2) * 2

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -43,7 +43,10 @@ def copy_tmp_files(tmp_path: str, *file_paths: str) -> None:
     for file_path in file_paths:
         src_path = f"{TEST_DIR}/{file_path}"
         dst_path = f"{tmp_path}/{os.path.basename(file_path)}"
-        shutil.copy(src_path, dst_path)
+        if os.path.isdir(src_path):
+            shutil.copytree(src_path, dst_path)
+        else:
+            shutil.copy(src_path, dst_path)
     os.chdir(tmp_path)
 
 
@@ -749,14 +752,9 @@ class UnconvergedErrorHandlerTest(unittest.TestCase):
         os.chdir(CWD)
 
 
-class IncorrectSmearingHandlerTest(unittest.TestCase):
+class IncorrectSmearingHandlerTest(PymatgenTest):
     def setUp(self):
-        os.chdir(TEST_DIR)
-        subdir = os.path.join(TEST_DIR, "scan_metal")
-        os.chdir(subdir)
-
-        shutil.copy("INCAR", "INCAR.orig")
-        shutil.copy("vasprun.xml", "vasprun.xml.orig")
+        copy_tmp_files(self.tmp_path, "scan_metal/INCAR", "scan_metal/vasprun.xml")
 
     def test_check_correct_scan_metal(self):
         handler = IncorrectSmearingHandler()
@@ -767,62 +765,28 @@ class IncorrectSmearingHandlerTest(unittest.TestCase):
         assert Incar.from_file("INCAR")["SIGMA"] == 0.2
         os.remove("vasprun.xml")
 
-    @classmethod
-    def tearDown(cls):
-        shutil.move("INCAR.orig", "INCAR")
-        shutil.move("vasprun.xml.orig", "vasprun.xml")
-        clean_dir()
-        os.chdir(CWD)
 
-
-class IncorrectSmearingHandlerStaticTest(unittest.TestCase):
+class IncorrectSmearingHandlerStaticTest(PymatgenTest):
     def setUp(self):
-        os.chdir(TEST_DIR)
-        subdir = os.path.join(TEST_DIR, "static_smearing")
-        os.chdir(subdir)
-
-        shutil.copy("INCAR", "INCAR.orig")
-        shutil.copy("vasprun.xml", "vasprun.xml.orig")
+        copy_tmp_files(self.tmp_path, "static_smearing/INCAR", "static_smearing/vasprun.xml")
 
     def test_check_correct_scan_metal(self):
         handler = IncorrectSmearingHandler()
         assert not handler.check()
 
-    def tearDown(self):
-        shutil.move("INCAR.orig", "INCAR")
-        shutil.move("vasprun.xml.orig", "vasprun.xml")
-        clean_dir()
-        os.chdir(CWD)
 
-
-class IncorrectSmearingHandlerFermiTest(unittest.TestCase):
+class IncorrectSmearingHandlerFermiTest(PymatgenTest):
     def setUp(self):
-        os.chdir(TEST_DIR)
-        subdir = os.path.join(TEST_DIR, "fermi_smearing")
-        os.chdir(subdir)
-
-        shutil.copy("INCAR", "INCAR.orig")
-        shutil.copy("vasprun.xml", "vasprun.xml.orig")
+        copy_tmp_files(self.tmp_path, "fermi_smearing/INCAR", "fermi_smearing/vasprun.xml")
 
     def test_check_correct_scan_metal(self):
         handler = IncorrectSmearingHandler()
         assert not handler.check()
-
-    def tearDown(self):
-        shutil.move("INCAR.orig", "INCAR")
-        shutil.move("vasprun.xml.orig", "vasprun.xml")
-        clean_dir()
-        os.chdir(CWD)
 
 
 class KspacingMetalHandlerTest(PymatgenTest):
     def setUp(self):
-        os.chdir(TEST_DIR)
-        subdir = os.path.join(TEST_DIR, "scan_metal")
-        os.chdir(subdir)
-
-        shutil.copy("INCAR", "INCAR.orig")
-        shutil.copy("vasprun.xml", "vasprun.xml.orig")
+        copy_tmp_files(self.tmp_path, "scan_metal/INCAR", "scan_metal/vasprun.xml")
 
     def test_check_correct_scan_metal(self):
         handler = KspacingMetalHandler()
@@ -843,21 +807,12 @@ class KspacingMetalHandlerTest(PymatgenTest):
         # TODO (@janosh 2023-11-03) remove when ending ScanMetalHandler deprecation period
         assert issubclass(ScanMetalHandler, KspacingMetalHandler)
 
-    def tearDown(self):
-        shutil.move("INCAR.orig", "INCAR")
-        shutil.move("vasprun.xml.orig", "vasprun.xml")
-        clean_dir()
-        os.chdir(CWD)
 
-
-class LargeSigmaHandlerTest(unittest.TestCase):
+class LargeSigmaHandlerTest(PymatgenTest):
     def setUp(self):
-        os.chdir(TEST_DIR)
-        subdir = os.path.join(TEST_DIR, "large_sigma")
-        os.chdir(subdir)
-
-        shutil.copy("INCAR", "INCAR.orig")
-        shutil.copy("vasprun.xml", "vasprun.xml.orig")
+        copy_tmp_files(
+            self.tmp_path, "large_sigma/INCAR", "large_sigma/vasprun.xml", "large_sigma/OUTCAR", "large_sigma/POSCAR"
+        )
 
     def test_check_correct_large_sigma(self):
         handler = LargeSigmaHandler()
@@ -865,13 +820,7 @@ class LargeSigmaHandlerTest(unittest.TestCase):
         dct = handler.correct()
         assert dct["errors"] == ["LargeSigma"]
         assert Incar.from_file("INCAR")["SIGMA"] == 1.44
-        os.remove("vasprun.xml")
-
-    def tearDown(self):
-        shutil.move("INCAR.orig", "INCAR")
-        shutil.move("vasprun.xml.orig", "vasprun.xml")
-        clean_dir()
-        os.chdir(CWD)
+        assert os.path.isfile("vasprun.xml")
 
 
 class ZpotrfErrorHandlerTest(PymatgenTest):

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -59,7 +59,6 @@ def clean_dir():
 
 class VaspErrorHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.environ["PMG_VASP_PSP_DIR"] = TEST_DIR
         os.chdir(TEST_DIR)
         shutil.copy("INCAR", "INCAR.orig")
         shutil.copy("KPOINTS", "KPOINTS.orig")
@@ -571,13 +570,9 @@ class VaspErrorHandlerTest(unittest.TestCase):
         os.chdir(CWD)
 
 
-class AliasingErrorHandlerTest(unittest.TestCase):
+class AliasingErrorHandlerTest(PymatgenTest):
     def setUp(self):
-        os.chdir(TEST_DIR)
-        shutil.copy("INCAR", "INCAR.orig")
-        shutil.copy("KPOINTS", "KPOINTS.orig")
-        shutil.copy("POSCAR", "POSCAR.orig")
-        shutil.copy("CHGCAR", "CHGCAR.orig")
+        copy_tmp_files(self.tmp_path, "INCAR", "KPOINTS", "POSCAR", "CHGCAR")
 
     def test_aliasing(self):
         os.chdir(os.path.join(TEST_DIR, "aliasing"))
@@ -620,15 +615,6 @@ class AliasingErrorHandlerTest(unittest.TestCase):
         shutil.move("INCAR.orig", "INCAR")
         clean_dir()
         os.chdir(TEST_DIR)
-
-    def tearDown(self):
-        os.chdir(TEST_DIR)
-        shutil.move("INCAR.orig", "INCAR")
-        shutil.move("KPOINTS.orig", "KPOINTS")
-        shutil.move("POSCAR.orig", "POSCAR")
-        shutil.move("CHGCAR.orig", "CHGCAR")
-        clean_dir()
-        os.chdir(CWD)
 
 
 class UnconvergedErrorHandlerTest(unittest.TestCase):

--- a/custodian/vasp/tests/test_handlers.py
+++ b/custodian/vasp/tests/test_handlers.py
@@ -1,19 +1,9 @@
-"""
-Created on Jun 1, 2012
-"""
-
-__author__ = "Shyue Ping Ong, Stephen Dacek"
-__copyright__ = "Copyright 2012, The Materials Project"
-__version__ = "0.1"
-__maintainer__ = "Shyue Ping Ong"
-__email__ = "shyue@mit.edu"
-__date__ = "Jun 1, 2012"
-
+"""Created on Jun 1, 2012"""
 import datetime
-import glob
 import os
 import shutil
 import unittest
+from glob import glob
 
 import pytest
 from pymatgen.io.vasp.inputs import Incar, Kpoints, Structure, VaspInput
@@ -37,22 +27,28 @@ from custodian.vasp.handlers import (
     WalltimeHandler,
 )
 
-test_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "test_files")
+__author__ = "Shyue Ping Ong, Stephen Dacek"
+__copyright__ = "Copyright 2012, The Materials Project"
+__version__ = "0.1"
+__maintainer__ = "Shyue Ping Ong"
+__email__ = "shyue@mit.edu"
+__date__ = "Jun 1, 2012"
 
-cwd = os.getcwd()
+TEST_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "test_files")
+CWD = os.getcwd()
 
 
 def clean_dir():
-    for f in glob.glob("error.*.tar.gz"):
+    for f in glob("error.*.tar.gz"):
         os.remove(f)
-    for f in glob.glob("custodian.chk.*.tar.gz"):
+    for f in glob("custodian.chk.*.tar.gz"):
         os.remove(f)
 
 
 class VaspErrorHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.environ["PMG_VASP_PSP_DIR"] = test_dir
-        os.chdir(test_dir)
+        os.environ["PMG_VASP_PSP_DIR"] = TEST_DIR
+        os.chdir(TEST_DIR)
         shutil.copy("INCAR", "INCAR.orig")
         shutil.copy("KPOINTS", "KPOINTS.orig")
         shutil.copy("POSCAR", "POSCAR.orig")
@@ -248,7 +244,7 @@ class VaspErrorHandlerTest(unittest.TestCase):
         assert d["errors"] == []
 
     def test_too_few_bands(self):
-        os.chdir(os.path.join(test_dir, "too_few_bands"))
+        os.chdir(os.path.join(TEST_DIR, "too_few_bands"))
         shutil.copy("INCAR", "INCAR.orig")
         h = VaspErrorHandler("vasp.too_few_bands")
         h.check()
@@ -257,11 +253,11 @@ class VaspErrorHandlerTest(unittest.TestCase):
         assert d["actions"] == [{"action": {"_set": {"NBANDS": 501}}, "dict": "INCAR"}]
         clean_dir()
         shutil.move("INCAR.orig", "INCAR")
-        os.chdir(test_dir)
+        os.chdir(TEST_DIR)
 
     def test_rot_matrix(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", test_dir)
-        subdir = os.path.join(test_dir, "poscar_error")
+        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
+        subdir = os.path.join(TEST_DIR, "poscar_error")
         os.chdir(subdir)
         shutil.copy("KPOINTS", "KPOINTS.orig")
         h = VaspErrorHandler()
@@ -553,33 +549,33 @@ class VaspErrorHandlerTest(unittest.TestCase):
         assert d["actions"] is None
 
     def tearDown(self):
-        os.chdir(test_dir)
+        os.chdir(TEST_DIR)
         shutil.move("INCAR.orig", "INCAR")
         shutil.move("KPOINTS.orig", "KPOINTS")
         shutil.move("POSCAR.orig", "POSCAR")
         shutil.move("CHGCAR.orig", "CHGCAR")
         clean_dir()
-        os.chdir(cwd)
+        os.chdir(CWD)
 
 
 class AliasingErrorHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", test_dir)
-        os.chdir(test_dir)
+        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
+        os.chdir(TEST_DIR)
         shutil.copy("INCAR", "INCAR.orig")
         shutil.copy("KPOINTS", "KPOINTS.orig")
         shutil.copy("POSCAR", "POSCAR.orig")
         shutil.copy("CHGCAR", "CHGCAR.orig")
 
     def test_aliasing(self):
-        os.chdir(os.path.join(test_dir, "aliasing"))
+        os.chdir(os.path.join(TEST_DIR, "aliasing"))
         shutil.copy("INCAR", "INCAR.orig")
         h = AliasingErrorHandler("vasp.aliasing")
         h.check()
         d = h.correct()
         shutil.move("INCAR.orig", "INCAR")
         clean_dir()
-        os.chdir(test_dir)
+        os.chdir(TEST_DIR)
 
         assert d["errors"] == ["aliasing"]
         assert d["actions"] == [
@@ -589,7 +585,7 @@ class AliasingErrorHandlerTest(unittest.TestCase):
         ]
 
     def test_aliasing_incar(self):
-        os.chdir(os.path.join(test_dir, "aliasing"))
+        os.chdir(os.path.join(TEST_DIR, "aliasing"))
         shutil.copy("INCAR", "INCAR.orig")
         h = AliasingErrorHandler("vasp.aliasing_incar")
         h.check()
@@ -611,23 +607,23 @@ class AliasingErrorHandlerTest(unittest.TestCase):
 
         shutil.move("INCAR.orig", "INCAR")
         clean_dir()
-        os.chdir(test_dir)
+        os.chdir(TEST_DIR)
 
     def tearDown(self):
-        os.chdir(test_dir)
+        os.chdir(TEST_DIR)
         shutil.move("INCAR.orig", "INCAR")
         shutil.move("KPOINTS.orig", "KPOINTS")
         shutil.move("POSCAR.orig", "POSCAR")
         shutil.move("CHGCAR.orig", "CHGCAR")
         clean_dir()
-        os.chdir(cwd)
+        os.chdir(CWD)
 
 
 class UnconvergedErrorHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", test_dir)
-        os.chdir(test_dir)
-        subdir = os.path.join(test_dir, "unconverged")
+        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
+        os.chdir(TEST_DIR)
+        subdir = os.path.join(TEST_DIR, "unconverged")
         os.chdir(subdir)
 
         shutil.copy("INCAR", "INCAR.orig")
@@ -739,14 +735,14 @@ class UnconvergedErrorHandlerTest(unittest.TestCase):
         shutil.move("POSCAR.orig", "POSCAR")
         shutil.move("CONTCAR.orig", "CONTCAR")
         clean_dir()
-        os.chdir(cwd)
+        os.chdir(CWD)
 
 
 class IncorrectSmearingHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", test_dir)
-        os.chdir(test_dir)
-        subdir = os.path.join(test_dir, "scan_metal")
+        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
+        os.chdir(TEST_DIR)
+        subdir = os.path.join(TEST_DIR, "scan_metal")
         os.chdir(subdir)
 
         shutil.copy("INCAR", "INCAR.orig")
@@ -766,14 +762,14 @@ class IncorrectSmearingHandlerTest(unittest.TestCase):
         shutil.move("INCAR.orig", "INCAR")
         shutil.move("vasprun.xml.orig", "vasprun.xml")
         clean_dir()
-        os.chdir(cwd)
+        os.chdir(CWD)
 
 
 class IncorrectSmearingHandlerStaticTest(unittest.TestCase):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", test_dir)
-        os.chdir(test_dir)
-        subdir = os.path.join(test_dir, "static_smearing")
+        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
+        os.chdir(TEST_DIR)
+        subdir = os.path.join(TEST_DIR, "static_smearing")
         os.chdir(subdir)
 
         shutil.copy("INCAR", "INCAR.orig")
@@ -787,14 +783,14 @@ class IncorrectSmearingHandlerStaticTest(unittest.TestCase):
         shutil.move("INCAR.orig", "INCAR")
         shutil.move("vasprun.xml.orig", "vasprun.xml")
         clean_dir()
-        os.chdir(cwd)
+        os.chdir(CWD)
 
 
 class IncorrectSmearingHandlerFermiTest(unittest.TestCase):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", test_dir)
-        os.chdir(test_dir)
-        subdir = os.path.join(test_dir, "fermi_smearing")
+        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
+        os.chdir(TEST_DIR)
+        subdir = os.path.join(TEST_DIR, "fermi_smearing")
         os.chdir(subdir)
 
         shutil.copy("INCAR", "INCAR.orig")
@@ -808,14 +804,14 @@ class IncorrectSmearingHandlerFermiTest(unittest.TestCase):
         shutil.move("INCAR.orig", "INCAR")
         shutil.move("vasprun.xml.orig", "vasprun.xml")
         clean_dir()
-        os.chdir(cwd)
+        os.chdir(CWD)
 
 
 class KspacingMetalHandlerTest(PymatgenTest):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", test_dir)
-        os.chdir(test_dir)
-        subdir = os.path.join(test_dir, "scan_metal")
+        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
+        os.chdir(TEST_DIR)
+        subdir = os.path.join(TEST_DIR, "scan_metal")
         os.chdir(subdir)
 
         shutil.copy("INCAR", "INCAR.orig")
@@ -830,12 +826,12 @@ class KspacingMetalHandlerTest(PymatgenTest):
         os.remove("vasprun.xml")
 
     def test_check_with_non_kspacing_wf(self):
-        os.chdir(test_dir)
+        os.chdir(TEST_DIR)
         shutil.copy("INCAR", f"{self.tmp_path}/INCAR")
         shutil.copy("vasprun.xml", f"{self.tmp_path}/vasprun.xml")
         h = KspacingMetalHandler(output_filename=f"{self.tmp_path}/vasprun.xml")
         assert h.check() is False
-        os.chdir(os.path.join(test_dir, "scan_metal"))
+        os.chdir(os.path.join(TEST_DIR, "scan_metal"))
 
         # TODO (@janosh 2023-11-03) remove when ending ScanMetalHandler deprecation period
         assert issubclass(ScanMetalHandler, KspacingMetalHandler)
@@ -844,14 +840,14 @@ class KspacingMetalHandlerTest(PymatgenTest):
         shutil.move("INCAR.orig", "INCAR")
         shutil.move("vasprun.xml.orig", "vasprun.xml")
         clean_dir()
-        os.chdir(cwd)
+        os.chdir(CWD)
 
 
 class LargeSigmaHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", test_dir)
-        os.chdir(test_dir)
-        subdir = os.path.join(test_dir, "large_sigma")
+        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
+        os.chdir(TEST_DIR)
+        subdir = os.path.join(TEST_DIR, "large_sigma")
         os.chdir(subdir)
 
         shutil.copy("INCAR", "INCAR.orig")
@@ -869,13 +865,13 @@ class LargeSigmaHandlerTest(unittest.TestCase):
         shutil.move("INCAR.orig", "INCAR")
         shutil.move("vasprun.xml.orig", "vasprun.xml")
         clean_dir()
-        os.chdir(cwd)
+        os.chdir(CWD)
 
 
 class ZpotrfErrorHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", test_dir)
-        os.chdir(test_dir)
+        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
+        os.chdir(TEST_DIR)
         os.chdir("zpotrf")
         shutil.copy("POSCAR", "POSCAR.orig")
         shutil.copy("INCAR", "INCAR.orig")
@@ -924,19 +920,19 @@ class ZpotrfErrorHandlerTest(unittest.TestCase):
         assert Incar.from_file("INCAR")["ISYM"] == 0
 
     def tearDown(self):
-        os.chdir(test_dir)
+        os.chdir(TEST_DIR)
         os.chdir("zpotrf")
         shutil.move("POSCAR.orig", "POSCAR")
         shutil.move("INCAR.orig", "INCAR")
         os.remove("OSZICAR")
         clean_dir()
-        os.chdir(cwd)
+        os.chdir(CWD)
 
 
 class ZpotrfErrorHandlerSmallTest(unittest.TestCase):
     def setUp(self):
-        os.environ.setdefault("PMG_VASP_PSP_DIR", test_dir)
-        os.chdir(test_dir)
+        os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_DIR)
+        os.chdir(TEST_DIR)
         os.chdir("zpotrf_small")
         shutil.copy("POSCAR", "POSCAR.orig")
         shutil.copy("INCAR", "INCAR.orig")
@@ -953,18 +949,18 @@ class ZpotrfErrorHandlerSmallTest(unittest.TestCase):
         ]
 
     def tearDown(self):
-        os.chdir(test_dir)
+        os.chdir(TEST_DIR)
         os.chdir("zpotrf_small")
         shutil.move("POSCAR.orig", "POSCAR")
         shutil.move("INCAR.orig", "INCAR")
         os.remove("OSZICAR")
         clean_dir()
-        os.chdir(cwd)
+        os.chdir(CWD)
 
 
 class WalltimeHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.chdir(os.path.join(test_dir, "postprocess"))
+        os.chdir(os.path.join(TEST_DIR, "postprocess"))
         if "CUSTODIAN_WALLTIME_START" in os.environ:
             os.environ.pop("CUSTODIAN_WALLTIME_START")
 
@@ -1017,13 +1013,13 @@ class WalltimeHandlerTest(unittest.TestCase):
     def tearDown(cls):
         if "CUSTODIAN_WALLTIME_START" in os.environ:
             os.environ.pop("CUSTODIAN_WALLTIME_START")
-        os.chdir(cwd)
+        os.chdir(CWD)
 
 
 class PositiveEnergyHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.chdir(test_dir)
-        self.subdir = os.path.join(test_dir, "positive_energy")
+        os.chdir(TEST_DIR)
+        self.subdir = os.path.join(TEST_DIR, "positive_energy")
         os.chdir(self.subdir)
         shutil.copy("INCAR", "INCAR.orig")
         shutil.copy("POSCAR", "POSCAR.orig")
@@ -1044,13 +1040,13 @@ class PositiveEnergyHandlerTest(unittest.TestCase):
     def tearDownClass(cls):
         shutil.move("INCAR.orig", "INCAR")
         shutil.move("POSCAR.orig", "POSCAR")
-        os.chdir(cwd)
+        os.chdir(CWD)
 
 
 class PotimHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.chdir(test_dir)
-        self.subdir = os.path.join(test_dir, "potim")
+        os.chdir(TEST_DIR)
+        self.subdir = os.path.join(TEST_DIR, "potim")
         os.chdir(self.subdir)
         shutil.copy("INCAR", "INCAR.orig")
         shutil.copy("POSCAR", "POSCAR.orig")
@@ -1076,12 +1072,12 @@ class PotimHandlerTest(unittest.TestCase):
     def tearDownClass(cls):
         shutil.move("INCAR.orig", "INCAR")
         shutil.move("POSCAR.orig", "POSCAR")
-        os.chdir(cwd)
+        os.chdir(CWD)
 
 
 class LrfCommHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.chdir(test_dir)
+        os.chdir(TEST_DIR)
         os.chdir("lrf_comm")
         for f in ["INCAR", "OUTCAR", "std_err.txt"]:
             shutil.copy(f, f + ".orig")
@@ -1095,17 +1091,17 @@ class LrfCommHandlerTest(unittest.TestCase):
         assert vi["INCAR"]["LPEAD"] is True
 
     def tearDown(self):
-        os.chdir(test_dir)
+        os.chdir(TEST_DIR)
         os.chdir("lrf_comm")
         for f in ["INCAR", "OUTCAR", "std_err.txt"]:
             shutil.move(f + ".orig", f)
         clean_dir()
-        os.chdir(cwd)
+        os.chdir(CWD)
 
 
 class KpointsTransHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.chdir(test_dir)
+        os.chdir(TEST_DIR)
         shutil.copy("KPOINTS", "KPOINTS.orig")
 
     def test_kpoints_trans(self):
@@ -1123,12 +1119,12 @@ class KpointsTransHandlerTest(unittest.TestCase):
     def tearDown(self):
         shutil.move("KPOINTS.orig", "KPOINTS")
         clean_dir()
-        os.chdir(cwd)
+        os.chdir(CWD)
 
 
 class OutOfMemoryHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.chdir(test_dir)
+        os.chdir(TEST_DIR)
         shutil.copy("INCAR", "INCAR.orig")
 
     def test_oom(self):
@@ -1145,12 +1141,12 @@ class OutOfMemoryHandlerTest(unittest.TestCase):
     def tearDown(self):
         shutil.move("INCAR.orig", "INCAR")
         clean_dir()
-        os.chdir(cwd)
+        os.chdir(CWD)
 
 
 class DriftErrorHandlerTest(unittest.TestCase):
     def setUp(self):
-        os.chdir(os.path.abspath(test_dir))
+        os.chdir(os.path.abspath(TEST_DIR))
         os.chdir("drift")
         shutil.copy("INCAR", "INCAR.orig")
 
@@ -1190,4 +1186,4 @@ class DriftErrorHandlerTest(unittest.TestCase):
     def tearDown(self):
         shutil.move("INCAR.orig", "INCAR")
         clean_dir()
-        os.chdir(cwd)
+        os.chdir(CWD)


### PR DESCRIPTION
The tests in `custodian/vasp/tests/test_handlers.py` are laden with order-dependent side effects. Running all tests in that file does not leave the `test_files/` unchanged. Large numbers of files are modified and added while tests run and again deleted at the end... but only if all tests pass. Failing tests leave behind dirty files in the repo that then cause subsequent test runs to fail that were previously passing.

The right way to run IO-heavy tests like in Custodian is to move everything into temporary dirs that are auto-cleaned by the OS and can't affect anything inside the repo.