### PR TITLE
Fix unpacking of `error.tar.gz` files when a custom `directory` is set

### DIFF
--- a/src/custodian/utils.py
+++ b/src/custodian/utils.py
@@ -21,12 +21,13 @@ def backup(filenames, prefix="error", directory="./") -> None:
         directory (str): directory where the files exist
     """
     num = max([0] + [int(file.split(".")[-3]) for file in glob(os.path.join(directory, f"{prefix}.*.tar.gz"))])
-    filename = os.path.join(directory, f"{prefix}.{num + 1}.tar.gz")
+    prefix = f"{prefix}.{num + 1}
+    filename = os.path.join(directory, f"{prefix}.tar.gz")
     logging.info(f"Backing up run to {filename}.")
     with tarfile.open(filename, "w:gz") as tar:
         for fname in filenames:
             for file in glob(os.path.join(directory, fname)):
-                tar.add(file)
+                tar.add(file, arcname=prefix)
 
 
 def get_execution_host_info():

--- a/src/custodian/utils.py
+++ b/src/custodian/utils.py
@@ -7,6 +7,7 @@ import tarfile
 from glob import glob
 from typing import ClassVar
 
+
 def backup(filenames, prefix="error", directory="./") -> None:
     """
     Backup files to a tar.gz file. Used, for example, in backing up the

--- a/src/custodian/utils.py
+++ b/src/custodian/utils.py
@@ -6,7 +6,6 @@ import os
 import tarfile
 from glob import glob
 from typing import ClassVar
-from pathlib import Path
 
 def backup(filenames, prefix="error", directory="./") -> None:
     """

--- a/src/custodian/utils.py
+++ b/src/custodian/utils.py
@@ -6,7 +6,7 @@ import os
 import tarfile
 from glob import glob
 from typing import ClassVar
-
+from pathlib import Path
 
 def backup(filenames, prefix="error", directory="./") -> None:
     """
@@ -27,7 +27,7 @@ def backup(filenames, prefix="error", directory="./") -> None:
     with tarfile.open(filename, "w:gz") as tar:
         for fname in filenames:
             for file in glob(os.path.join(directory, fname)):
-                tar.add(file, arcname=os.path.join(prefix, file))
+                tar.add(file, arcname=os.path.join(prefix, os.path.basename(file)))
 
 
 def get_execution_host_info():

--- a/src/custodian/utils.py
+++ b/src/custodian/utils.py
@@ -27,7 +27,7 @@ def backup(filenames, prefix="error", directory="./") -> None:
     with tarfile.open(filename, "w:gz") as tar:
         for fname in filenames:
             for file in glob(os.path.join(directory, fname)):
-                tar.add(file, arcname=os.path.join(directory, prefix))
+                tar.add(file, arcname=prefix)
 
 
 def get_execution_host_info():

--- a/src/custodian/utils.py
+++ b/src/custodian/utils.py
@@ -27,7 +27,7 @@ def backup(filenames, prefix="error", directory="./") -> None:
     with tarfile.open(filename, "w:gz") as tar:
         for fname in filenames:
             for file in glob(os.path.join(directory, fname)):
-                tar.add(file, arcname=prefix)
+                tar.add(file, arcname=os.path.join(prefix,file))
 
 
 def get_execution_host_info():

--- a/src/custodian/utils.py
+++ b/src/custodian/utils.py
@@ -27,7 +27,7 @@ def backup(filenames, prefix="error", directory="./") -> None:
     with tarfile.open(filename, "w:gz") as tar:
         for fname in filenames:
             for file in glob(os.path.join(directory, fname)):
-                tar.add(file, arcname=prefix)
+                tar.add(file, arcname=os.path.join(directory, prefix))
 
 
 def get_execution_host_info():

--- a/src/custodian/utils.py
+++ b/src/custodian/utils.py
@@ -8,7 +8,7 @@ from glob import glob
 from typing import ClassVar
 
 
-def backup(filenames, prefix="error", directory="./") -> None:
+def backup(filenames: list[str], prefix="error", directory="./") -> None:
     """
     Backup files to a tar.gz file. Used, for example, in backing up the
     files of an errored run before performing corrections.

--- a/src/custodian/utils.py
+++ b/src/custodian/utils.py
@@ -8,7 +8,7 @@ from glob import glob
 from typing import ClassVar
 
 
-def backup(filenames: list[str], prefix="error", directory="./") -> None:
+def backup(filenames, prefix="error", directory="./") -> None:
     """
     Backup files to a tar.gz file. Used, for example, in backing up the
     files of an errored run before performing corrections.

--- a/src/custodian/utils.py
+++ b/src/custodian/utils.py
@@ -27,7 +27,7 @@ def backup(filenames, prefix="error", directory="./") -> None:
     with tarfile.open(filename, "w:gz") as tar:
         for fname in filenames:
             for file in glob(os.path.join(directory, fname)):
-                tar.add(file, arcname=os.path.join(prefix,file))
+                tar.add(file, arcname=os.path.join(prefix, file))
 
 
 def get_execution_host_info():

--- a/src/custodian/utils.py
+++ b/src/custodian/utils.py
@@ -21,7 +21,7 @@ def backup(filenames, prefix="error", directory="./") -> None:
         directory (str): directory where the files exist
     """
     num = max([0] + [int(file.split(".")[-3]) for file in glob(os.path.join(directory, f"{prefix}.*.tar.gz"))])
-    prefix = f"{prefix}.{num + 1}
+    prefix = f"{prefix}.{num + 1}"
     filename = os.path.join(directory, f"{prefix}.tar.gz")
     logging.info(f"Backing up run to {filename}.")
     with tarfile.open(filename, "w:gz") as tar:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,3 +39,5 @@ def test_backup(tmp_path) -> None:
     assert Path(tmp_path / "error.1.tar.gz").exists()
     with tarfile.open(tmp_path / "error.1.tar.gz", "r:gz") as tar:
         assert len(tar.getmembers()) > 0
+        assert tar.getnames() == ["error.1/INCAR"]
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,7 +39,7 @@ def test_backup(tmp_path, monkeypatch) -> None:
 
     assert Path("error.1.tar.gz").exists()
     with tarfile.open("error.1.tar.gz", "r:gz") as tar:
-        assert len(tar.getmembers()) > 0
+        assert len(tar.getmembers()) == 1
         assert tar.getnames() == ["error.1/INCAR"]
 
 
@@ -47,13 +47,17 @@ def test_backup_with_glob(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
     with open("INCAR", "w") as f:
         f.write("This is a test file.")
+    with open("POSCAR", "w") as f:
+        f.write("This is a test file.")
+    with open("garbage", "w") as f:
+        f.write("This is a test file.")
 
     backup(["*CAR"])
 
     assert Path("error.1.tar.gz").exists()
     with tarfile.open("error.1.tar.gz", "r:gz") as tar:
-        assert len(tar.getmembers()) > 0
-        assert tar.getnames() == ["error.1/INCAR"]
+        assert len(tar.getmembers()) == 2
+        assert tar.getnames() == ["error.1/INCAR", "error.1/POSCAR"]
 
 
 def test_backup_with_directory(tmp_path) -> None:
@@ -64,5 +68,5 @@ def test_backup_with_directory(tmp_path) -> None:
 
     assert Path(tmp_path / "error.1.tar.gz").exists()
     with tarfile.open(tmp_path / "error.1.tar.gz", "r:gz") as tar:
-        assert len(tar.getmembers()) > 0
+        assert len(tar.getmembers()) == 1
         assert tar.getnames() == ["error.1/INCAR"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,8 +29,31 @@ def test_cache_and_clear() -> None:
     assert some_func(1) == 1
     assert n_calls == 3
 
+def test_backup(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    with open("INCAR", "w") as f:
+        f.write("This is a test file.")
 
-def test_backup(tmp_path) -> None:
+    backup(["INCAR"])
+
+    assert Path("error.1.tar.gz").exists()
+    with tarfile.open("error.1.tar.gz", "r:gz") as tar:
+        assert len(tar.getmembers()) > 0
+        assert tar.getnames() == ["error.1/INCAR"]
+
+def test_backup_with_glob(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    with open("INCAR", "w") as f:
+        f.write("This is a test file.")
+
+    backup(["*CAR"])
+
+    assert Path("error.1.tar.gz").exists()
+    with tarfile.open("error.1.tar.gz", "r:gz") as tar:
+        assert len(tar.getmembers()) > 0
+        assert tar.getnames() == ["error.1/INCAR"]
+
+def test_backup_with_directory(tmp_path) -> None:
     with open(tmp_path / "INCAR", "w") as f:
         f.write("This is a test file.")
 
@@ -40,3 +63,4 @@ def test_backup(tmp_path) -> None:
     with tarfile.open(tmp_path / "error.1.tar.gz", "r:gz") as tar:
         assert len(tar.getmembers()) > 0
         assert tar.getnames() == ["error.1/INCAR"]
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,4 +40,3 @@ def test_backup(tmp_path) -> None:
     with tarfile.open(tmp_path / "error.1.tar.gz", "r:gz") as tar:
         assert len(tar.getmembers()) > 0
         assert tar.getnames() == ["error.1/INCAR"]
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,6 +29,7 @@ def test_cache_and_clear() -> None:
     assert some_func(1) == 1
     assert n_calls == 3
 
+
 def test_backup(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
     with open("INCAR", "w") as f:
@@ -40,6 +41,7 @@ def test_backup(tmp_path, monkeypatch) -> None:
     with tarfile.open("error.1.tar.gz", "r:gz") as tar:
         assert len(tar.getmembers()) > 0
         assert tar.getnames() == ["error.1/INCAR"]
+
 
 def test_backup_with_glob(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
@@ -53,6 +55,7 @@ def test_backup_with_glob(tmp_path, monkeypatch) -> None:
         assert len(tar.getmembers()) > 0
         assert tar.getnames() == ["error.1/INCAR"]
 
+
 def test_backup_with_directory(tmp_path) -> None:
     with open(tmp_path / "INCAR", "w") as f:
         f.write("This is a test file.")
@@ -63,4 +66,3 @@ def test_backup_with_directory(tmp_path) -> None:
     with tarfile.open(tmp_path / "error.1.tar.gz", "r:gz") as tar:
         assert len(tar.getmembers()) > 0
         assert tar.getnames() == ["error.1/INCAR"]
-


### PR DESCRIPTION
Closes #380.

**Fixes:**
- The `error.tar.gz` files now unpack without including the full file path of the original files that were tar'd.

**Changes**:
- I have made it so that doing `tar -xvf error1.tar.gz` will not accidentally overwrite files in the parent directory. The files will be written out to `error.1/*` instead.

**Maintenance**:
- I added a few missing tests and a regression test for #380.