### PR TITLE
Don't needlessly inherit from `unittest.TestCase`

### DIFF
--- a/tests/ansible/test_interpreter.py
+++ b/tests/ansible/test_interpreter.py
@@ -1,6 +1,4 @@
-"""
-Created on Jun 1, 2012
-"""
+"""Created on Jun 1, 2012."""
 
 
 __author__ = "Shyue Ping Ong"
@@ -10,7 +8,6 @@ __maintainer__ = "Shyue Ping Ong"
 __email__ = "shyue@mit.edu"
 __date__ = "Jun 1, 2012"
 
-import unittest
 
 import pytest
 
@@ -18,7 +15,7 @@ from custodian.ansible.actions import FileActions
 from custodian.ansible.interpreter import Modder
 
 
-class ModderTest(unittest.TestCase):
+class TestModder:
     def test_dict_modify(self):
         modder = Modder()
         dct = {"Hello": "World"}
@@ -159,8 +156,3 @@ class MyObject:
     @staticmethod
     def from_dict(dct):
         return MyObject(dct["b"]["a"])
-
-
-if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'Test.testName']
-    unittest.main()

--- a/tests/feff/test_jobs.py
+++ b/tests/feff/test_jobs.py
@@ -1,12 +1,4 @@
-__author__ = "Chen Zheng"
-__copyright__ = "Copyright 2012, The Materials Project"
-__version__ = "0.1"
-__maintainer__ = "Chen Zheng"
-__email__ = "chz022@ucsd.edu"
-__date__ = "Oct 18, 2017"
-
 import os
-import unittest
 
 from monty.os import cd
 from monty.tempfile import ScratchDir
@@ -15,33 +7,41 @@ from pymatgen.io.feff.inputs import Atoms, Tags
 from custodian import TEST_FILES
 from custodian.feff.jobs import FeffJob
 
+__author__ = "Chen Zheng"
+__copyright__ = "Copyright 2012, The Materials Project"
+__version__ = "0.1"
+__maintainer__ = "Chen Zheng"
+__email__ = "chz022@ucsd.edu"
+__date__ = "Oct 18, 2017"
+
 TEST_DIR = f"{TEST_FILES}/feff_unconverged"
 
 
-class FeffJobTest(unittest.TestCase):
-    def test_to_from_dict(self):
-        f = FeffJob("hello")
-        f2 = FeffJob.from_dict(f.as_dict())
-        assert type(f) == type(f2)
-        assert f2.feff_cmd == "hello"
+def test_to_from_dict():
+    f = FeffJob("hello")
+    f2 = FeffJob.from_dict(f.as_dict())
+    assert type(f) == type(f2)
+    assert f2.feff_cmd == "hello"
 
-    def test_setup(self):
-        with cd(TEST_DIR), ScratchDir(".", copy_from_current_on_enter=True):
-            f = FeffJob("hello", backup=True)
-            f.setup()
 
-            parameter = Tags.from_file("feff.inp")
-            parameter_orig = Tags.from_file("feff.inp.orig")
-            assert parameter == parameter_orig
+def test_setup():
+    with cd(TEST_DIR), ScratchDir(".", copy_from_current_on_enter=True):
+        f = FeffJob("hello", backup=True)
+        f.setup()
 
-            atom = Atoms.cluster_from_file("feff.inp")
-            atom_origin = Atoms.cluster_from_file("feff.inp.orig")
-            assert atom == atom_origin
+        parameter = Tags.from_file("feff.inp")
+        parameter_orig = Tags.from_file("feff.inp.orig")
+        assert parameter == parameter_orig
 
-    def test_postprocess(self):
-        with cd(TEST_DIR), ScratchDir(".", copy_from_current_on_enter=True):
-            f = FeffJob("hello", backup=True, gzipped=True)
-            f.postprocess()
-            assert os.path.exists("feff_out.1.tar.gz")
-            f.postprocess()
-            assert os.path.exists("feff_out.2.tar.gz")
+        atom = Atoms.cluster_from_file("feff.inp")
+        atom_origin = Atoms.cluster_from_file("feff.inp.orig")
+        assert atom == atom_origin
+
+
+def test_postprocess():
+    with cd(TEST_DIR), ScratchDir(".", copy_from_current_on_enter=True):
+        f = FeffJob("hello", backup=True, gzipped=True)
+        f.postprocess()
+        assert os.path.exists("feff_out.1.tar.gz")
+        f.postprocess()
+        assert os.path.exists("feff_out.2.tar.gz")

--- a/tests/lobster/test_handlers.py
+++ b/tests/lobster/test_handlers.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 
 from custodian import TEST_FILES
 from custodian.lobster.handlers import ChargeSpillingValidator, EnoughBandsValidator, LobsterFilesValidator
@@ -7,7 +6,7 @@ from custodian.lobster.handlers import ChargeSpillingValidator, EnoughBandsValid
 test_files_lobster = f"{TEST_FILES}/lobster/lobsterouts"
 
 
-class TestChargeSpillingValidator(unittest.TestCase):
+class TestChargeSpillingValidator:
     def test_check_and_correct(self):
         v = ChargeSpillingValidator(output_filename=f"{test_files_lobster}/lobsterout.normal")
         assert not v.check()
@@ -31,7 +30,7 @@ class TestChargeSpillingValidator(unittest.TestCase):
         assert isinstance(v2, ChargeSpillingValidator)
 
 
-class TestLobsterFilesValidator(unittest.TestCase):
+class TestLobsterFilesValidator:
     def test_check_and_correct_1(self):
         os.chdir(test_files_lobster)
         v = LobsterFilesValidator()
@@ -55,7 +54,7 @@ class TestLobsterFilesValidator(unittest.TestCase):
         assert isinstance(v2, LobsterFilesValidator)
 
 
-class TestEnoughBandsValidator(unittest.TestCase):
+class TestEnoughBandsValidator:
     def test_check_and_correct(self):
         v = EnoughBandsValidator(output_filename=f"{test_files_lobster}/lobsterout.normal")
         assert not v.check()

--- a/tests/lobster/test_jobs.py
+++ b/tests/lobster/test_jobs.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import unittest
 
 from monty.os import cd
 from monty.tempfile import ScratchDir
@@ -11,7 +10,7 @@ from custodian.lobster.jobs import LobsterJob
 test_files_lobster2 = f"{TEST_FILES}/lobster/lobsterins"
 test_files_lobster3 = f"{TEST_FILES}/lobster/vasp_lobster_output"
 
-VASP_OUTPUT_FILES = [
+VASP_OUTPUT_FILES = (
     "OUTCAR",
     "vasprun.xml",
     "CHG",
@@ -30,11 +29,11 @@ VASP_OUTPUT_FILES = [
     "REPORT",
     "WAVECAR",
     "XDATCAR",
-]
+)
 
-LOBSTERINPUT_FILES = ["lobsterin"]
+LOBSTERINPUT_FILES = ("lobsterin",)
 
-LOBSTER_FILES = [
+LOBSTER_FILES = (
     "lobsterin",
     "lobsterin.orig",
     "lobsterout",
@@ -53,12 +52,12 @@ LOBSTER_FILES = [
     "ICOBILIST.lobster",
     "COBICAR.lobster",
     "DOSCAR.LSO.lobster",
-]
+)
 
-FW_FILES = ["custodian.json", "FW.json", "FW_submit.script"]
+FW_FILES = ("custodian.json", "FW.json", "FW_submit.script")
 
 
-class LobsterJobTest(unittest.TestCase):
+class TestLobsterJob:
     """Similar to VaspJobTest. Omit test of run."""
 
     def test_to_from_dict(self):
@@ -87,7 +86,7 @@ class LobsterJobTest(unittest.TestCase):
                 shutil.copy("lobsterin", "lobsterin.orig")
                 v = LobsterJob("hello", gzipped=True, add_files_to_gzip=VASP_OUTPUT_FILES)
                 v.postprocess()
-                for file in VASP_OUTPUT_FILES + LOBSTER_FILES + FW_FILES:
+                for file in (*VASP_OUTPUT_FILES, *LOBSTER_FILES, *FW_FILES):
                     filegz = file + ".gz"
                     assert os.path.exists(filegz)
 
@@ -95,5 +94,5 @@ class LobsterJobTest(unittest.TestCase):
                 shutil.copy("lobsterin", "lobsterin.orig")
                 v = LobsterJob("hello", gzipped=False, add_files_to_gzip=VASP_OUTPUT_FILES)
                 v.postprocess()
-                for file in VASP_OUTPUT_FILES + LOBSTER_FILES + FW_FILES:
+                for file in (*VASP_OUTPUT_FILES, *LOBSTER_FILES, *FW_FILES):
                     assert os.path.exists(file)

--- a/tests/nwchem/test_handlers.py
+++ b/tests/nwchem/test_handlers.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import unittest
 from glob import glob
 
 from custodian import TEST_FILES
@@ -14,18 +13,17 @@ __status__ = "Beta"
 __date__ = "6/18/13"
 
 
-class NwchemErrorHandlerTest(unittest.TestCase):
-    def test_check_correct(self):
-        os.chdir(f"{TEST_FILES}/nwchem")
-        shutil.copy("C1N1Cl1_1.nw", "C1N1Cl1_1.nw.orig")
-        handler = NwchemErrorHandler(output_filename="C1N1Cl1_1.nwout")
-        handler.check()
-        handler.correct()
-        shutil.move("C1N1Cl1_1.nw.orig", "C1N1Cl1_1.nw")
-        shutil.copy("Li1_1.nw", "Li1_1.nw.orig")
-        handler = NwchemErrorHandler(output_filename="Li1_1.nwout")
-        handler.check()
-        handler.correct()
-        shutil.move("Li1_1.nw.orig", "Li1_1.nw")
-        for f in glob("error.*.tar.gz"):
-            os.remove(f)
+def test_check_correct():
+    os.chdir(f"{TEST_FILES}/nwchem")
+    shutil.copy("C1N1Cl1_1.nw", "C1N1Cl1_1.nw.orig")
+    handler = NwchemErrorHandler(output_filename="C1N1Cl1_1.nwout")
+    handler.check()
+    handler.correct()
+    shutil.move("C1N1Cl1_1.nw.orig", "C1N1Cl1_1.nw")
+    shutil.copy("Li1_1.nw", "Li1_1.nw.orig")
+    handler = NwchemErrorHandler(output_filename="Li1_1.nwout")
+    handler.check()
+    handler.correct()
+    shutil.move("Li1_1.nw.orig", "Li1_1.nw")
+    for f in glob("error.*.tar.gz"):
+        os.remove(f)

--- a/tests/qchem/test_handlers.py
+++ b/tests/qchem/test_handlers.py
@@ -24,7 +24,7 @@ __credits__ = "Xiaohui Qu"
 
 
 TEST_DIR = f"{TEST_FILES}/qchem/new_test_files"
-SCR_DIR = os.path.join(TEST_DIR, "scratch")
+SCR_DIR = f"{TEST_DIR}/scratch"
 CWD = os.getcwd()
 
 

--- a/tests/qchem/test_job_handler_interaction.py
+++ b/tests/qchem/test_job_handler_interaction.py
@@ -23,7 +23,7 @@ __status__ = "Alpha"
 __date__ = "6/3/22"
 
 TEST_DIR = f"{TEST_FILES}/qchem/new_test_files"
-SCR_DIR = os.path.join(TEST_DIR, "scratch")
+SCR_DIR = f"{TEST_DIR}/scratch"
 CWD = os.getcwd()
 
 

--- a/tests/qchem/test_jobs.py
+++ b/tests/qchem/test_jobs.py
@@ -25,7 +25,7 @@ __date__ = "6/6/18"
 __credits__ = "Shyam Dwaraknath"
 
 TEST_DIR = f"{TEST_FILES}/qchem/new_test_files"
-SCR_DIR = os.path.join(TEST_DIR, "scratch")
+SCR_DIR = f"{TEST_DIR}/scratch"
 CWD = os.getcwd()
 
 
@@ -132,7 +132,7 @@ class OptFFComplexUnlinkedTest(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "FF_complex/mol.qin.freq_0_ref")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/FF_complex/mol.qin.freq_0_ref").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         expected_next = QCJob(
@@ -146,7 +146,7 @@ class OptFFComplexUnlinkedTest(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "FF_complex/mol.qin.opt_1_unlinked")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/FF_complex/mol.qin.opt_1_unlinked").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
 
@@ -201,7 +201,7 @@ class OptFFTestComplexLinkedChangeNsegTest(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "FF_complex/mol.qin.freq_0_ref")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/FF_complex/mol.qin.freq_0_ref").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         expected_next = QCJob(
@@ -216,7 +216,7 @@ class OptFFTestComplexLinkedChangeNsegTest(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "FF_complex/mol.qin.opt_1")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/FF_complex/mol.qin.opt_1").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         expected_next = QCJob(
@@ -231,7 +231,7 @@ class OptFFTestComplexLinkedChangeNsegTest(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "FF_complex/mol.qin.freq_1")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/FF_complex/mol.qin.freq_1").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
 
@@ -240,34 +240,13 @@ class OptFFTestComplexLinkedChangeNsegTest(TestCase):
 class OptFFTest(TestCase):
     def setUp(self):
         os.makedirs(SCR_DIR)
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "FF_working/test.qin"),
-            os.path.join(SCR_DIR, "test.qin"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "FF_working/test.qout.opt_0"),
-            os.path.join(SCR_DIR, "test.qout.opt_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "FF_working/test.qout.freq_0"),
-            os.path.join(SCR_DIR, "test.qout.freq_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "FF_working/test.qin.freq_0"),
-            os.path.join(SCR_DIR, "test.qin.freq_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "FF_working/test.qin.freq_1"),
-            os.path.join(SCR_DIR, "test.qin.freq_1"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "FF_working/test.qout.opt_1"),
-            os.path.join(SCR_DIR, "test.qout.opt_1"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "FF_working/test.qout.freq_1"),
-            os.path.join(SCR_DIR, "test.qout.freq_1"),
-        )
+        shutil.copyfile(f"{TEST_DIR}/FF_working/test.qin", f"{SCR_DIR}/test.qin")
+        shutil.copyfile(f"{TEST_DIR}/FF_working/test.qout.opt_0", f"{SCR_DIR}/test.qout.opt_0")
+        shutil.copyfile(f"{TEST_DIR}/FF_working/test.qout.freq_0", f"{SCR_DIR}/test.qout.freq_0")
+        shutil.copyfile(f"{TEST_DIR}/FF_working/test.qin.freq_0", f"{SCR_DIR}/test.qin.freq_0")
+        shutil.copyfile(f"{TEST_DIR}/FF_working/test.qin.freq_1", f"{SCR_DIR}/test.qin.freq_1")
+        shutil.copyfile(f"{TEST_DIR}/FF_working/test.qout.opt_1", f"{SCR_DIR}/test.qout.opt_1")
+        shutil.copyfile(f"{TEST_DIR}/FF_working/test.qout.freq_1", f"{SCR_DIR}/test.qout.freq_1")
         os.chdir(SCR_DIR)
 
     def tearDown(self):
@@ -303,7 +282,7 @@ class OptFFTest(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "FF_working/test.qin.freq_0")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/FF_working/test.qin.freq_0").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "test.qin")).as_dict()
         )
         expected_next = QCJob(
@@ -317,7 +296,7 @@ class OptFFTest(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "FF_working/test.qin.opt_1")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/FF_working/test.qin.opt_1").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "test.qin")).as_dict()
         )
         expected_next = QCJob(
@@ -331,7 +310,7 @@ class OptFFTest(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "FF_working/test.qin.freq_1")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/FF_working/test.qin.freq_1").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "test.qin")).as_dict()
         )
         with pytest.raises(StopIteration):
@@ -342,14 +321,8 @@ class OptFFTest(TestCase):
 class OptFFTest1(TestCase):
     def setUp(self):
         os.makedirs(SCR_DIR)
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "2620_complete/mol.qin.orig"),
-            os.path.join(SCR_DIR, "mol.qin"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "2620_complete/mol.qout.opt_0"),
-            os.path.join(SCR_DIR, "mol.qout.opt_0"),
-        )
+        shutil.copyfile(f"{TEST_DIR}/2620_complete/mol.qin.orig", f"{SCR_DIR}/mol.qin")
+        shutil.copyfile(f"{TEST_DIR}/2620_complete/mol.qout.opt_0", f"{SCR_DIR}/mol.qout.opt_0")
         os.chdir(SCR_DIR)
 
     def tearDown(self):
@@ -358,11 +331,7 @@ class OptFFTest1(TestCase):
 
     def test_OptFF(self):
         job = QCJob.opt_with_frequency_flattener(
-            qchem_command="qchem -slurm",
-            max_cores=32,
-            input_file="mol.qin",
-            output_file="mol.qout",
-            linked=False,
+            qchem_command="qchem -slurm", max_cores=32, input_file="mol.qin", output_file="mol.qout", linked=False
         )
         expected_next = QCJob(
             qchem_command="qchem -slurm",
@@ -382,22 +351,10 @@ class OptFFTest1(TestCase):
 class OptFFTest2(TestCase):
     def setUp(self):
         os.makedirs(SCR_DIR)
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "disconnected_but_converged/mol.qin.orig"),
-            os.path.join(SCR_DIR, "mol.qin"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "disconnected_but_converged/mol.qout.opt_0"),
-            os.path.join(SCR_DIR, "mol.qout.opt_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "disconnected_but_converged/mol.qout.freq_0"),
-            os.path.join(SCR_DIR, "mol.qout.freq_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "disconnected_but_converged/mol.qin.freq_0"),
-            os.path.join(SCR_DIR, "mol.qin.freq_0"),
-        )
+        shutil.copyfile(f"{TEST_DIR}/disconnected_but_converged/mol.qin.orig", f"{SCR_DIR}/mol.qin")
+        shutil.copyfile(f"{TEST_DIR}/disconnected_but_converged/mol.qout.opt_0", f"{SCR_DIR}/mol.qout.opt_0")
+        shutil.copyfile(f"{TEST_DIR}/disconnected_but_converged/mol.qout.freq_0", f"{SCR_DIR}/mol.qout.freq_0")
+        shutil.copyfile(f"{TEST_DIR}/disconnected_but_converged/mol.qin.freq_0", f"{SCR_DIR}/mol.qin.freq_0")
         os.chdir(SCR_DIR)
 
     def tearDown(self):
@@ -433,7 +390,7 @@ class OptFFTest2(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "disconnected_but_converged/mol.qin.freq_0")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/disconnected_but_converged/mol.qin.freq_0").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         with pytest.raises(StopIteration):
@@ -444,46 +401,16 @@ class OptFFTest2(TestCase):
 class OptFFTestSwitching(TestCase):
     def setUp(self):
         os.makedirs(SCR_DIR)
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "FF_switching/mol.qin.orig"),
-            os.path.join(SCR_DIR, "mol.qin"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "FF_switching/mol.qout.opt_0"),
-            os.path.join(SCR_DIR, "mol.qout.opt_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "FF_switching/mol.qout.freq_0"),
-            os.path.join(SCR_DIR, "mol.qout.freq_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "FF_switching/mol.qin.freq_0"),
-            os.path.join(SCR_DIR, "mol.qin.freq_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "FF_switching/mol.qin.freq_1"),
-            os.path.join(SCR_DIR, "mol.qin.freq_1"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "FF_switching/mol.qin.freq_2"),
-            os.path.join(SCR_DIR, "mol.qin.freq_2"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "FF_switching/mol.qout.opt_1"),
-            os.path.join(SCR_DIR, "mol.qout.opt_1"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "FF_switching/mol.qout.freq_1"),
-            os.path.join(SCR_DIR, "mol.qout.freq_1"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "FF_switching/mol.qout.opt_2"),
-            os.path.join(SCR_DIR, "mol.qout.opt_2"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "FF_switching/mol.qout.freq_2"),
-            os.path.join(SCR_DIR, "mol.qout.freq_2"),
-        )
+        shutil.copyfile(f"{TEST_DIR}/FF_switching/mol.qin.orig", f"{SCR_DIR}/mol.qin")
+        shutil.copyfile(f"{TEST_DIR}/FF_switching/mol.qout.opt_0", f"{SCR_DIR}/mol.qout.opt_0")
+        shutil.copyfile(f"{TEST_DIR}/FF_switching/mol.qout.freq_0", f"{SCR_DIR}/mol.qout.freq_0")
+        shutil.copyfile(f"{TEST_DIR}/FF_switching/mol.qin.freq_0", f"{SCR_DIR}/mol.qin.freq_0")
+        shutil.copyfile(f"{TEST_DIR}/FF_switching/mol.qin.freq_1", f"{SCR_DIR}/mol.qin.freq_1")
+        shutil.copyfile(f"{TEST_DIR}/FF_switching/mol.qin.freq_2", f"{SCR_DIR}/mol.qin.freq_2")
+        shutil.copyfile(f"{TEST_DIR}/FF_switching/mol.qout.opt_1", f"{SCR_DIR}/mol.qout.opt_1")
+        shutil.copyfile(f"{TEST_DIR}/FF_switching/mol.qout.freq_1", f"{SCR_DIR}/mol.qout.freq_1")
+        shutil.copyfile(f"{TEST_DIR}/FF_switching/mol.qout.opt_2", f"{SCR_DIR}/mol.qout.opt_2")
+        shutil.copyfile(f"{TEST_DIR}/FF_switching/mol.qout.freq_2", f"{SCR_DIR}/mol.qout.freq_2")
         os.chdir(SCR_DIR)
 
     def tearDown(self):
@@ -519,7 +446,7 @@ class OptFFTestSwitching(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "FF_switching/mol.qin.freq_0")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/FF_switching/mol.qin.freq_0").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         expected_next = QCJob(
@@ -533,7 +460,7 @@ class OptFFTestSwitching(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "FF_switching/mol.qin.opt_1")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/FF_switching/mol.qin.opt_1").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         expected_next = QCJob(
@@ -547,7 +474,7 @@ class OptFFTestSwitching(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "FF_switching/mol.qin.freq_1")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/FF_switching/mol.qin.freq_1").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         expected_next = QCJob(
@@ -561,7 +488,7 @@ class OptFFTestSwitching(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "FF_switching/mol.qin.opt_2")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/FF_switching/mol.qin.opt_2").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         expected_next = QCJob(
@@ -575,7 +502,7 @@ class OptFFTestSwitching(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "FF_switching/mol.qin.freq_2")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/FF_switching/mol.qin.freq_2").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         with pytest.raises(StopIteration):
@@ -586,46 +513,16 @@ class OptFFTestSwitching(TestCase):
 class OptFFTest6004(TestCase):
     def setUp(self):
         os.makedirs(SCR_DIR)
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "6004_frag12/mol.qin.orig"),
-            os.path.join(SCR_DIR, "mol.qin"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "6004_frag12/mol.qout.opt_0"),
-            os.path.join(SCR_DIR, "mol.qout.opt_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "6004_frag12/mol.qout.freq_0"),
-            os.path.join(SCR_DIR, "mol.qout.freq_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "6004_frag12/mol.qin.freq_0"),
-            os.path.join(SCR_DIR, "mol.qin.freq_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "6004_frag12/mol.qin.freq_1"),
-            os.path.join(SCR_DIR, "mol.qin.freq_1"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "6004_frag12/mol.qin.freq_2"),
-            os.path.join(SCR_DIR, "mol.qin.freq_2"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "6004_frag12/mol.qout.opt_1"),
-            os.path.join(SCR_DIR, "mol.qout.opt_1"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "6004_frag12/mol.qout.freq_1"),
-            os.path.join(SCR_DIR, "mol.qout.freq_1"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "6004_frag12/mol.qout.opt_2"),
-            os.path.join(SCR_DIR, "mol.qout.opt_2"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "6004_frag12/mol.qout.freq_2"),
-            os.path.join(SCR_DIR, "mol.qout.freq_2"),
-        )
+        shutil.copyfile(f"{TEST_DIR}/6004_frag12/mol.qin.orig", f"{SCR_DIR}/mol.qin")
+        shutil.copyfile(f"{TEST_DIR}/6004_frag12/mol.qout.opt_0", f"{SCR_DIR}/mol.qout.opt_0")
+        shutil.copyfile(f"{TEST_DIR}/6004_frag12/mol.qout.freq_0", f"{SCR_DIR}/mol.qout.freq_0")
+        shutil.copyfile(f"{TEST_DIR}/6004_frag12/mol.qin.freq_0", f"{SCR_DIR}/mol.qin.freq_0")
+        shutil.copyfile(f"{TEST_DIR}/6004_frag12/mol.qin.freq_1", f"{SCR_DIR}/mol.qin.freq_1")
+        shutil.copyfile(f"{TEST_DIR}/6004_frag12/mol.qin.freq_2", f"{SCR_DIR}/mol.qin.freq_2")
+        shutil.copyfile(f"{TEST_DIR}/6004_frag12/mol.qout.opt_1", f"{SCR_DIR}/mol.qout.opt_1")
+        shutil.copyfile(f"{TEST_DIR}/6004_frag12/mol.qout.freq_1", f"{SCR_DIR}/mol.qout.freq_1")
+        shutil.copyfile(f"{TEST_DIR}/6004_frag12/mol.qout.opt_2", f"{SCR_DIR}/mol.qout.opt_2")
+        shutil.copyfile(f"{TEST_DIR}/6004_frag12/mol.qout.freq_2", f"{SCR_DIR}/mol.qout.freq_2")
         os.chdir(SCR_DIR)
 
     def tearDown(self):
@@ -661,7 +558,7 @@ class OptFFTest6004(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "6004_frag12/mol.qin.freq_0")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/6004_frag12/mol.qin.freq_0").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         expected_next = QCJob(
@@ -675,7 +572,7 @@ class OptFFTest6004(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "6004_frag12/mol.qin.opt_1")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/6004_frag12/mol.qin.opt_1").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         expected_next = QCJob(
@@ -689,7 +586,7 @@ class OptFFTest6004(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "6004_frag12/mol.qin.freq_1")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/6004_frag12/mol.qin.freq_1").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         expected_next = QCJob(
@@ -703,7 +600,7 @@ class OptFFTest6004(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "6004_frag12/mol.qin.opt_2")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/6004_frag12/mol.qin.opt_2").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         expected_next = QCJob(
@@ -717,7 +614,7 @@ class OptFFTest6004(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "6004_frag12/mol.qin.freq_2")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/6004_frag12/mol.qin.freq_2").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
 
@@ -726,18 +623,9 @@ class OptFFTest6004(TestCase):
 class OptFFTest5952(TestCase):
     def setUp(self):
         os.makedirs(SCR_DIR)
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "5952_frag16/mol.qin.orig"),
-            os.path.join(SCR_DIR, "mol.qin"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "5952_frag16/mol.qout.opt_0"),
-            os.path.join(SCR_DIR, "mol.qout.opt_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "5952_frag16/mol.qout.freq_0"),
-            os.path.join(SCR_DIR, "mol.qout.freq_0"),
-        )
+        shutil.copyfile(f"{TEST_DIR}/5952_frag16/mol.qin.orig", f"{SCR_DIR}/mol.qin")
+        shutil.copyfile(f"{TEST_DIR}/5952_frag16/mol.qout.opt_0", f"{SCR_DIR}/mol.qout.opt_0")
+        shutil.copyfile(f"{TEST_DIR}/5952_frag16/mol.qout.freq_0", f"{SCR_DIR}/mol.qout.freq_0")
         os.chdir(SCR_DIR)
 
     def tearDown(self):
@@ -773,7 +661,7 @@ class OptFFTest5952(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "5952_frag16/mol.qin.freq_0")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/5952_frag16/mol.qin.freq_0").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         with pytest.raises(StopIteration):
@@ -784,46 +672,16 @@ class OptFFTest5952(TestCase):
 class OptFFTest5690(TestCase):
     def setUp(self):
         os.makedirs(SCR_DIR)
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "5690_frag18/mol.qin.orig"),
-            os.path.join(SCR_DIR, "mol.qin"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "5690_frag18/mol.qout.opt_0"),
-            os.path.join(SCR_DIR, "mol.qout.opt_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "5690_frag18/mol.qout.freq_0"),
-            os.path.join(SCR_DIR, "mol.qout.freq_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "5690_frag18/mol.qin.freq_0"),
-            os.path.join(SCR_DIR, "mol.qin.freq_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "5690_frag18/mol.qin.freq_1"),
-            os.path.join(SCR_DIR, "mol.qin.freq_1"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "5690_frag18/mol.qin.freq_2"),
-            os.path.join(SCR_DIR, "mol.qin.freq_2"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "5690_frag18/mol.qout.opt_1"),
-            os.path.join(SCR_DIR, "mol.qout.opt_1"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "5690_frag18/mol.qout.freq_1"),
-            os.path.join(SCR_DIR, "mol.qout.freq_1"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "5690_frag18/mol.qout.opt_2"),
-            os.path.join(SCR_DIR, "mol.qout.opt_2"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "5690_frag18/mol.qout.freq_2"),
-            os.path.join(SCR_DIR, "mol.qout.freq_2"),
-        )
+        shutil.copyfile(f"{TEST_DIR}/5690_frag18/mol.qin.orig", f"{SCR_DIR}/mol.qin")
+        shutil.copyfile(f"{TEST_DIR}/5690_frag18/mol.qout.opt_0", f"{SCR_DIR}/mol.qout.opt_0")
+        shutil.copyfile(f"{TEST_DIR}/5690_frag18/mol.qout.freq_0", f"{SCR_DIR}/mol.qout.freq_0")
+        shutil.copyfile(f"{TEST_DIR}/5690_frag18/mol.qin.freq_0", f"{SCR_DIR}/mol.qin.freq_0")
+        shutil.copyfile(f"{TEST_DIR}/5690_frag18/mol.qin.freq_1", f"{SCR_DIR}/mol.qin.freq_1")
+        shutil.copyfile(f"{TEST_DIR}/5690_frag18/mol.qin.freq_2", f"{SCR_DIR}/mol.qin.freq_2")
+        shutil.copyfile(f"{TEST_DIR}/5690_frag18/mol.qout.opt_1", f"{SCR_DIR}/mol.qout.opt_1")
+        shutil.copyfile(f"{TEST_DIR}/5690_frag18/mol.qout.freq_1", f"{SCR_DIR}/mol.qout.freq_1")
+        shutil.copyfile(f"{TEST_DIR}/5690_frag18/mol.qout.opt_2", f"{SCR_DIR}/mol.qout.opt_2")
+        shutil.copyfile(f"{TEST_DIR}/5690_frag18/mol.qout.freq_2", f"{SCR_DIR}/mol.qout.freq_2")
         os.chdir(SCR_DIR)
 
     def tearDown(self):
@@ -859,7 +717,7 @@ class OptFFTest5690(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "5690_frag18/mol.qin.freq_0")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/5690_frag18/mol.qin.freq_0").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         expected_next = QCJob(
@@ -873,7 +731,7 @@ class OptFFTest5690(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "5690_frag18/mol.qin.opt_1")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/5690_frag18/mol.qin.opt_1").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         expected_next = QCJob(
@@ -887,7 +745,7 @@ class OptFFTest5690(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "5690_frag18/mol.qin.freq_1")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/5690_frag18/mol.qin.freq_1").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         expected_next = QCJob(
@@ -901,7 +759,7 @@ class OptFFTest5690(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "5690_frag18/mol.qin.opt_2")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/5690_frag18/mol.qin.opt_2").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         expected_next = QCJob(
@@ -915,7 +773,7 @@ class OptFFTest5690(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "5690_frag18/mol.qin.freq_2")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/5690_frag18/mol.qin.freq_2").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         with pytest.raises(StopIteration):
@@ -926,38 +784,14 @@ class OptFFTest5690(TestCase):
 class OptFFSmallNegFreqTest(TestCase):
     def setUp(self):
         os.makedirs(f"{SCR_DIR}/scratch", exist_ok=True)
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "small_neg_freq/mol.qin.orig"),
-            os.path.join(SCR_DIR, "mol.qin"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "small_neg_freq/mol.qin.opt_0"),
-            os.path.join(SCR_DIR, "mol.qin.opt_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "small_neg_freq/mol.qout.opt_0"),
-            os.path.join(SCR_DIR, "mol.qout.opt_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "small_neg_freq/mol.qout.freq_0"),
-            os.path.join(SCR_DIR, "mol.qout.freq_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "small_neg_freq/mol.qout.opt_1"),
-            os.path.join(SCR_DIR, "mol.qout.opt_1"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "small_neg_freq/mol.qout.freq_1"),
-            os.path.join(SCR_DIR, "mol.qout.freq_1"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "small_neg_freq/mol.qout.opt_2"),
-            os.path.join(SCR_DIR, "mol.qout.opt_2"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "small_neg_freq/mol.qout.freq_2"),
-            os.path.join(SCR_DIR, "mol.qout.freq_2"),
-        )
+        shutil.copyfile(f"{TEST_DIR}/small_neg_freq/mol.qin.orig", f"{SCR_DIR}/mol.qin")
+        shutil.copyfile(f"{TEST_DIR}/small_neg_freq/mol.qin.opt_0", f"{SCR_DIR}/mol.qin.opt_0")
+        shutil.copyfile(f"{TEST_DIR}/small_neg_freq/mol.qout.opt_0", f"{SCR_DIR}/mol.qout.opt_0")
+        shutil.copyfile(f"{TEST_DIR}/small_neg_freq/mol.qout.freq_0", f"{SCR_DIR}/mol.qout.freq_0")
+        shutil.copyfile(f"{TEST_DIR}/small_neg_freq/mol.qout.opt_1", f"{SCR_DIR}/mol.qout.opt_1")
+        shutil.copyfile(f"{TEST_DIR}/small_neg_freq/mol.qout.freq_1", f"{SCR_DIR}/mol.qout.freq_1")
+        shutil.copyfile(f"{TEST_DIR}/small_neg_freq/mol.qout.opt_2", f"{SCR_DIR}/mol.qout.opt_2")
+        shutil.copyfile(f"{TEST_DIR}/small_neg_freq/mol.qout.freq_2", f"{SCR_DIR}/mol.qout.freq_2")
         os.chdir(SCR_DIR)
 
     def tearDown(self):
@@ -995,7 +829,7 @@ class OptFFSmallNegFreqTest(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "small_neg_freq/mol.qin.freq_0")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/small_neg_freq/mol.qin.freq_0").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         shutil.copyfile(
@@ -1014,7 +848,7 @@ class OptFFSmallNegFreqTest(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "small_neg_freq/mol.qin.opt_1")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/small_neg_freq/mol.qin.opt_1").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         shutil.copyfile(
@@ -1033,7 +867,7 @@ class OptFFSmallNegFreqTest(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "small_neg_freq/mol.qin.freq_1")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/small_neg_freq/mol.qin.freq_1").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         shutil.copyfile(
@@ -1052,7 +886,7 @@ class OptFFSmallNegFreqTest(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "small_neg_freq/mol.qin.opt_2")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/small_neg_freq/mol.qin.opt_2").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         shutil.copyfile(
@@ -1071,7 +905,7 @@ class OptFFSmallNegFreqTest(TestCase):
         ).as_dict()
         assert next(job).as_dict() == expected_next
         assert (
-            QCInput.from_file(os.path.join(TEST_DIR, "small_neg_freq/mol.qin.freq_2")).as_dict()
+            QCInput.from_file(f"{TEST_DIR}/small_neg_freq/mol.qin.freq_2").as_dict()
             == QCInput.from_file(os.path.join(SCR_DIR, "mol.qin")).as_dict()
         )
         shutil.copyfile(
@@ -1086,26 +920,11 @@ class OptFFSmallNegFreqTest(TestCase):
 class OptFFSingleFreqFragsTest(TestCase):
     def setUp(self):
         os.makedirs(f"{SCR_DIR}/scratch", exist_ok=True)
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "single_freq_frag/mol.qin.orig"),
-            os.path.join(SCR_DIR, "mol.qin"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "single_freq_frag/mol.qin.opt_0"),
-            os.path.join(SCR_DIR, "mol.qin.opt_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "single_freq_frag/mol.qout.opt_0"),
-            os.path.join(SCR_DIR, "mol.qout.opt_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "single_freq_frag/mol.qin.freq_0"),
-            os.path.join(SCR_DIR, "mol.qin.freq_0"),
-        )
-        shutil.copyfile(
-            os.path.join(TEST_DIR, "single_freq_frag/mol.qout.freq_0"),
-            os.path.join(SCR_DIR, "mol.qout.freq_0"),
-        )
+        shutil.copyfile(f"{TEST_DIR}/single_freq_frag/mol.qin.orig", f"{SCR_DIR}/mol.qin")
+        shutil.copyfile(f"{TEST_DIR}/single_freq_frag/mol.qin.opt_0", f"{SCR_DIR}/mol.qin.opt_0")
+        shutil.copyfile(f"{TEST_DIR}/single_freq_frag/mol.qout.opt_0", f"{SCR_DIR}/mol.qout.opt_0")
+        shutil.copyfile(f"{TEST_DIR}/single_freq_frag/mol.qin.freq_0", f"{SCR_DIR}/mol.qin.freq_0")
+        shutil.copyfile(f"{TEST_DIR}/single_freq_frag/mol.qout.freq_0", f"{SCR_DIR}/mol.qout.freq_0")
 
         os.chdir(SCR_DIR)
 

--- a/tests/test_custodian.py
+++ b/tests/test_custodian.py
@@ -319,7 +319,7 @@ custodian_params:
         os.chdir(self.cwd)
 
 
-# class CustodianCheckpointTest(unittest.TestCase):
+# class TestCustodianCheckpoint:
 #     def test_checkpoint_loading(self):
 #         self.cwd = os.getcwd()
 #         pth = f"{TEST_FILES}/checkpointing"
@@ -334,7 +334,7 @@ custodian_params:
 #             max_errors=100,
 #             checkpoint=True,
 #         )
-#         self.assertEqual(len(c.run_log), 3)
-#         self.assertEqual(len(c.run()), 5)
+#         assert len(c.run_log) == 3
+#         assert len(c.run()) == 5
 #         os.remove("custodian.json")
 #         os.chdir(self.cwd)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,38 +1,27 @@
-import unittest
-
 from custodian.utils import tracked_lru_cache
 
 
-class TrackedLruCacheTest(unittest.TestCase):
-    def setUp(self):
-        # clear cache before and after each test to avoid
-        # unexpected caching from other tests
-        tracked_lru_cache.tracked_cache_clear()
+def test_cache_and_clear():
+    n_calls = 0
 
-    def test_cache_and_clear(self):
-        n_calls = 0
+    @tracked_lru_cache
+    def some_func(x):
+        nonlocal n_calls
+        n_calls += 1
+        return x
 
-        @tracked_lru_cache
-        def some_func(x):
-            nonlocal n_calls
-            n_calls += 1
-            return x
+    assert some_func(1) == 1
+    assert n_calls == 1
+    assert some_func(2) == 2
+    assert n_calls == 2
+    assert some_func(1) == 1
+    assert n_calls == 2
 
-        assert some_func(1) == 1
-        assert n_calls == 1
-        assert some_func(2) == 2
-        assert n_calls == 2
-        assert some_func(1) == 1
-        assert n_calls == 2
+    assert len(tracked_lru_cache.cached_functions) == 1
 
-        assert len(tracked_lru_cache.cached_functions) == 1
+    tracked_lru_cache.tracked_cache_clear()
 
-        tracked_lru_cache.tracked_cache_clear()
+    assert len(tracked_lru_cache.cached_functions) == 0
 
-        assert len(tracked_lru_cache.cached_functions) == 0
-
-        assert some_func(1) == 1
-        assert n_calls == 3
-
-    def tearDown(self):
-        tracked_lru_cache.tracked_cache_clear()
+    assert some_func(1) == 1
+    assert n_calls == 3

--- a/tests/vasp/conftest.py
+++ b/tests/vasp/conftest.py
@@ -1,6 +1,5 @@
-"""
-This module mocks functions needed for pytest.
-"""
+"""This module mocks functions needed for pytest."""
+
 import multiprocessing
 
 import pytest
@@ -8,7 +7,5 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _patch_get_potential_energy(monkeypatch):
-    """
-    Monkeypatch the multiprocessing.cpu_count() function to always return 64
-    """
+    """Monkeypatch the multiprocessing.cpu_count() function to always return 64."""
     monkeypatch.setattr(multiprocessing, "cpu_count", lambda *args, **kwargs: 64)

--- a/tests/vasp/test_handlers.py
+++ b/tests/vasp/test_handlers.py
@@ -41,9 +41,7 @@ os.environ.setdefault("PMG_VASP_PSP_DIR", TEST_FILES)
 
 @pytest.fixture(autouse=True)
 def _clear_tracked_cache():
-    """
-    Clear the cache of the stored functions between the tests.
-    """
+    """Clear the cache of the stored functions between the tests."""
     from custodian.utils import tracked_lru_cache
 
     tracked_lru_cache.tracked_cache_clear()

--- a/tests/vasp/test_io.py
+++ b/tests/vasp/test_io.py
@@ -7,9 +7,7 @@ from custodian.vasp.io import load_outcar, load_vasprun
 
 @pytest.fixture(autouse=True)
 def _clear_tracked_cache():
-    """
-    Clear the cache of the stored functions between the tests.
-    """
+    """Clear the cache of the stored functions between the tests."""
     from custodian.utils import tracked_lru_cache
 
     tracked_lru_cache.tracked_cache_clear()

--- a/tests/vasp/test_validators.py
+++ b/tests/vasp/test_validators.py
@@ -9,9 +9,7 @@ from custodian.vasp.validators import VaspAECCARValidator, VaspFilesValidator, V
 
 @pytest.fixture(autouse=True)
 def _clear_tracked_cache():
-    """
-    Clear the cache of the stored functions between the tests.
-    """
+    """Clear the cache of the stored functions between the tests."""
     from custodian.utils import tracked_lru_cache
 
     tracked_lru_cache.tracked_cache_clear()


### PR DESCRIPTION
Not needed if there are no `setUp` and `tearDown` methods.