### PR TITLE
`NonConvergingErrorHandler` document `AMIX` maybe ineffective in helping SCF convergence

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,16 +2,16 @@ exclude: ^(docs|tests/files|tasks.py)
 
 ci:
   autoupdate_schedule: monthly
-  skip: [ mypy, pyright ]
+  skip: [mypy, pyright]
   autofix_commit_msg: pre-commit auto-fixes
   autoupdate_commit_msg: pre-commit autoupdate
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.2
+    rev: v0.8.3
     hooks:
       - id: ruff
-        args: [ --fix, --unsafe-fixes ]
+        args: [--fix, --unsafe-fixes]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -30,16 +30,9 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
-        stages: [ commit-msg ]
-        exclude_types: [ html ]
-        additional_dependencies: [ tomli ] # needed to read pyproject.toml below py3.11
-
-  - repo: https://github.com/MarcoGorelli/cython-lint
-    rev: v0.16.2
-    hooks:
-      - id: cython-lint
-        args: [ --no-pycodestyle ]
-      - id: double-quote-cython-strings
+        stages: [commit-msg]
+        exclude_types: [html]
+        additional_dependencies: [tomli] # needed to read pyproject.toml below py3.11
 
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.19.1
@@ -47,7 +40,7 @@ repos:
       - id: blacken-docs
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.42.0
+    rev: v0.43.0
     hooks:
       - id: markdownlint
         # MD013: line too long
@@ -55,15 +48,9 @@ repos:
         # MD033: no inline HTML
         # MD041: first line in a file should be a top-level heading
         # MD025: single title
-        args: [ --disable, MD013, MD024, MD025, MD033, MD041, "--" ]
-
-  - repo: https://github.com/kynan/nbstripout
-    rev: 0.8.0
-    hooks:
-      - id: nbstripout
-        args: [ --drop-empty-cells, --keep-output ]
+        args: [--disable, MD013, MD024, MD025, MD033, MD041, "--"]
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.387
+    rev: v1.1.390
     hooks:
       - id: pyright

--- a/src/custodian/vasp/handlers.py
+++ b/src/custodian/vasp/handlers.py
@@ -1560,6 +1560,9 @@ class NonConvergingErrorHandler(ErrorHandler):
     Check if a run is hitting the maximum number of electronic steps at the
     last nionic_steps ionic steps (default=10). If so, change ALGO using a
     multi-step ladder scheme or kill the job.
+
+    In some cases (ALGO=All or ALGO=Normal and ISMEAR < 0), this handler also changes AMIX
+    and BMIX but unsure if this helps much. Some anecdotal evidence suggests it doesn't.
     """
 
     is_monitor = True

--- a/src/custodian/vasp/jobs.py
+++ b/src/custodian/vasp/jobs.py
@@ -725,7 +725,7 @@ class VaspJob(Job):
                         proc.kill()
                         return
             except (psutil.NoSuchProcess, psutil.AccessDenied) as exc:
-                logger.warning(f"Exception {exc} encountered while killing VASP.")
+                logger.exception(f"Exception {exc} encountered while killing VASP.")
                 continue
 
         logger.warning(

--- a/src/custodian/vasp/utils.py
+++ b/src/custodian/vasp/utils.py
@@ -18,6 +18,7 @@ def _estimate_num_k_points_from_kspacing(structure: Structure, kspacing: float) 
     Inputs:
         structure (Structure): structure used in the calculation
         kspacing (float): KSPACING used in the calculation
+
     Returns:
         tuple[int,int,int] : the number of estimated k-points on each axis.
 


### PR DESCRIPTION
also use `logger.exception` instead of `logger.warning` in `VaspJob.terminate` to get full stacktrace which can help a lot with debugging

I discussed `AMIX` effectiveness with @Andrew-S-Rosen prior to this PR. also pinging @esoteric-ephemera in case you want to chime in