### PR TITLE
Move `_clear_tracked_cache` fixture

### DIFF
--- a/tests/vasp/conftest.py
+++ b/tests/vasp/conftest.py
@@ -12,13 +12,3 @@ def _patch_get_potential_energy(monkeypatch):
     Monkeypatch the multiprocessing.cpu_count() function to always return 64
     """
     monkeypatch.setattr(multiprocessing, "cpu_count", lambda *args, **kwargs: 64)
-
-
-@pytest.fixture(autouse=True)
-def _clear_tracked_cache():
-    """
-    Clear the cache of the stored functions between the tests.
-    """
-    from custodian.utils import tracked_lru_cache
-
-    tracked_lru_cache.tracked_cache_clear()

--- a/tests/vasp/test_handlers.py
+++ b/tests/vasp/test_handlers.py
@@ -39,6 +39,16 @@ CWD = os.getcwd()
 os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_FILES)
 
 
+@pytest.fixture(autouse=True)
+def _clear_tracked_cache():
+    """
+    Clear the cache of the stored functions between the tests.
+    """
+    from custodian.utils import tracked_lru_cache
+
+    tracked_lru_cache.tracked_cache_clear()
+
+
 def copy_tmp_files(tmp_path: str, *file_paths: str) -> None:
     for file_path in file_paths:
         src_path = f"{TEST_FILES}/{file_path}"

--- a/tests/vasp/test_io.py
+++ b/tests/vasp/test_io.py
@@ -1,4 +1,5 @@
 import pytest
+
 from custodian import TEST_FILES
 from custodian.utils import tracked_lru_cache
 from custodian.vasp.io import load_outcar, load_vasprun

--- a/tests/vasp/test_io.py
+++ b/tests/vasp/test_io.py
@@ -1,6 +1,17 @@
+import pytest
 from custodian import TEST_FILES
 from custodian.utils import tracked_lru_cache
 from custodian.vasp.io import load_outcar, load_vasprun
+
+
+@pytest.fixture(autouse=True)
+def _clear_tracked_cache():
+    """
+    Clear the cache of the stored functions between the tests.
+    """
+    from custodian.utils import tracked_lru_cache
+
+    tracked_lru_cache.tracked_cache_clear()
 
 
 class TestIO:

--- a/tests/vasp/test_validators.py
+++ b/tests/vasp/test_validators.py
@@ -1,8 +1,19 @@
 import os
 import shutil
+import pytest
 
 from custodian import TEST_FILES
 from custodian.vasp.validators import VaspAECCARValidator, VaspFilesValidator, VaspNpTMDValidator, VasprunXMLValidator
+
+
+@pytest.fixture(autouse=True)
+def _clear_tracked_cache():
+    """
+    Clear the cache of the stored functions between the tests.
+    """
+    from custodian.utils import tracked_lru_cache
+
+    tracked_lru_cache.tracked_cache_clear()
 
 
 class TestVasprunXMLValidator:

--- a/tests/vasp/test_validators.py
+++ b/tests/vasp/test_validators.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+
 import pytest
 
 from custodian import TEST_FILES


### PR DESCRIPTION
As requested in #273 I have moved the fixture related to the cached files to the specific modules using it. 
Let me know if you think other changes might be needed.