### PR TITLE
Use `vasp_gam` for 1x1x1 k-point grids regardless of whether it is gamma-centered or not

### DIFF
--- a/src/custodian/vasp/jobs.py
+++ b/src/custodian/vasp/jobs.py
@@ -1005,11 +1005,7 @@ def _gamma_point_only_check(vis: VaspInput) -> bool:
         # Prevent VASP gamma from being run on DFPT tasks.
         return False
 
-    if (
-        kpts is not None
-        and tuple(kpts.kpts[0]) == (1, 1, 1)
-        and all(abs(ks) < 1.0e-6 for ks in kpts.kpts_shift)
-    ):
+    if kpts is not None and tuple(kpts.kpts[0]) == (1, 1, 1) and all(abs(ks) < 1.0e-6 for ks in kpts.kpts_shift):
         return True
 
     if (kspacing := vis["INCAR"].get("KSPACING")) is not None:

--- a/src/custodian/vasp/jobs.py
+++ b/src/custodian/vasp/jobs.py
@@ -1007,13 +1007,12 @@ def _gamma_point_only_check(vis: VaspInput) -> bool:
 
     if (
         kpts is not None
-        and kpts.style == Kpoints.supported_modes.Gamma
         and tuple(kpts.kpts[0]) == (1, 1, 1)
         and all(abs(ks) < 1.0e-6 for ks in kpts.kpts_shift)
     ):
         return True
 
-    if (kspacing := vis["INCAR"].get("KSPACING")) is not None and vis["INCAR"].get("KGAMMA", True):
+    if (kspacing := vis["INCAR"].get("KSPACING")) is not None:
         # Get number of kpoints per axis according to the formula given by VASP:
         # https://www.vasp.at/wiki/index.php/KSPACING
         # Note that the VASP definition of the closure relation between reciprocal

--- a/tests/vasp/test_jobs.py
+++ b/tests/vasp/test_jobs.py
@@ -211,8 +211,8 @@ class TestAutoGamma:
         assert not _gamma_point_only_check(vis.get_input_set())
 
         # KSPACING-related checks
-        vis = MPRelaxSet(structure=structure, user_incar_settings={"KSPACING": 0.5})
-        assert _gamma_point_only_check(vis.get_input_set())
+        vis = MPRelaxSet(structure=structure, user_incar_settings={"KSPACING": 0.005})
+        assert not _gamma_point_only_check(vis.get_input_set())
 
         vis = MPRelaxSet(structure=structure, user_incar_settings={"KSPACING": 50})
-        assert not _gamma_point_only_check(vis.get_input_set())
+        assert _gamma_point_only_check(vis.get_input_set())

--- a/tests/vasp/test_jobs.py
+++ b/tests/vasp/test_jobs.py
@@ -204,7 +204,7 @@ class TestAutoGamma:
         assert _gamma_point_only_check(vis.get_input_set())
 
         # no longer Gamma-centered
-        vis = MPRelaxSet(structure=structure, user_kpoints_settings=Kpoints([(2, 1 ,1)])
+        vis = MPRelaxSet(structure=structure, user_kpoints_settings=Kpoints([(2, 1 ,1)]))
         assert not _gamma_point_only_check(vis.get_input_set())
 
         vis = MPRelaxSet(structure=structure, user_kpoints_settings=Kpoints(kpts_shift=(0.1, 0.0, 0.0)))

--- a/tests/vasp/test_jobs.py
+++ b/tests/vasp/test_jobs.py
@@ -201,16 +201,18 @@ class TestAutoGamma:
 
         vis = MPRelaxSet(structure=structure)
         assert vis.kpoints.kpts == [(1, 1, 1)]
-        assert vis.kpoints.style.name == "Gamma"
         assert _gamma_point_only_check(vis.get_input_set())
 
         # no longer Gamma-centered
+        vis = MPRelaxSet(structure=structure, user_kpoints_settings=Kpoints([(2, 1 ,1]))
+        assert not _gamma_point_only_check(vis.get_input_set())
+        
         vis = MPRelaxSet(structure=structure, user_kpoints_settings=Kpoints(kpts_shift=(0.1, 0.0, 0.0)))
         assert not _gamma_point_only_check(vis.get_input_set())
 
-        # have to increase KSPACING or this will result in a non 1 x 1 x 1 grid
+        # KSPACING-related checks
         vis = MPRelaxSet(structure=structure, user_incar_settings={"KSPACING": 0.5})
         assert _gamma_point_only_check(vis.get_input_set())
 
-        vis = MPRelaxSet(structure=structure, user_incar_settings={"KSPACING": 0.5, "KGAMMA": False})
+        vis = MPRelaxSet(structure=structure, user_incar_settings={"KSPACING": 50})
         assert not _gamma_point_only_check(vis.get_input_set())

--- a/tests/vasp/test_jobs.py
+++ b/tests/vasp/test_jobs.py
@@ -204,7 +204,7 @@ class TestAutoGamma:
         assert _gamma_point_only_check(vis.get_input_set())
 
         # no longer Gamma-centered
-        vis = MPRelaxSet(structure=structure, user_kpoints_settings=Kpoints([(2, 1 ,1]))
+        vis = MPRelaxSet(structure=structure, user_kpoints_settings=Kpoints([(2, 1 ,1)])
         assert not _gamma_point_only_check(vis.get_input_set())
 
         vis = MPRelaxSet(structure=structure, user_kpoints_settings=Kpoints(kpts_shift=(0.1, 0.0, 0.0)))

--- a/tests/vasp/test_jobs.py
+++ b/tests/vasp/test_jobs.py
@@ -206,7 +206,7 @@ class TestAutoGamma:
         # no longer Gamma-centered
         vis = MPRelaxSet(structure=structure, user_kpoints_settings=Kpoints([(2, 1 ,1]))
         assert not _gamma_point_only_check(vis.get_input_set())
-        
+
         vis = MPRelaxSet(structure=structure, user_kpoints_settings=Kpoints(kpts_shift=(0.1, 0.0, 0.0)))
         assert not _gamma_point_only_check(vis.get_input_set())
 

--- a/tests/vasp/test_jobs.py
+++ b/tests/vasp/test_jobs.py
@@ -204,7 +204,7 @@ class TestAutoGamma:
         assert _gamma_point_only_check(vis.get_input_set())
 
         # no longer Gamma-centered
-        vis = MPRelaxSet(structure=structure, user_kpoints_settings=Kpoints([(2, 1 ,1)]))
+        vis = MPRelaxSet(structure=structure, user_kpoints_settings=Kpoints([(2, 1, 1)]))
         assert not _gamma_point_only_check(vis.get_input_set())
 
         vis = MPRelaxSet(structure=structure, user_kpoints_settings=Kpoints(kpts_shift=(0.1, 0.0, 0.0)))

--- a/tests/vasp/test_jobs.py
+++ b/tests/vasp/test_jobs.py
@@ -204,7 +204,7 @@ class TestAutoGamma:
         assert _gamma_point_only_check(vis.get_input_set())
 
         # no longer Gamma-centered
-        vis = MPRelaxSet(structure=structure, user_kpoints_settings=Kpoints([(2, 1, 1)]))
+        vis = MPRelaxSet(structure=structure, user_kpoints_settings=Kpoints(kpts=[2, 1, 1]))
         assert not _gamma_point_only_check(vis.get_input_set())
 
         vis = MPRelaxSet(structure=structure, user_kpoints_settings=Kpoints(kpts_shift=(0.1, 0.0, 0.0)))


### PR DESCRIPTION
## Summary

Closes #374.

This PR makes a change to the logic for choosing whether a VASP calculation should be run with the gamma-point only version of VASP (typically `vasp_gam`) or not. Specifically, we no longer check for whether the KPOINTS file is gamma-centered or not. This is because a 1x1x1 Monkhorst-Pack grid should be the same as a 1x1x1 Gamma-centered grid. An analogous change was made for the KSPACING-related check.

The tests have been updated, and two previously missing tests have been added:
- A test to make sure the standard version of VASP is used when the kpoints are not 1x1x1
- A test to make sure that the standard version of VASP is used when a small KSPACING is set

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
