### PR TITLE
Use ISEARCH = 1 with ALGO = "All"

### DIFF
--- a/src/custodian/vasp/handlers.py
+++ b/src/custodian/vasp/handlers.py
@@ -580,7 +580,7 @@ class VaspErrorHandler(ErrorHandler):
 
             # This sometimes comes up with ALGO = Fast. We will switch the ALGO.
             if vi["INCAR"].get("ALGO", "Normal").lower() != "all":
-                actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "All"}}})
+                actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "All", "ISEARCH": 1}}})
 
             # This can sometimes be due to load-balancing issues for small systems.
             # See bottom of https://www.vasp.at/wiki/index.php/NCORE. A.S.R. ran some
@@ -1187,14 +1187,14 @@ class UnconvergedErrorHandler(ErrorHandler):
                 # Algo = All is recommended in the VASP manual and some meta-GGAs explicitly
                 # say to set Algo = All for proper convergence. I am using "--" as the check
                 # for METAGGA here because this is the default in the vasprun.xml file
-                actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "All"}}})
+                actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "All", "ISEARCH": 1}}})
 
             # If a hybrid is used, do not set Algo = Fast or VeryFast. Hybrid calculations do not
             # support these algorithms, but no warning is printed.
             if v.incar.get("LHFCALC", False):
                 if v.incar.get("ISMEAR", -1) >= 0 or not 50 <= v.incar.get("IALGO", 38) <= 59:
                     if algo != "all":
-                        actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "All"}}})
+                        actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "All", "ISEARCH": 1}}})
                     # See the VASP manual section on LHFCALC for more information.
                     elif algo != "damped":
                         actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "Damped", "TIME": 0.5}}})
@@ -1213,7 +1213,7 @@ class UnconvergedErrorHandler(ErrorHandler):
                 elif algo == "normal" and v.incar.get("ISMEAR", 1) >= 0:
                     # NB: default for ISMEAR is 1. To avoid algo_tet errors, only set
                     # ALGO = ALL if ISMEAR >= 0
-                    actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "All"}}})
+                    actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "All", "ISEARCH": 1}}})
                 else:
                     # Try mixing as last resort
                     new_settings = {
@@ -1665,7 +1665,7 @@ class NonConvergingErrorHandler(ErrorHandler):
         # manual and some meta-GGAs explicitly say to set Algo = All for proper convergence.
         # I am using "none" here because METAGGA is a string variable and this is the default
         if (incar.get("LHFCALC", False) or incar.get("METAGGA", "none").lower() != "none") and algo != "all":
-            actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "All"}}})
+            actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "All", "ISEARCH": 1}}})
 
         # Ladder from VeryFast to Fast to Normal to All
         # (except for meta-GGAs and hybrids).
@@ -1677,7 +1677,7 @@ class NonConvergingErrorHandler(ErrorHandler):
             elif algo == "fast":
                 actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "Normal"}}})
             elif algo == "normal" and incar.get("ISMEAR", 1) >= 0:
-                actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "All"}}})
+                actions.append({"dict": "INCAR", "action": {"_set": {"ALGO": "All", "ISEARCH": 1}}})
             elif algo == "all" or (algo == "normal" and incar.get("ISMEAR", 1) < 0):
                 if amix > 0.1 and bmix > 0.01:
                     # Try linear mixing

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -57,8 +57,7 @@ def test_backup_with_glob(tmp_path, monkeypatch) -> None:
     assert Path("error.1.tar.gz").exists()
     with tarfile.open("error.1.tar.gz", "r:gz") as tar:
         assert len(tar.getmembers()) == 2
-        tar.getnames().sort()
-        assert tar.getnames() == ["error.1/INCAR", "error.1/POSCAR"]
+        assert set(tar.getnames()) == {"error.1/INCAR", "error.1/POSCAR"}
 
 
 def test_backup_with_directory(tmp_path) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -57,6 +57,7 @@ def test_backup_with_glob(tmp_path, monkeypatch) -> None:
     assert Path("error.1.tar.gz").exists()
     with tarfile.open("error.1.tar.gz", "r:gz") as tar:
         assert len(tar.getmembers()) == 2
+        tar.getnames().sort()
         assert tar.getnames() == ["error.1/INCAR", "error.1/POSCAR"]
 
 

--- a/tests/vasp/test_handlers.py
+++ b/tests/vasp/test_handlers.py
@@ -713,17 +713,6 @@ class UnconvergedErrorHandlerTest(PymatgenTest):
         }
         tracked_lru_cache.tracked_cache_clear()
 
-        shutil.copy("vasprun.xml.electronic_hybrid_fast", "vasprun.xml")
-        handler = UnconvergedErrorHandler()
-        assert handler.check()
-        dct = handler.correct()
-        assert dct["errors"] == ["Unconverged"]
-        assert dct == {
-            "actions": [{"action": {"_set": {"ALGO": "All", "ISEARCH": 1}}, "dict": "INCAR"}],
-            "errors": ["Unconverged"],
-        }
-        tracked_lru_cache.tracked_cache_clear()
-
         shutil.copy("vasprun.xml.electronic_hybrid_all", "vasprun.xml")
         handler = UnconvergedErrorHandler()
         assert handler.check()

--- a/tests/vasp/test_handlers.py
+++ b/tests/vasp/test_handlers.py
@@ -685,7 +685,10 @@ class UnconvergedErrorHandlerTest(PymatgenTest):
         assert handler.check()
         dct = handler.correct()
         assert dct["errors"] == ["Unconverged"]
-        assert dct == {"actions": [{"action": {"_set": {"ALGO": "All"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
+        assert dct == {
+            "actions": [{"action": {"_set": {"ALGO": "All", "ISEARCH": 1}}, "dict": "INCAR"}],
+            "errors": ["Unconverged"],
+        }
         tracked_lru_cache.tracked_cache_clear()
 
         shutil.copy("vasprun.xml.electronic_metagga_fast", "vasprun.xml")
@@ -693,7 +696,10 @@ class UnconvergedErrorHandlerTest(PymatgenTest):
         assert handler.check()
         dct = handler.correct()
         assert dct["errors"] == ["Unconverged"]
-        assert dct == {"actions": [{"action": {"_set": {"ALGO": "All"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
+        assert dct == {
+            "actions": [{"action": {"_set": {"ALGO": "All", "ISEARCH": 1}}, "dict": "INCAR"}],
+            "errors": ["Unconverged"],
+        }
         tracked_lru_cache.tracked_cache_clear()
 
         shutil.copy("vasprun.xml.electronic_hybrid_fast", "vasprun.xml")
@@ -701,7 +707,21 @@ class UnconvergedErrorHandlerTest(PymatgenTest):
         assert handler.check()
         dct = handler.correct()
         assert dct["errors"] == ["Unconverged"]
-        assert dct == {"actions": [{"action": {"_set": {"ALGO": "All"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
+        assert dct == {
+            "actions": [{"action": {"_set": {"ALGO": "All", "ISEARCH": 1}}, "dict": "INCAR"}],
+            "errors": ["Unconverged"],
+        }
+        tracked_lru_cache.tracked_cache_clear()
+
+        shutil.copy("vasprun.xml.electronic_hybrid_fast", "vasprun.xml")
+        handler = UnconvergedErrorHandler()
+        assert handler.check()
+        dct = handler.correct()
+        assert dct["errors"] == ["Unconverged"]
+        assert dct == {
+            "actions": [{"action": {"_set": {"ALGO": "All"}}, "dict": "INCAR"}],
+            "errors": ["Unconverged"],
+        }
         tracked_lru_cache.tracked_cache_clear()
 
         shutil.copy("vasprun.xml.electronic_hybrid_all", "vasprun.xml")
@@ -716,7 +736,10 @@ class UnconvergedErrorHandlerTest(PymatgenTest):
         handler = UnconvergedErrorHandler()
         assert handler.check()
         dct = handler.correct()
-        assert dct == {"actions": [{"action": {"_set": {"ALGO": "All"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
+        assert dct == {
+            "actions": [{"action": {"_set": {"ALGO": "All", "ISEARCH": 1}}, "dict": "INCAR"}],
+            "errors": ["Unconverged"],
+        }
 
     def test_check_correct_ionic(self) -> None:
         shutil.copy("vasprun.xml.ionic", "vasprun.xml")
@@ -731,7 +754,7 @@ class UnconvergedErrorHandlerTest(PymatgenTest):
         assert handler.check()
         dct = handler.correct()
         assert dct["errors"] == ["Unconverged"]
-        assert {"dict": "INCAR", "action": {"_set": {"ALGO": "All"}}} in dct["actions"]
+        assert {"dict": "INCAR", "action": {"_set": {"ALGO": "All", "ISEARCH": 1}}} in dct["actions"]
 
     def test_amin(self) -> None:
         shutil.copy("vasprun.xml.electronic_amin", "vasprun.xml")
@@ -752,7 +775,10 @@ class UnconvergedErrorHandlerTest(PymatgenTest):
         assert handler.check()
         dct = handler.correct()
         assert dct["errors"] == ["Unconverged"]
-        assert dct == {"actions": [{"action": {"_set": {"ALGO": "All"}}, "dict": "INCAR"}], "errors": ["Unconverged"]}
+        assert dct == {
+            "actions": [{"action": {"_set": {"ALGO": "All", "ISEARCH": 1}}, "dict": "INCAR"}],
+            "errors": ["Unconverged"],
+        }
 
     def test_psmaxn(self) -> None:
         shutil.copy("vasprun.xml.electronic", "vasprun.xml")

--- a/tests/vasp/test_handlers.py
+++ b/tests/vasp/test_handlers.py
@@ -719,7 +719,7 @@ class UnconvergedErrorHandlerTest(PymatgenTest):
         dct = handler.correct()
         assert dct["errors"] == ["Unconverged"]
         assert dct == {
-            "actions": [{"action": {"_set": {"ALGO": "All"}}, "dict": "INCAR"}],
+            "actions": [{"action": {"_set": {"ALGO": "All", "ISEARCH": 1}}, "dict": "INCAR"}],
             "errors": ["Unconverged"],
         }
         tracked_lru_cache.tracked_cache_clear()


### PR DESCRIPTION
## Summary

Closes #394. As noted in the [VASP manual](https://www.vasp.at/wiki/index.php/ISEARCH), it is strongly recommended to use ISEARCH = 1 (default: ISEARCH = 0) when setting ALGO = All. Currently, Custodian does not do this but should. This PR adds ISEARCH = 1 alongside ALGO = All actions.

There are two subtleties to keep in mind:
- The parameter was only added in some relatively recent version of VASP (unclear which one), such that the parameter should do nothing with older versions of VASP. I confirmed that using an unsupported flag (e.g. `COW = 1`) does not cause a VASP 6.5.1 crash. However, I know that in the past, setting an unsupported flag in VASP 5.x did cause a crash (see https://github.com/Quantum-Accelerators/quacc/issues/2734). I am not sure the best way to proceed with this in mind. The easiest option would be to tell the user to just use an older version of Custodian.
- If Custodian switches the algorithm to ALGO = "All" with ISEARCH = 1 and then a new error happens where the error is switch again later, we will have ISEARCH = 1 still in the INCAR. According to the VASP manual, this should not make a difference though because it is only used when ALGO = "All". I do not consider this a blocker


## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
