### PR TITLE
Add JDFTx jobs.py to run JDFTx using atomate2/jobflow

### DIFF
--- a/src/custodian/jdftx/__init__.py
+++ b/src/custodian/jdftx/__init__.py
@@ -1,0 +1,4 @@
+"""
+This package implements various JDFTx Jobs and Error Handlers.
+Used Cp2kJob developed by Nick Winner as a template.
+"""

--- a/src/custodian/jdftx/jobs.py
+++ b/src/custodian/jdftx/jobs.py
@@ -16,8 +16,6 @@ class JDFTxJob(Job):
     # job = JDFTxJob()
     # job.run()  # assumes input files already written to directory
 
-    # Used Cp2kJob developed by Nick Winner as a template.
-
     def __init__(
         self,
         jdftx_cmd,

--- a/src/custodian/jdftx/jobs.py
+++ b/src/custodian/jdftx/jobs.py
@@ -1,0 +1,88 @@
+"""This module implements basic kinds of jobs for JDFTx runs."""
+
+import logging
+import os
+import subprocess
+
+from custodian.custodian import Job
+
+logger = logging.getLogger(__name__)
+
+
+class JDFTxJob(Job):
+    """A basic JDFTx job. Runs whatever is in the working directory."""
+
+    # If testing, use something like:
+    # job = JDFTxJob()
+    # job.run()  # assumes input files already written to directory
+
+    # Used Cp2kJob developed by Nick Winner as a template.
+
+    def __init__(
+        self,
+        jdftx_cmd,
+        input_file="jdftx.in",
+        output_file="jdftx.out",
+        stderr_file="std_err.txt",
+    ) -> None:
+        """
+        This constructor is necessarily complex due to the need for
+        flexibility. For standard kinds of runs, it's often better to use one
+        of the static constructors. The defaults are usually fine too.
+
+        Args:
+            jdftx_cmd (str): Command to run JDFTx as a string.
+            input_file (str): Name of the file to use as input to JDFTx
+                executable. Defaults to "input.in"
+            output_file (str): Name of file to direct standard out to.
+                Defaults to "jdftx.out".
+            stderr_file (str): Name of file to direct standard error to.
+                Defaults to "std_err.txt".
+        """
+        self.jdftx_cmd = jdftx_cmd
+        self.input_file = input_file
+        self.output_file = output_file
+        self.stderr_file = stderr_file
+
+    def setup(self, directory="./") -> None:
+        """No setup required."""
+
+    def run(self, directory="./"):
+        """
+        Perform the actual JDFTx run.
+
+        Returns:
+        -------
+            (subprocess.Popen) Used for monitoring.
+        """
+        cmd = self.jdftx_cmd + " -i " + self.input_file + " -o " + self.output_file
+        logger.info(f"Running {cmd}")
+        with (
+            open(os.path.join(directory, self.output_file), "w") as f_std,
+            open(os.path.join(directory, self.stderr_file), "w", buffering=1) as f_err,
+        ):
+            # use line buffering for stderr
+            return subprocess.run(
+                cmd.split(),
+                cwd=directory,
+                stdout=f_std,
+                stderr=f_err,
+                shell=False,
+                check=False,
+            )
+
+    def postprocess(self, directory="./") -> None:
+        """No post-processing required."""
+
+    def terminate(self, directory="./") -> None:
+        """Terminate JDFTx."""
+        # This will kill any running process with "jdftx" in the name,
+        # this might have unintended consequences if running multiple jdftx processes
+        # on the same node.
+        for cmd in self.jdftx_cmd:
+            if "jdftx" in cmd:
+                try:
+                    os.system(f"killall {cmd}")
+                except Exception as e:
+                    print(f"Unexpected error occurred: {e}")
+                    raise


### PR DESCRIPTION
## Summary

Hi,
This PR is to add jobs.py for JDFTx. We have a draft PR open on atomate2 to integrate JDFTx, but it seems that this script belongs here. Jobs.py was created using the CP2K template, with only the basic functionalities for now (just enough to run a job). 


## Todos

If this is work in progress, what else needs to be done?

- feature 2: ...
- fix 2:

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
