### PR TITLE
Add FEXCF and IBZKPT error handling for VASP

### DIFF
--- a/src/custodian/vasp/handlers.py
+++ b/src/custodian/vasp/handlers.py
@@ -137,6 +137,8 @@ class VaspErrorHandler(ErrorHandler):
         "set_core_wf": ["internal error in SET_CORE_WF"],
         "read_error": ["Error reading item", "Error code was IERR= 5"],
         "auto_nbands": ["The number of bands has been changed"],
+        "ibzkpt": ["not all point group operations"],
+        "fexcf": ["supplied exchange-correlation table"],
     }
 
     def __init__(
@@ -208,6 +210,20 @@ class VaspErrorHandler(ErrorHandler):
 
         if "tet" in self.errors:
             actions.append({"dict": "INCAR", "action": {"_set": {"ISMEAR": 0, "SIGMA": 0.05}}})
+
+        if "ibzkpt" in self.errors:
+            # Discussion here:
+            # https://www.vasp.at/forum/viewtopic.php?p=24485
+            if self.error_count["ibzkpt"] == 0 and vi["INCAR"].get("ISYM", 2) != 0:
+                actions.append({"dict": "INCAR", "action": {"_set": {"ISYM": 0}}})
+            elif self.error_count["ibzkpt"] == 1 and vi["INCAR"].get("SYMPREC", 1e-5) > 1e-6:
+                actions.append({"dict": "INCAR", "action": {"_set": {"SYMPREC": 1e-6}}})
+            self.error_count["ibzkpt"] += 1
+
+        if "fexcf" in self.errors:
+            # Minimal fixes suggested here, only practical one is CONTCAR --> POSCAR
+            # https://www.vasp.at/forum/viewtopic.php?p=14827
+            actions.append({"file": "CONTCAR", "action": {"_file_copy": {"dest": "POSCAR"}}})
 
         if "dentet" in self.errors:
             # For dentet: follow advice in this thread

--- a/src/custodian/vasp/handlers.py
+++ b/src/custodian/vasp/handlers.py
@@ -223,7 +223,13 @@ class VaspErrorHandler(ErrorHandler):
         if "fexcf" in self.errors:
             # Minimal fixes suggested here, only practical one is CONTCAR --> POSCAR
             # https://www.vasp.at/forum/viewtopic.php?p=14827
-            actions.append({"file": "CONTCAR", "action": {"_file_copy": {"dest": "POSCAR"}}})
+            if self.error_count["fexcf"] == 0:
+                # First see if last ionic configuration is more stable on rerun
+                actions.append({"file": "CONTCAR", "action": {"_file_copy": {"dest": "POSCAR"}}})
+            elif self.error_count["fexcf"] == 1 and vi["INCAR"].get("IBRION", -1) == 1:
+                # Try more stable geometry optimization method
+                actions.append({"dict": "INCAR", "action": {"_set": {"IBRION": 2}}})
+            self.error_count["fexcf"] += 1
 
         if "dentet" in self.errors:
             # For dentet: follow advice in this thread

--- a/src/custodian/vasp/jobs.py
+++ b/src/custodian/vasp/jobs.py
@@ -988,6 +988,9 @@ def _gamma_point_only_check(vis: VaspInput) -> bool:
     """
     Check if only a single k-point is used in this calculation.
 
+    Additionally, ensure that density functional perturbation theory
+    (DFPT) calculations are not being run - these cannot use Gamma-only.
+
     Parameters
     -----------
     vis: VaspInput, the VASP input set for the calculation
@@ -997,6 +1000,11 @@ def _gamma_point_only_check(vis: VaspInput) -> bool:
     bool: True --> use vasp_gam, False --> use vasp_std
     """
     kpts = vis["KPOINTS"]
+
+    if any(vis["INCAR"].get(k, False) for k in ("LEPSILON", "LOPTICS")):
+        # Prevent VASP gamma from being run on DFPT tasks.
+        return False
+
     if (
         kpts is not None
         and kpts.style == Kpoints.supported_modes.Gamma


### PR DESCRIPTION
Adds support for correcting two VASP errors:
- [FEXCF](https://www.vasp.at/forum/viewtopic.php?p=14827), close #365
- [IBZKPT](https://www.vasp.at/forum/viewtopic.php?p=24485)

Also ensure that $\Gamma$-point only VASP isn't run when DFPT calcs are run (either / both `LEPSILON` or `LOPTICS` are True)

To do:
- Add tests