### PR TITLE
Small bugfixes

### DIFF
--- a/src/custodian/qchem/jobs.py
+++ b/src/custodian/qchem/jobs.py
@@ -300,7 +300,7 @@ class QCJob(Job):
             freq_outdata = QCOutput(output_file + ".freq_pre").data
             if freq_outdata["version"] == "6":
                 opt_set = OptSet(molecule=freq_outdata["initial_molecule"], qchem_version=freq_outdata["version"])
-                opt_geom_opt = copy.deepcopy(opt_set.geom_opt)
+                opt_geom_opt = copy.deepcopy(opt_set.geom_opt) or {}
 
             if linked:
                 opt_rem["geom_opt_hessian"] = "read"
@@ -345,7 +345,7 @@ class QCJob(Job):
                 opt_outdata = QCOutput(f"{output_file}.{opt_method}_{ii}").data
                 opt_indata = QCInput.from_file(f"{input_file}.{opt_method}_{ii}")
                 if opt_outdata["version"] == "6":
-                    opt_geom_opt = copy.deepcopy(opt_indata.geom_opt)
+                    opt_geom_opt = copy.deepcopy(opt_indata.geom_opt) or {}
                     opt_geom_opt["initial_hessian"] = "read"
                 for key in opt_indata.rem:
                     if key not in {"job_type", "geom_opt2", "scf_guess_always"}:

--- a/src/custodian/qchem/jobs.py
+++ b/src/custodian/qchem/jobs.py
@@ -320,7 +320,7 @@ class QCJob(Job):
                 vdw_mode=orig_input.vdw_mode,
                 van_der_waals=orig_input.van_der_waals,
                 nbo=orig_input.nbo,
-                geom_opt=opt_geom_opt,
+                geom_opt=opt_geom_opt or None,
             )
             opt_QCInput.write_file(input_file)
             first = False
@@ -437,7 +437,7 @@ class QCJob(Job):
                         vdw_mode=orig_input.vdw_mode,
                         van_der_waals=orig_input.van_der_waals,
                         nbo=orig_input.nbo,
-                        geom_opt=opt_geom_opt,
+                        geom_opt=opt_geom_opt or None,
                     )
                     opt_QCInput.write_file(input_file)
                 else:

--- a/src/custodian/qchem/jobs.py
+++ b/src/custodian/qchem/jobs.py
@@ -272,7 +272,7 @@ class QCJob(Job):
         freq_rem["job_type"] = "freq"
         opt_rem = copy.deepcopy(orig_input.rem)
         opt_rem["job_type"] = opt_method
-        opt_geom_opt = None
+        opt_geom_opt = {}
         if "geom_opt2" in orig_input.rem:
             freq_rem.pop("geom_opt2", None)
             if linked:

--- a/src/custodian/vasp/handlers.py
+++ b/src/custodian/vasp/handlers.py
@@ -556,8 +556,10 @@ class VaspErrorHandler(ErrorHandler):
             if vi["INCAR"].get("ALGO", "Normal").lower() in {"fast", "veryfast"}:
                 actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "Normal"}}})
             else:
-                potim = round(vi["INCAR"].get("POTIM", 0.5) / 2.0, 2)
-                actions.append({"dict": "INCAR", "action": {"_set": {"POTIM": potim}}})
+                current_potim = vi["INCAR"].get("POTIM", 0.5)
+                if (potim := round(current_potim / 2.0, 2)) < current_potim:
+                    actions.append({"dict": "INCAR", "action": {"_set": {"POTIM": potim}}})
+
             if vi["INCAR"].get("ICHARG", 0) < 10:
                 actions += [
                     {"file": "CHGCAR", "action": {"_file_delete": {"mode": "actual"}}},


### PR DESCRIPTION
- QCHEM: ensure variables are correctly initialized given their expected type (issues with mixed `dict` / `None` init)
- VASP: ensure `eddrm` handler terminates a calculation once POTIM has reached the defined threshhold (0.01)