### PR TITLE
Fix the FileNotFound error for the Gaussian tests and add type annotations 

### DIFF
--- a/custodian/gaussian/handlers.py
+++ b/custodian/gaussian/handlers.py
@@ -297,12 +297,12 @@ class GaussianErrorHandler(ErrorHandler):
         return False
 
     @staticmethod
-    def convert_mem(mem: float | int, unit: str) -> float:
+    def convert_mem(mem: float, unit: str) -> float:
         """
         Convert memory size between different units to megabytes (MB).
 
         Args:
-            mem (float | int): The memory size to convert.
+            mem (float): The memory size to convert.
             unit (str): The unit of the input memory size. Supported units include
                 'kb', 'mb', 'gb', 'tb', and word units ('kw', 'mw', 'gw', 'tw'), or an
                 empty string for default conversion (from words).

--- a/tests/gaussian/test_handlers.py
+++ b/tests/gaussian/test_handlers.py
@@ -22,8 +22,9 @@ CWD = os.getcwd()
 
 def gunzip_file(gauss_file):
     output_file = os.path.splitext(gauss_file)[0]
-    with gzip.open(gauss_file, "rb") as f_in, open(output_file, "wb") as f_out:
-        shutil.copyfileobj(f_in, f_out)
+    if not os.path.exists(output_file) and os.path.exists(gauss_file):
+        with gzip.open(gauss_file, "rb") as f_in, open(output_file, "wb") as f_out:
+            shutil.copyfileobj(f_in, f_out)
     return output_file
 
 
@@ -310,8 +311,9 @@ class TestGaussianErrorHandler(TestCase):
         os.chdir(CWD)
         shutil.rmtree(SCR_DIR)
         files_to_remove = glob.glob(f"{TEST_DIR}/*.out")
-        for file_path in files_to_remove:
-            os.remove(file_path)
+        if files_to_remove and glob.glob(f"{TEST_DIR}/*.out.gz"):
+            for file_path in files_to_remove:
+                os.remove(file_path)
 
 
 class TestWallTimeErrorHandler(TestCase):
@@ -367,5 +369,6 @@ class TestWallTimeErrorHandler(TestCase):
         os.chdir(CWD)
         shutil.rmtree(SCR_DIR)
         files_to_remove = glob.glob(f"{TEST_DIR}/*.out")
-        for file_path in files_to_remove:
-            os.remove(file_path)
+        if files_to_remove and glob.glob(f"{TEST_DIR}/*.out.gz"):
+            for file_path in files_to_remove:
+                os.remove(file_path)

--- a/tests/gaussian/test_jobs.py
+++ b/tests/gaussian/test_jobs.py
@@ -37,8 +37,9 @@ class TestGaussianJob(TestCase):
         os.chdir(CWD)
         shutil.rmtree(SCR_DIR)
         files_to_remove = glob.glob(f"{TEST_DIR}/*.out")
-        for file_path in files_to_remove:
-            os.remove(file_path)
+        if files_to_remove and glob.glob(f"{TEST_DIR}/*.out.gz"):
+            for file_path in files_to_remove:
+                os.remove(file_path)
 
     def test_normal(self):
         g = GaussianJob(
@@ -51,8 +52,9 @@ class TestGaussianJob(TestCase):
         )
         g.setup()
         assert os.path.exists(f"{SCR_DIR}/test.com.orig")
-        with gzip.open(f"{TEST_DIR}/mol_opt.out.gz", "rb") as f_in, open(f"{TEST_DIR}/mol_opt.out", "wb") as f_out:
-            shutil.copyfileobj(f_in, f_out)
+        if not os.path.exists(f"{TEST_DIR}/mol_opt.out") and os.path.exists(f"{TEST_DIR}/mol_opt.out.gz"):
+            with gzip.open(f"{TEST_DIR}/mol_opt.out.gz", "rb") as f_in, open(f"{TEST_DIR}/mol_opt.out", "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out)
         shutil.copy(f"{TEST_DIR}/mol_opt.out", f"{SCR_DIR}/test.out")
         g.postprocess()
         assert os.path.exists(f"{SCR_DIR}/test.com{self.suffix}")
@@ -72,8 +74,9 @@ class TestGaussianJob(TestCase):
         assert len(jobs) == 1, "One job should be generated under normal conditions."
         jobs[0].setup()
         assert os.path.exists(f"{SCR_DIR}/test.com.orig")
-        with gzip.open(f"{TEST_DIR}/mol_opt.out.gz", "rb") as f_in, open(f"{TEST_DIR}/mol_opt.out", "wb") as f_out:
-            shutil.copyfileobj(f_in, f_out)
+        if not os.path.exists(f"{TEST_DIR}/mol_opt.out") and os.path.exists(f"{TEST_DIR}/mol_opt.out.gz"):
+            with gzip.open(f"{TEST_DIR}/mol_opt.out.gz", "rb") as f_in, open(f"{TEST_DIR}/mol_opt.out", "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out)
         shutil.copy(f"{TEST_DIR}/mol_opt.out", f"{SCR_DIR}/test.out")
         jobs[0].postprocess()
         assert os.path.exists(f"{SCR_DIR}/test.com.guess1")

--- a/tests/gaussian/test_jobs.py
+++ b/tests/gaussian/test_jobs.py
@@ -59,7 +59,7 @@ class TestGaussianJob(TestCase):
         assert os.path.exists(f"{SCR_DIR}/test.out{self.suffix}")
 
     def test_better_guess(self):
-        g = GaussianJob.better_guess(
+        g = GaussianJob.generate_better_guess(
             self.gaussian_cmd,
             self.input_file,
             self.output_file,


### PR DESCRIPTION
## Summary

- Fix the issue with Gaussian test files getting unzipped automatically, which was leading to a FileNotFound error for all Gaussian output test files. 
- Add type annotations to GaussianErrorHandler 

Follow up to [#328](https://github.com/materialsproject/custodian/pull/328)