### PR TITLE
Fix `scratch_dir` keyword argument in `Custodian` class

### DIFF
--- a/src/custodian/custodian.py
+++ b/src/custodian/custodian.py
@@ -373,7 +373,8 @@ class Custodian:
             copy_to_current_on_exit=True,
             copy_from_current_on_enter=True,
         ) as temp_dir:
-            self.directory = temp_dir  # reset self.directory to the temp_dir
+            if self.scratch_dir:
+                self.directory = temp_dir  # reset self.directory to the temp_dir
             self.total_errors = 0
             start = datetime.datetime.now()
             logger.info(f"Run started at {start} in {temp_dir}.")
@@ -412,7 +413,8 @@ class Custodian:
             Custodian._delete_checkpoints(self.directory)
 
         # Return self.directory as expected
-        self.directory = original_directory
+        if self.scratch_dir:
+            self.directory = original_directory
 
         return self.run_log
 

--- a/src/custodian/custodian.py
+++ b/src/custodian/custodian.py
@@ -178,7 +178,8 @@ class Custodian:
             terminate_on_nonzero_returncode (bool): If True, a non-zero return
                 code on any Job will result in a termination. Defaults to True.
             directory (str): The directory to run the jobs in. Defaults to
-                the current working directory.
+                the current working directory. If you would like to have the
+                jobs run in a temporary directory, use `scratch_dir` instead.
             **kwargs: Any other kwargs are ignored. This is to allow for easy
                  subclassing and instantiation from a dict.
         """

--- a/src/custodian/custodian.py
+++ b/src/custodian/custodian.py
@@ -377,7 +377,7 @@ class Custodian:
                 self.directory = temp_dir  # reset self.directory to the temp_dir
             self.total_errors = 0
             start = datetime.datetime.now()
-            logger.info(f"Run started at {start} in {self.directory}.")
+            logger.info(f"Run started at {start} in {self.directory}")
             v = sys.version.replace("\n", " ")
             logger.info(f"Custodian running on Python version {v}")
             host, cluster = get_execution_host_info()
@@ -400,7 +400,7 @@ class Custodian:
                     raise
             finally:
                 # Log the corrections to a json file.
-                logger.info(f"Logging to {os.path.join(self.directory, Custodian.LOG_FILE)}...")
+                logger.info(f"Logging to {os.path.join(self.directory, Custodian.LOG_FILE)}")
                 dumpfn(self.run_log, os.path.join(self.directory, Custodian.LOG_FILE), cls=MontyEncoder, indent=4)
                 end = datetime.datetime.now()
                 logger.info(f"Run ended at {end}.")

--- a/src/custodian/custodian.py
+++ b/src/custodian/custodian.py
@@ -372,7 +372,7 @@ class Custodian:
             copy_to_current_on_exit=True,
             copy_from_current_on_enter=True,
         ) as temp_dir:
-            self.directory = temp_dir # reset self.directory to the temp_dir
+            self.directory = temp_dir  # reset self.directory to the temp_dir
             self.total_errors = 0
             start = datetime.datetime.now()
             logger.info(f"Run started at {start} in {temp_dir}.")

--- a/src/custodian/custodian.py
+++ b/src/custodian/custodian.py
@@ -377,7 +377,7 @@ class Custodian:
                 self.directory = temp_dir  # reset self.directory to the temp_dir
             self.total_errors = 0
             start = datetime.datetime.now()
-            logger.info(f"Run started at {start} in {temp_dir}.")
+            logger.info(f"Run started at {start} in {self.directory}.")
             v = sys.version.replace("\n", " ")
             logger.info(f"Custodian running on Python version {v}")
             host, cluster = get_execution_host_info()
@@ -407,7 +407,7 @@ class Custodian:
                 run_time = end - start
                 logger.info(f"Run completed. Total time taken = {run_time}.")
                 if self.gzipped_output:
-                    gzip_dir(temp_dir)
+                    gzip_dir(self.directory)
 
             # Cleanup checkpoint files (if any) if run is successful.
             Custodian._delete_checkpoints(self.directory)

--- a/src/custodian/custodian.py
+++ b/src/custodian/custodian.py
@@ -365,12 +365,14 @@ class Custodian:
             MaxCorrectionsError: if max_errors is reached
             MaxCorrectionsPerHandlerError: if max_errors_per_handler is reached
         """
+        original_directory = self.directory
         with ScratchDir(
             self.scratch_dir,
             create_symbolic_link=True,
             copy_to_current_on_exit=True,
             copy_from_current_on_enter=True,
         ) as temp_dir:
+            self.directory = temp_dir # reset self.directory to the temp_dir
             self.total_errors = 0
             start = datetime.datetime.now()
             logger.info(f"Run started at {start} in {temp_dir}.")
@@ -403,10 +405,13 @@ class Custodian:
                 run_time = end - start
                 logger.info(f"Run completed. Total time taken = {run_time}.")
                 if self.gzipped_output:
-                    gzip_dir(".")
+                    gzip_dir(temp_dir)
 
             # Cleanup checkpoint files (if any) if run is successful.
             Custodian._delete_checkpoints(self.directory)
+
+        # Return self.directory as expected
+        self.directory = original_directory
 
         return self.run_log
 


### PR DESCRIPTION
Closes #387. With the reliance on absolute rather than relative file paths in https://github.com/materialsproject/custodian/pull/317, the use of the `scratch_dir` keyword argument seems to have been broken, as jobs were always run in the current working directory rather than the scratch directory.

This PR fixes the `scratch_dir` keyword argument by ensuring that the jobs are properly run in the created scratch directory.  

This PR also fixes an issue with `gzipped_output` not being thread-safe due to a stray relative path.