### PR TITLE
Enable export of environment variables plus lobster run as a command

### DIFF
--- a/custodian/lobster/jobs.py
+++ b/custodian/lobster/jobs.py
@@ -87,8 +87,8 @@ class LobsterJob(Job):
             zopen(os.path.join(directory, self.stderr_file), "w", buffering=1) as f_err,
         ):
             # use line buffering for stderr
-            cmd = ' '.join(cmd) # to join split commands (e.g., from atomate and atomate2)
-            return subprocess.run(cmd, stdout=f_std, stderr=f_err, shell=True)  # pylint: disable=R1732
+            cmd = " ".join(cmd)  # to join split commands (e.g., from atomate and atomate2)
+            return subprocess.run(cmd, stdout=f_std, stderr=f_err, shell=True, check=False)  # pylint: disable=R1732
 
     def postprocess(self, directory="./"):
         """Will gzip relevant files (won't gzip custodian.json and other output files from the cluster)."""

--- a/custodian/lobster/jobs.py
+++ b/custodian/lobster/jobs.py
@@ -78,17 +78,16 @@ class LobsterJob(Job):
 
     def run(self, directory="./"):
         """Runs the job."""
-        cmd = self.lobster_cmd
+        cmd = " ".join(self.lobster_cmd)  # join split commands (e.g., from atomate and atomate2)
 
-        logger.info(f"Running {' '.join(cmd)}")
+        logger.info(f"Running {cmd}")
 
         with (
             zopen(os.path.join(directory, self.output_file), "w") as f_std,
+            # use line buffering for stderr
             zopen(os.path.join(directory, self.stderr_file), "w", buffering=1) as f_err,
         ):
-            # use line buffering for stderr
-            cmd = " ".join(cmd)  # to join split commands (e.g., from atomate and atomate2)
-            return subprocess.run(cmd, stdout=f_std, stderr=f_err, shell=True, check=False)  # pylint: disable=R1732
+            return subprocess.run(cmd, stdout=f_std, stderr=f_err, shell=True, check=False)
 
     def postprocess(self, directory="./"):
         """Will gzip relevant files (won't gzip custodian.json and other output files from the cluster)."""

--- a/custodian/lobster/jobs.py
+++ b/custodian/lobster/jobs.py
@@ -87,7 +87,8 @@ class LobsterJob(Job):
             zopen(os.path.join(directory, self.stderr_file), "w", buffering=1) as f_err,
         ):
             # use line buffering for stderr
-            return subprocess.Popen(cmd, cwd=directory, stdout=f_std, stderr=f_err)  # pylint: disable=R1732
+            cmd = ' '.join(cmd) # to join split commands (e.g., from atomate and atomate2)
+            return subprocess.run(cmd, stdout=f_std, stderr=f_err, shell=True)  # pylint: disable=R1732
 
     def postprocess(self, directory="./"):
         """Will gzip relevant files (won't gzip custodian.json and other output files from the cluster)."""

--- a/custodian/lobster/jobs.py
+++ b/custodian/lobster/jobs.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import shlex
 import shutil
 import subprocess
 
@@ -78,7 +79,8 @@ class LobsterJob(Job):
 
     def run(self, directory="./"):
         """Runs the job."""
-        cmd = " ".join(self.lobster_cmd)  # join split commands (e.g., from atomate and atomate2)
+        # join split commands (e.g. from atomate and atomate2)
+        cmd = self.lobster_cmd if isinstance(self.lobster_cmd, str) else shlex.join(self.lobster_cmd)
 
         logger.info(f"Running {cmd}")
 


### PR DESCRIPTION
## Summary

This will enable using "NUM_OMP_THREADS=48 /bin/lobster-command" as a command. With this, running VASP and LOBSTER within one job-script with jobflow and atomate2 only (without installing fireworks or jobflow remote) will be possible. If users rely on one 1 CPU node only, this should ensure good run times.

(cc @naik-aakash )