### PR TITLE
small fixes to propagate directory

### DIFF
--- a/src/custodian/cp2k/interpreter.py
+++ b/src/custodian/cp2k/interpreter.py
@@ -42,7 +42,7 @@ class Cp2kModder(Modder):
         self.ci = ci or Cp2kInput.from_file(os.path.join(self.directory, filename))
         self.filename = filename
         actions = actions or [FileActions, DictActions]
-        super().__init__(actions, strict)
+        super().__init__(actions, strict, directory=directory)
 
     def apply_actions(self, actions) -> None:
         """

--- a/src/custodian/cp2k/jobs.py
+++ b/src/custodian/cp2k/jobs.py
@@ -101,11 +101,19 @@ class Cp2kJob(Job):
             )
 
         if self.settings_override or self.restart:
-            modder = Cp2kModder(filename=os.path.join(directory, self.input_file), actions=[], ci=self.ci)
+            modder = Cp2kModder(
+                filename=os.path.join(directory, self.input_file),
+                actions=[],
+                ci=self.ci,
+                directory=directory,
+            )
             modder.apply_actions(self.settings_override)
 
         if self.backup:
-            shutil.copy(os.path.join(directory, self.input_file), os.path.join(directory, f"{self.input_file}.orig"))
+            shutil.copy(
+                os.path.join(directory, self.input_file),
+                os.path.join(directory, f"{self.input_file}.orig"),
+            )
 
     def run(self, directory="./"):
         """
@@ -138,9 +146,15 @@ class Cp2kJob(Job):
                     continue
                 if not os.path.isdir(os.path.join(directory, file)):
                     if self.final:
-                        shutil.move(os.path.join(directory, file), os.path.join(directory, f"run{self.suffix}/{file}"))
+                        shutil.move(
+                            os.path.join(directory, file),
+                            os.path.join(directory, f"run{self.suffix}/{file}"),
+                        )
                     else:
-                        shutil.copy(os.path.join(directory, file), os.path.join(directory, f"run{self.suffix}/{file}"))
+                        shutil.copy(
+                            os.path.join(directory, file),
+                            os.path.join(directory, f"run{self.suffix}/{file}"),
+                        )
 
         # Remove continuation so if a subsequent job is run in
         # the same directory, will not restart this job.
@@ -200,7 +214,12 @@ class Cp2kJob(Job):
 
         ci = Cp2kInput.from_file(zpath(os.path.join(directory, input_file)))
         run_type = ci["global"].get("run_type", Keyword("RUN_TYPE", "ENERGY_FORCE")).values[0]
-        if run_type in {"ENERGY", "WAVEFUNCTION_OPTIMIZATION", "WFN_OPT", "ENERGY_FORCE"}:  # no need for double job
+        if run_type in {
+            "ENERGY",
+            "WAVEFUNCTION_OPTIMIZATION",
+            "WFN_OPT",
+            "ENERGY_FORCE",
+        }:  # no need for double job
             return [job1]
 
         job2_settings_override = [
@@ -270,7 +289,10 @@ class Cp2kJob(Job):
         run_type = ci["global"].get("run_type", Keyword("RUN_TYPE", "ENERGY_FORCE")).values[0]
         if run_type not in {"ENERGY", "WAVEFUNCTION_OPTIMIZATION", "WFN_OPT"}:
             job1.settings_override = [
-                {"dict": input_file, "action": {"_set": {"GLOBAL": {"RUN_TYPE": "ENERGY_FORCE"}}}}
+                {
+                    "dict": input_file,
+                    "action": {"_set": {"GLOBAL": {"RUN_TYPE": "ENERGY_FORCE"}}},
+                }
             ]
 
         job2 = Cp2kJob(
@@ -337,7 +359,12 @@ class Cp2kJob(Job):
 
         ci = Cp2kInput.from_file(zpath(os.path.join(directory, input_file)))
         r = ci["global"].get("run_type", Keyword("RUN_TYPE", "ENERGY_FORCE")).values[0]
-        if r in {"ENERGY", "WAVEFUNCTION_OPTIMIZATION", "WFN_OPT", "ENERGY_FORCE"}:  # no need for double job
+        if r in {
+            "ENERGY",
+            "WAVEFUNCTION_OPTIMIZATION",
+            "WFN_OPT",
+            "ENERGY_FORCE",
+        }:  # no need for double job
             return [job1]
 
         job2_settings_override = [

--- a/src/custodian/feff/interpreter.py
+++ b/src/custodian/feff/interpreter.py
@@ -32,7 +32,7 @@ class FeffModder(Modder):
         self.feffinp = feffinp or FEFFDictSet.from_directory(self.directory)
         self.feffinp = self.feffinp.all_input()
         actions = actions or [FileActions, DictActions]
-        super().__init__(actions, strict)
+        super().__init__(actions, strict, directory=directory)
 
     def apply_actions(self, actions) -> None:
         """

--- a/src/custodian/vasp/interpreter.py
+++ b/src/custodian/vasp/interpreter.py
@@ -30,7 +30,7 @@ class VaspModder(Modder):
         self.vi = vi or VaspInput.from_directory(directory)
         self.directory = directory
         actions = actions or [FileActions, DictActions]
-        super().__init__(actions, strict)
+        super().__init__(actions, strict, directory=directory)
 
     def apply_actions(self, actions) -> None:
         """


### PR DESCRIPTION
## Summary

Address #340 . Problem: the base Modder() class also sets the directory, so the call to the super `__init__` also needs the directory. 

## Todos

Could do with some unit tests! Nothing new added though. 
