### PR TITLE
Fix `custodian.utils.backup` when `directory` keyword argument is set

### DIFF
--- a/src/custodian/utils.py
+++ b/src/custodian/utils.py
@@ -25,7 +25,7 @@ def backup(filenames, prefix="error", directory="./") -> None:
     logging.info(f"Backing up run to {filename}.")
     with tarfile.open(filename, "w:gz") as tar:
         for fname in filenames:
-            for file in glob(fname):
+            for file in glob(os.path.join(directory, fname)):
                 tar.add(file)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
-from custodian.utils import tracked_lru_cache
-
+from custodian.utils import backup, tracked_lru_cache
+from pathlib import Path
+import tarfile
 
 def test_cache_and_clear() -> None:
     n_calls = 0
@@ -25,3 +26,13 @@ def test_cache_and_clear() -> None:
 
     assert some_func(1) == 1
     assert n_calls == 3
+
+def test_backup(tmp_path) -> None:
+    with open(tmp_path / "INCAR", "w") as f:
+        f.write("This is a test file.")
+
+    backup(["INCAR"], directory=tmp_path)
+
+    assert Path(tmp_path / "error.1.tar.gz").exists()
+    with tarfile.open(tmp_path / "error.1.tar.gz", "r:gz") as tar:
+        assert len(tar.getmembers()) > 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
-from custodian.utils import backup, tracked_lru_cache
-from pathlib import Path
 import tarfile
+from pathlib import Path
+
+from custodian.utils import backup, tracked_lru_cache
+
 
 def test_cache_and_clear() -> None:
     n_calls = 0
@@ -26,6 +28,7 @@ def test_cache_and_clear() -> None:
 
     assert some_func(1) == 1
     assert n_calls == 3
+
 
 def test_backup(tmp_path) -> None:
     with open(tmp_path / "INCAR", "w") as f:


### PR DESCRIPTION
Closes #378 and adds a regression test.