### PR TITLE
Add a fix for `nbands_not_sufficient`

### DIFF
--- a/tests/vasp/test_handlers.py
+++ b/tests/vasp/test_handlers.py
@@ -536,10 +536,11 @@ class VaspErrorHandlerTest(PymatgenTest):
 
     def test_nbands_not_sufficient(self) -> None:
         handler = VaspErrorHandler("vasp.nbands_not_sufficient")
+        shutil.copy("OUTCAR_auto_nbands", "OUTCAR")
         assert handler.check() is True
         dct = handler.correct()
-        assert dct["errors"] == ["nbands_not_sufficient"]
-        assert dct["actions"] is None
+        assert "nbands_not_sufficient" in dct["errors"]
+        assert dct["actions"] == [{"action": {"_set": {"NBANDS": 9}}, "dict": "INCAR"}]
 
     def test_too_few_bands_round_error(self) -> None:
         # originally there are NBANDS= 7


### PR DESCRIPTION
## Summary

Previously, the `nbands_not_sufficient` error in VASP was treated as unfixable. Now, the handler will automatically increase `NBANDS` to the default value within VASP.

The reason for this fix is that, for some reason that remains unclear to me, there seems to be some VASP bug or quirk where NBANDS is set by VASP to some extremely low value without the user requesting it. Setting NBANDS back to the default value mentioned in the VASP manual resolves the problem.

Details: https://www.vasp.at/forum/viewtopic.php?t=20343


## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
