### PR TITLE
Add a handler for the spin-polarized Harris functional error

### DIFF
--- a/src/custodian/vasp/handlers.py
+++ b/src/custodian/vasp/handlers.py
@@ -139,6 +139,7 @@ class VaspErrorHandler(ErrorHandler):
         "auto_nbands": ["The number of bands has been changed"],
         "ibzkpt": ["not all point group operations"],
         "fexcf": ["supplied exchange-correlation table"],
+        "spin_polarized_harris": ["Spin polarized Harris functional dynamics is a good joke"],
     }
 
     def __init__(
@@ -714,6 +715,14 @@ class VaspErrorHandler(ErrorHandler):
             # Unfixable error --- the user made a mistake in the INCAR
             warnings.warn("Looks like you made a typo in the INCAR. Please double-check it.", UserWarning)
             return {"errors": ["read_error"], "actions": None}
+
+        if "spin_polarized_harris" in self.errors:
+            # Unfixable error --- the user made a mistake in the INCAR
+            warnings.warn(
+                "You cannot run a calculation with ICHARG >= 10, ISPIN = 2, and NSW > 0. Try setting NSW = 0.",
+                UserWarning,
+            )
+            return {"errors": ["spin_polarized_harris"], "actions": None}
 
         if "hnform" in self.errors and vi["INCAR"].get("ISYM", 2) > 0:
             # The only solution is to change your k-point grid or disable symmetry

--- a/tests/files/vasp.harris
+++ b/tests/files/vasp.harris
@@ -1,0 +1,1 @@
+Spin polarized Harris functional dynamics is a good joke

--- a/tests/vasp/test_handlers.py
+++ b/tests/vasp/test_handlers.py
@@ -566,6 +566,13 @@ class VaspErrorHandlerTest(PymatgenTest):
         assert dct["errors"] == ["read_error"]
         assert dct["actions"] is None
 
+    def test_harris(self) -> None:
+        handler = VaspErrorHandler("vasp.harris")
+        assert handler.check() is True
+        dct = handler.correct()
+        assert dct["errors"] == ["spin_polarized_harris"]
+        assert dct["actions"] is None
+
     def test_amin(self) -> None:
         # Cell with at least one dimension >= 50 A, but AMIN > 0.01, and calculation not yet complete
         shutil.copy("INCAR.amin", "INCAR")


### PR DESCRIPTION
## Summary

Closes #392. This is a non-fixable error, so we just warn the user to fix their INCAR. We don't make the change for them because it was probably a conceptual error.

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
