### PR TITLE
Fix backup numbering when .tar.gz files are decompressed to .tar

### DIFF
--- a/src/custodian/utils.py
+++ b/src/custodian/utils.py
@@ -20,7 +20,18 @@ def backup(filenames, prefix="error", directory="./") -> None:
             series of error.1.tar.gz, error.2.tar.gz, ... will be generated.
         directory (str): directory where the files exist
     """
-    num = max([0] + [int(file.split(".")[-3]) for file in glob(os.path.join(directory, f"{prefix}.*.tar.gz"))])
+
+    backup_files = glob(os.path.join(directory, f"{prefix}.*.tar.gz")) + glob(os.path.join(directory, f"{prefix}.*.tar"))
+    nums = []
+    for file in backup_files:
+        try:
+            if file.endswith('.tar.gz'):
+                nums.append(int(file.split(".")[-3]))
+            elif file.endswith('.tar'):
+                nums.append(int(file.split(".")[-2]))
+        except (ValueError, IndexError):
+            continue
+    num = max([0] + nums)
     prefix = f"{prefix}.{num + 1}"
     filename = os.path.join(directory, f"{prefix}.tar.gz")
     logging.info(f"Backing up run to {filename}.")


### PR DESCRIPTION
## Summary

This is a fix to issue #403. It makes sure that backup files aren't overwritten when a series of custodian jobs are executed in the same folder. The fix is achieved by taking both .tar.gz and .tar files into account when determining the file number.
