### PR TITLE
Fix installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ Package = "https://pypi.org/project/custodian"
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["custodian"]
+include = ["custodian*"]
 
 [tool.ruff]
 target-version = "py311"


### PR DESCRIPTION
## Summary

Major changes:

- Fix the broken pip installation 

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
