### PR TITLE
Fix breaking change to ISMEAR=-5 handling for NKPT<4

### DIFF
--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -193,21 +193,10 @@ class VaspErrorHandler(ErrorHandler):
             # follow advice in this thread
             # https://vasp.at/forum/viewtopic.php?f=3&t=416&p=4047&hilit=dentet#p4047
             err_type = "tet" if "tet" in self.errors else "dentet"
-            if self.error_count[err_type] == 0:
-                if vi["INCAR"].get("KSPACING"):
-                    # decrease KSPACING by 20% in each direction (approximately double no. of kpoints)
-                    action = {"_set": {"KSPACING": vi["INCAR"].get("KSPACING") * 0.8}}
-                    actions.append({"dict": "INCAR", "action": action})
-                elif vi["KPOINTS"] and vi["KPOINTS"].num_kpts < 1:
-                    # increase KPOINTS by 20% in each direction (approximately double no. of kpoints)
-                    new_kpts = tuple(int(round(num * 1.2, 0)) for num in vi["KPOINTS"].kpts[0])
-                    actions.append({"dict": "KPOINTS", "action": {"_set": {"kpoints": (new_kpts,)}}})
-                elif vi["KPOINTS"] and vi["KPOINTS"].num_kpts >= 1:
-                    n_kpts = vi["KPOINTS"].num_kpts * 1.2
-                    new_kpts = tuple([int(round(n_kpts**1 / 3, 0))] * 3)
-                    actions.append(
-                        {"dict": "KPOINTS", "action": {"_set": {"generation_style": "Gamma", "kpoints": (new_kpts,)}}}
-                    )
+            if vi["INCAR"].get("KSPACING"):
+                # decrease KSPACING by 20% in each direction (approximately double no. of kpoints)
+                action = {"_set": {"KSPACING": vi["INCAR"].get("KSPACING") * 0.8}}
+                actions.append({"dict": "INCAR", "action": action})
             else:
                 actions.append({"dict": "INCAR", "action": {"_set": {"ISMEAR": 0, "SIGMA": 0.05}}})
             self.error_count[err_type] += 1

--- a/custodian/vasp/handlers.py
+++ b/custodian/vasp/handlers.py
@@ -192,14 +192,12 @@ class VaspErrorHandler(ErrorHandler):
         if self.errors.intersection(["tet", "dentet"]):
             # follow advice in this thread
             # https://vasp.at/forum/viewtopic.php?f=3&t=416&p=4047&hilit=dentet#p4047
-            err_type = "tet" if "tet" in self.errors else "dentet"
             if vi["INCAR"].get("KSPACING"):
                 # decrease KSPACING by 20% in each direction (approximately double no. of kpoints)
                 action = {"_set": {"KSPACING": vi["INCAR"].get("KSPACING") * 0.8}}
                 actions.append({"dict": "INCAR", "action": action})
             else:
                 actions.append({"dict": "INCAR", "action": {"_set": {"ISMEAR": 0, "SIGMA": 0.05}}})
-            self.error_count[err_type] += 1
 
         # Missing AMIN error handler:
         # previously, custodian would kill the job without letting it run if AMIN was flagged

--- a/tests/vasp/test_handlers.py
+++ b/tests/vasp/test_handlers.py
@@ -111,6 +111,7 @@ class VaspErrorHandlerTest(PymatgenTest):
         assert dct["errors"] == ["tet"]
         assert dct["actions"] == [{"action": {"_set": {"kpoints": ((10, 2, 2),)}}, "dict": "KPOINTS"}]
 
+        handler = VaspErrorHandler("vasp.teterror")
         handler.check()
         dct = handler.correct()
         assert dct["errors"] == ["tet"]
@@ -157,11 +158,6 @@ class VaspErrorHandlerTest(PymatgenTest):
 
     def test_dentet(self) -> None:
         handler = VaspErrorHandler("vasp.dentet")
-        handler.check()
-        dct = handler.correct()
-        assert dct["errors"] == ["dentet"]
-        assert dct["actions"] == [{"action": {"_set": {"kpoints": ((10, 2, 2),)}}, "dict": "KPOINTS"}]
-
         handler.check()
         dct = handler.correct()
         assert dct["errors"] == ["dentet"]
@@ -514,13 +510,6 @@ class VaspErrorHandlerTest(PymatgenTest):
         assert handler.check() is True
         dct = handler.correct()
         assert dct["errors"] == ["tet"]
-        incar = Incar.from_file("INCAR")
-        assert incar["ISMEAR"] == -5
-        assert incar["SIGMA"] == 0.05
-        assert dct["actions"] == [{"action": {"_set": {"kpoints": ((10, 2, 2),)}}, "dict": "KPOINTS"}]
-
-        assert handler.check() is True
-        assert handler.correct()["errors"] == ["tet"]
         incar = Incar.from_file("INCAR")
         assert incar["ISMEAR"] == 0
         assert incar["SIGMA"] == 0.05

--- a/tests/vasp/test_handlers.py
+++ b/tests/vasp/test_handlers.py
@@ -109,12 +109,6 @@ class VaspErrorHandlerTest(PymatgenTest):
         handler.check()
         dct = handler.correct()
         assert dct["errors"] == ["tet"]
-        assert dct["actions"] == [{"action": {"_set": {"kpoints": ((10, 2, 2),)}}, "dict": "KPOINTS"}]
-
-        handler = VaspErrorHandler("vasp.teterror")
-        handler.check()
-        dct = handler.correct()
-        assert dct["errors"] == ["tet"]
         assert dct["actions"] == [{"action": {"_set": {"ISMEAR": 0, "SIGMA": 0.05}}, "dict": "INCAR"}]
 
         handler = VaspErrorHandler("vasp.teterror", errors_subset_to_catch=["eddrmm"])


### PR DESCRIPTION
Closes #335. See the tagged issue report for full details.

In short, this PR reverts the breaking changes made in #284 related to handling ISMEAR = -5 for NKPT<4. The change in #284 does not work and even if it did, it would not be the wisest course of action. I also split up the "tet" and "dentet" error handling because those are two separate errors that can, in principle, be handled differently.